### PR TITLE
Serve Vite React SPA from Django at :8000/

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -7,16 +7,6 @@ same picture of what's open.
 
 ---
 
-## Parser — subchapter TOC + validation
-- **Branch:** `llm-summaries` (PR 1: subchapter schema; PR 2: TOC scanner + body FK stamping — both applied, not yet on `main`)
-- **State:** Full re-parse ran 2026-04-24. 9,930 sections emitted, 202 new, 5,562 text-updated. 227 Subchapters (209 official, 18 synthesized). 478 `ParseValidationIssue` rows surfaced as persistent parser-quality to-do.
-- **Open threads (branched to other forks):**
-  - Triage NEPA/SEPA short-title bypass (`len(bare_title) <= 3` → needs 4 for 4-char acronyms)
-  - Review the 18 synthesized subchapters — each is a chapter with a body divider but no TOC scrape; some may indicate scanner gaps
-  - Investigate `25.05.990` and similar pages where pdfplumber returns 5-line malformed extractions
-  - Review the 37 "declared-but-empty" subchapters flushed without body sections
-- **Done:** landmark `designation_type` backfill; subchapter divider bug fix; subchapter data model.
-
 ## Frontend — Vite/React cutover (path A)
 - **Branch:** not yet created. Suggested: `frontend/vite-cutover`
 - **State:** Investigation only. Confirmed two separate frontends:
@@ -43,3 +33,12 @@ so nothing is orphaned in a detached working tree.
 
 **When a workstream ships:** move its section to `## Done` at the
 bottom of the file with the merge date, so open/closed stays skimmable.
+
+---
+
+## Done
+
+### Parser — subchapter TOC + validation — merged 2026-04-24 (PR #12)
+- Subchapter schema, TOC scanner, body FK stamping, landmark `designation_type` backfill, subchapter divider bug fix.
+- Full re-parse 2026-04-24: 9,930 sections, 202 new, 5,562 text-updated, 227 subchapters (209 official, 18 synthesized), 478 `ParseValidationIssue` rows logged as persistent parser-quality backlog.
+- Known open quality threads (not blocking, captured for later): NEPA/SEPA short-title bypass needs `len(bare_title) <= 4` for 4-char acronyms; review 18 synthesized subchapters for scanner gaps; investigate `25.05.990` and similar 5-line malformed pdfplumber extractions; review 37 "declared-but-empty" subchapters.

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -8,18 +8,16 @@ same picture of what's open.
 ---
 
 ## Frontend — Vite/React cutover (path A)
