### PR TITLE
feat(frontend): route detail-page 404s to a kind-aware NotFound

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -16,7 +16,6 @@ locked decisions, known follow-up threads, and a chronological merge log.
 Prioritized to-do. Quick wins flagged with *(quick)*.
 
 **Frontend**
-- *(quick)* Route invalid `/legislation/<slug>` and `/events/<slug>` to the SPA `NotFound` component instead of "Could not load legislation: HTTP 404" error text. `LegislationDetail.jsx` and `MeetingDetail.jsx` both have a `setError` branch — add a 404 check that renders `<NotFound />`.
 - **Meeting agenda items (WIP).** Pick up the work in worktree `claude/zealous-tharp` at `.claude/worktrees/zealous-tharp`, commit `baa719c`. Touches `seattle/events.py` (uncomment + implement `_add_agenda_items`, scrape `hypAgendaPacket` from Legistar HTML), `seattle_app/api_views.py` (return `agenda_items`, `agenda_file_url`, `packet_url`, `minutes_file_url`, `minutes_status`), `frontend/src/components/MeetingDetail.jsx` (~93 LoC of new components: `MatterChip`, `DocIcon`, `AgendaDocButtons`, `AgendaItemRow`). When ready: branch from `main`, cherry-pick `baa719c`, open PR.
 
 **LLM summaries — wire up the existing infrastructure**
@@ -53,6 +52,9 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### Frontend — bad-slug 404 → kind-aware NotFound — merged 2026-04-24 (PR #16)
+`LegislationDetail` and `MeetingDetail` now check for HTTP 404 from the API and render `<NotFound />` instead of the "Could not load: HTTP 404" error text. `NotFound` gained a `kind` prop with three variants — `legislation` ("Legislation not found" → recent legislation), `meeting` ("Meeting not found" → upcoming meetings), and the default generic ("Page not found" → This Week). The wildcard `<Route path="*">` in `App.jsx` keeps using the generic variant.
 
 ### Parser — NEPA/SEPA acronym titles — fixed in PR #12
 The "NEPA/SEPA short-title bypass" Open thread was already resolved in `a7c4cc0` via a precise `is_acronym_title` check at `parse_smc_pdf.py:588-592` (`0 < len(bare_title) <= 6 and isalpha() and isupper()`). Cleaner than expanding the generic short-title bypass from `<= 3` to `<= 4`, which would have admitted noise like `"Co2."` or `"12-1"`. Entry was stale on the work log — surfaced 2026-04-24 during quick-wins triage.

--- a/frontend/src/components/LegislationDetail.jsx
+++ b/frontend/src/components/LegislationDetail.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
+import NotFound from './NotFound'
 import './LegislationDetail.css'
 
 const VARIANT_CLASSES = {
@@ -32,21 +33,31 @@ export default function LegislationDetail() {
   const [bill, setBill] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [notFound, setNotFound] = useState(false)
 
   useEffect(() => {
     setLoading(true)
     setError(null)
+    setNotFound(false)
     fetch(`/api/legislation/${slug}/`)
       .then(r => {
+        if (r.status === 404) {
+          setNotFound(true)
+          setLoading(false)
+          return null
+        }
         if (!r.ok) throw new Error(`HTTP ${r.status}`)
         return r.json()
       })
-      .then(data => { setBill(data); setLoading(false) })
+      .then(data => {
+        if (data) { setBill(data); setLoading(false) }
+      })
       .catch(e => { setError(e.message); setLoading(false) })
   }, [slug])
 
-  if (loading) return <div className="leg-detail-loading">Loading…</div>
-  if (error)   return <div className="leg-detail-error">Could not load legislation: {error}</div>
+  if (loading)  return <div className="leg-detail-loading">Loading…</div>
+  if (notFound) return <NotFound kind="legislation" />
+  if (error)    return <div className="leg-detail-error">Could not load legislation: {error}</div>
 
   const primarySponsors = bill.sponsors.filter(s => s.primary)
   const coSponsors      = bill.sponsors.filter(s => !s.primary)

--- a/frontend/src/components/MeetingDetail.jsx
+++ b/frontend/src/components/MeetingDetail.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
+import NotFound from './NotFound'
 import './MeetingDetail.css'
 
 function formatDateTime(isoString) {
@@ -31,21 +32,31 @@ export default function MeetingDetail() {
   const [meeting, setMeeting] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [notFound, setNotFound] = useState(false)
 
   useEffect(() => {
     setLoading(true)
     setError(null)
+    setNotFound(false)
     fetch(`/api/meetings/${slug}/`)
       .then(r => {
+        if (r.status === 404) {
+          setNotFound(true)
+          setLoading(false)
+          return null
+        }
         if (!r.ok) throw new Error(`HTTP ${r.status}`)
         return r.json()
       })
-      .then(data => { setMeeting(data); setLoading(false) })
+      .then(data => {
+        if (data) { setMeeting(data); setLoading(false) }
+      })
       .catch(e => { setError(e.message); setLoading(false) })
   }, [slug])
 
-  if (loading) return <div className="mtg-detail-loading">Loading…</div>
-  if (error)   return <div className="mtg-detail-error">Could not load meeting: {error}</div>
+  if (loading)  return <div className="mtg-detail-loading">Loading…</div>
+  if (notFound) return <NotFound kind="meeting" />
+  if (error)    return <div className="mtg-detail-error">Could not load meeting: {error}</div>
 
   const legistarUrl = meeting.legistar_url || null
 

--- a/frontend/src/components/NotFound.jsx
+++ b/frontend/src/components/NotFound.jsx
@@ -1,17 +1,34 @@
 import { Link } from 'react-router-dom'
 import './NotFound.css'
 
-export default function NotFound() {
+const VARIANTS = {
+  legislation: {
+    title: 'Legislation not found',
+    message: "We couldn't find that piece of legislation. It may have been removed, or the link may be incorrect.",
+    linkLabel: '← Back to recent legislation',
+  },
+  meeting: {
+    title: 'Meeting not found',
+    message: "We couldn't find that meeting. It may have been removed, or the link may be incorrect.",
+    linkLabel: '← Back to upcoming meetings',
+  },
+}
+
+const DEFAULT_VARIANT = {
+  title: 'Page not found',
+  message: "We couldn't find the page you were looking for. The link may be broken, or the page may have moved.",
+  linkLabel: '← Back to This Week',
+}
+
+export default function NotFound({ kind }) {
+  const v = VARIANTS[kind] ?? DEFAULT_VARIANT
   return (
     <main className="notfound-page">
       <div className="notfound-container">
         <p className="notfound-code">404</p>
-        <h1 className="notfound-title">Page not found</h1>
-        <p className="notfound-message">
-          We couldn't find the page you were looking for. The link may be broken,
-          or the page may have moved.
-        </p>
-        <Link to="/" className="notfound-home-link">← Back to This Week</Link>
+        <h1 className="notfound-title">{v.title}</h1>
+        <p className="notfound-message">{v.message}</p>
+        <Link to="/" className="notfound-home-link">{v.linkLabel}</Link>
       </div>
     </main>
   )


### PR DESCRIPTION
Invalid /legislation/<slug> and /events/<slug> URLs were rendering the generic "Could not load: HTTP 404" error text. Detect 404 responses explicitly and render the SPA NotFound component instead, with a kind prop so the user knows what they were looking for didn't exist.

- LegislationDetail.jsx + MeetingDetail.jsx: track a notFound state set when fetch returns r.status === 404, render <NotFound kind="..." />
- NotFound.jsx: gain a kind prop with three variants: legislation → "Legislation not found" / Back to recent legislation
    meeting     → "Meeting not found"     / Back to upcoming meetings
    (default)   → "Page not found"        / Back to This Week
- App.jsx wildcard route keeps using the generic (no prop)
- WORK_LOG: move bad-slug 404 entry from Up next to Done (per the
  "include the Done-move in the same PR" convention)

## Test plan
  - [x] `/foo` (or any unknown URL) → generic "Page not found"
  - [x] `/legislation/this-slug-does-not-exist` → "Legislation not found"
  - [x] `/events/this-slug-does-not-exist` → "Meeting not found"
  - [x] Real `/legislation/<slug>` and `/events/<slug>` still render normally
  - [ ] All three variants share styling — only title/message/link label differ