-- **Branch:** not yet created. Suggested: `frontend/vite-cutover`
-- **State:** Investigation only. Confirmed two separate frontends:
-  - `:8000` — legacy Django templates + webpack bundles via `django-webpack-loader` (referenced in `seattle_app/settings.py:180-186` and `seattle_app/templates/base.html`)
-  - `:5173` — Vite React SPA in `frontend/` (new, with React Router + Leaflet)
-- **Decision locked:** Django admin at `/admin/` stays server-rendered. React owns `/` and everything else. No admin port needed.
-- **Next:**
-  1. Create `frontend/vite-cutover` branch
-  2. `npm run build` in `frontend/` to confirm clean Vite build → `frontend/dist/`
-  3. Add Django catch-all view serving `frontend/dist/index.html` AFTER all API + `/admin/` routes
-  4. Wire `frontend/dist/assets/` into `STATICFILES_DIRS`
-  5. Verify `:8000/` shows React app, `:8000/admin/` still works
-  6. Retire `django-webpack-loader`, root `package.json`, `webpack.config.js`, `webpack-stats.json` (separate PR)
+- **Branch:** `frontend/vite-cutover` (PR open, not yet merged)
+- **State:** Cutover complete on branch. `:8000/` now serves the Vite React build via Django (`react_app` view returns `frontend/dist/index.html`); `/static/assets/...` resolves through `STATICFILES_DIRS`; wagtail's `""` catch-all removed so React owns `/` and unmatched paths. Browser-verified: `/`, `/admin/`, `/cms/`, `/legislation/<slug>`, API routes all working.
+- **Decision locked:** Django admin at `/admin/` stays server-rendered. Wagtail admin stays at `/cms/`. React owns `/` and everything else.
+- **Next (this branch):** push and open PR.
+- **Next (follow-up branch `frontend/retire-webpack-loader`):**
+  1. Remove `django-webpack-loader` from `INSTALLED_APPS` and the `WEBPACK_LOADER` settings block
+  2. Delete `webpack-stats.json`, root `package.json`, root `package-lock.json`, `webpack.config.js`
+  3. Delete `seattle_app/templates/base.html` (and `home_page.html` if unused) + the now-orphaned `IndexView` in `seattle_app/views.py`
+  4. Drop the `webpack` service from `docker-compose.yml`
+  5. Remove `django-webpack-loader` from `requirements.txt`
 
 ---
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/static/',
   plugins: [react()],
   server: {
     proxy: {

--- a/seattle_app/settings.py
+++ b/seattle_app/settings.py
@@ -151,6 +151,7 @@ STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_DIRS = [
     BASE_DIR / "seattle_app" / "static",
+    BASE_DIR / "frontend" / "dist",
 ]
 
 # Media files

--- a/seattle_app/urls.py
+++ b/seattle_app/urls.py
@@ -4,14 +4,12 @@ from django.urls import path, include
 from django.conf.urls.static import static
 
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 from . import views
 from . import api_views
 
 urlpatterns = [
-    path("", views.IndexView.as_view(), name="index"),
     path("robots.txt", views.robots_txt, name="robots_txt"),
     path("admin/", admin.site.urls),
     path("api/reps/", include("reps.urls")),
@@ -20,9 +18,13 @@ urlpatterns = [
     path("api/meetings/upcoming/", api_views.upcoming_meetings, name="api_meetings_upcoming"),
     path("api/meetings/<slug:slug>/", api_views.meeting_detail, name="api_meeting_detail"),
     path("", include("councilmatic_search.urls")),
-    path("", include("councilmatic_cms.urls")),
-    # Catch-all: serve the React SPA for any remaining frontend routes
-    path("<path:path>", views.IndexView.as_view(), name="react_catchall"),
+    # Wagtail admin + documents only — wagtail's "" catch-all is intentionally not included
+    # so the React SPA can own all non-API, non-admin routes.
+    path("cms/", include(wagtailadmin_urls)),
+    path("documents/", include(wagtaildocs_urls)),
+    # React SPA catch-all (must be last). Matches "" and any unmatched path.
+    path("", views.react_app, name="react_index"),
+    path("<path:path>", views.react_app, name="react_catchall"),
 ]
 
 # Error handlers

--- a/seattle_app/views.py
+++ b/seattle_app/views.py
@@ -1,4 +1,6 @@
 import os
+from django.conf import settings
+from django.http import FileResponse
 from django.shortcuts import render
 from django.views.generic import TemplateView
 
@@ -7,7 +9,7 @@ from councilmatic_core.models import Bill, Event, Person
 
 class IndexView(TemplateView):
     template_name = "home_page.html"
-    
+
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context.update({
@@ -16,6 +18,11 @@ class IndexView(TemplateView):
             "person_count": Person.objects.count(),
         })
         return context
+
+
+def react_app(request, path=""):
+    index_path = settings.BASE_DIR / "frontend" / "dist" / "index.html"
+    return FileResponse(open(index_path, "rb"), content_type="text/html")
 
 
 def robots_txt(request):


### PR DESCRIPTION
## Summary
  - Vite `base: '/static/'` so built assets resolve via Django's static pipeline
  - New `react_app` view returns `frontend/dist/index.html` for `/` and any unmatched path
  - Restructured `urls.py`: keep `admin/`, APIs, `search/`, `cms/`, `documents/`; drop wagtail's `""` catch-all so React owns the SPA routes
  - WORK_LOG: parser workstream marked Done (PR #12); Frontend section moved from "Investigation only" → "Cutover complete on branch"
  - Legacy `IndexView`, `home_page.html`, `django-webpack-loader`, root `package.json`, `webpack.config.js`, `webpack-stats.json` are still present but unrouted — retiring them is a follow-up PR
  (`frontend/retire-webpack-loader`)

  ## Test plan
  - [x] `/` renders the React SPA
  - [x] `/legislation/<slug>` and `/events/<slug>` deep-link works (catch-all → React Router)
  - [x] `/admin/` reaches Django admin login (302 → /admin/login/)
  - [x] `/cms/` reaches Wagtail admin login
  - [x] `/api/legislation/recent/` and other API routes return 200
  - [x] `/static/assets/index-*.{js,css}` serves from `frontend/dist/`
  - [x] `npm run build` in `frontend/` produces a clean dist