### PR TITLE
fix(parser): close two section-boundary leaks (catastrophic over-size…

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -32,11 +32,7 @@ Prioritized to-do. Quick wins flagged with *(quick)*.
 - Open design questions: which Claude model? per-section caching strategy? batch via Anthropic Batch API to halve cost?
 
 **Parser quality** (from 2026-04-24 re-parse — 478 `ParseValidationIssue` rows)
-- **Section-boundary detection is leaking — 13 sections > 30k chars in DB, 3 catastrophic.** `25.30.130 Enforcement` (280,918 chars, page 4387), `23.47.004` (207,122 chars, page 4449, title is `ChartA, 23.50.012 ChartA, 23.54.015 Chart`), `23.54.015` (156,196 chars, page 4488, title is `Chart A, 23.54.030(B), (D), (F) and (J),`). Two failure modes:
-  1. **Missed real heading** — `25.30.130` keeps growing because the next real section heading isn't matching `SECTION_RE` or fails `_is_section_boundary`.
-  2. **Ghost heading on a citation** — body text like `23.47.004 ChartA, 23.50.012 ChartA, 23.54.015 Chart A` matches `SECTION_RE`, so the parser closes the previous section and opens a "ghost" section with the citation as its title.
-  - Also smaller-but-suspicious: `23.84A.036` has a single-char `S` title (could be the alphabetical-definitions edge case the existing `bare_title` logic handles, or could be a heading-detection miss). Other 30–53k sections (e.g., `25.05.675`, `15.91.045`, `23.47A.009`) need triage — some may be legitimately long.
-  - Starting points: `parse_smc_pdf.py:20` (`SECTION_RE`), `:108` (`_is_section_boundary`), `:572-602` (the heading-acceptance branch). Probably need stricter regex (require word-boundary before the section number? reject when preceded by a section-number-shaped string?) and/or look-ahead validation (the line after a heading should look like body, not a continuation of a citation list).
+- Triage the 10 suspicious 30–53k-char sections that aren't the catastrophic three (e.g., `25.05.675`, `15.91.045`, `23.47A.009`, `23.84A.036` with single-char `S` title, `25.05.800`, `22.602.045`, `23.58C.050`, `23.49.011`, `21.04.440`, `23.54.030`). Some may be legitimately long; others may have similar but smaller-scale heading-detection issues. Will need a full re-parse after the catastrophic fix lands to see which (if any) are still over-sized.
 - Investigate `25.05.990` and similar pages where pdfplumber returns 5-line malformed extractions.
 - Review the 18 synthesized subchapters (chapter has body divider but no TOC scrape) — some may indicate scanner gaps.
 - Review the 37 "declared-but-empty" subchapters flushed without body sections.
@@ -62,6 +58,13 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### Parser — section-boundary leak (catastrophic) — merged 2026-04-24 (PR #17)
+Fixed the three catastrophic over-sized sections (`25.30.130` 280k chars, `23.47.004` 207k, `23.54.015` 156k). Two distinct bugs:
+1. **`Chapter 25.32` not detected** because two-column extraction fragments full-width chapter headings ("Chapter" alone in one column, "25.32" in the other). Chapter-flush at `_walk_sections` never fires, so 60+ pages of `25.32 TABLE OF HISTORICAL LANDMARKS` table content kept appending to `25.30.130`. Fix: in `_extract_page_lines`, when no `CHAPTER_HEADING_RE` line exists in the column-split output, recover it from `extract_text()` (which doesn't column-split) and inject at the top.
+2. **Ghost heading from citation list** — body text like `23.47.004 ChartA, 23.50.012 ChartA, ...` in the "ORDINANCES CODIFIED" appendix matched `SECTION_RE`, creating a phantom section. Fix: new `EMBEDDED_SECTION_RE` + `LEGITIMATE_SECTION_CITATION_RE` reject titles that contain a section-number-shaped substring without a preceding `Section(s) X.Y.Z` lead-in. Real titles like `Penalty for violation of Section 3.30.050.` keep the lead-in and pass through.
+
+Verified: pages 4385–4500 dry-run emits only the 5 expected real sections (25.30.090–.130), no ghosts. Pages 370–390 regression check confirms legitimate `Section X.Y.Z` citation titles still emit. Full re-parse needed post-merge to refresh the DB and see if any of the 10 smaller suspicious sections still need attention.
 
 ### Frontend — bad-slug 404 → kind-aware NotFound — merged 2026-04-24 (PR #16)
 `LegislationDetail` and `MeetingDetail` now check for HTTP 404 from the API and render `<NotFound />` instead of the "Could not load: HTTP 404" error text. `NotFound` gained a `kind` prop with three variants — `legislation` ("Legislation not found" → recent legislation), `meeting` ("Meeting not found" → upcoming meetings), and the default generic ("Page not found" → This Week). The wildcard `<Route path="*">` in `App.jsx` keeps using the generic variant.

--- a/seattle_app/management/commands/parse_smc_pdf.py
+++ b/seattle_app/management/commands/parse_smc_pdf.py
@@ -43,6 +43,23 @@ CHAPTER_HEADING_RE = re.compile(
 # terminator). Body-text cross-references like "Chapter 25.05," or
 # "Chapter 23.41." don't reach a clean end, so they fail.
 
+EMBEDDED_SECTION_RE = re.compile(r"\b\d+[A-Z]?\.\d+[A-Z]?\.\d+[A-Z]?\b")
+# Matches a section-number-shaped substring anywhere in a string.
+# Used to detect ghost headings — body-text or appendix lines that
+# happen to match SECTION_RE because the line starts with a section
+# number, but whose "title" group is actually a list of citations.
+
+LEGITIMATE_SECTION_CITATION_RE = re.compile(
+    r"\bSection(?:s)?\s+\d+[A-Z]?\.\d+[A-Z]?\.\d+",
+    re.IGNORECASE,
+)
+# A section number preceded by "Section" or "Sections" in the title.
+# Real titles legitimately reference other sections this way (e.g.
+# "Penalty for violation of Section 3.30.050.", "Violation of Sections
+# 6.240.020,"). Ghost headings from citation-list lines in the
+# "ORDINANCES CODIFIED" appendix have section numbers without this
+# lead-in (e.g. "ChartA, 23.50.012 ChartA, 23.54.015 Chart").
+
 SUBCHAPTER_RE = re.compile(r"^Subchapter\s+[IVXLCDM]+\b")
 # Matches a subchapter heading like "Subchapter IX Categorical Exemptions"
 # or a bare "Subchapter III". Also a section terminator: without this,
@@ -590,6 +607,24 @@ class Command(BaseCommand):
                     and bare_title.isalpha()
                     and bare_title.isupper()
                 )
+                # Ghost-heading guard: a line like "23.47.004 ChartA,
+                # 23.50.012 ChartA, 23.54.015 Chart" matches SECTION_RE
+                # but its "title" is really a citation list from the
+                # "ORDINANCES CODIFIED" appendix or similar. Real titles
+                # only contain another section number when they're
+                # explicitly citing it ("Sections X.Y.Z" / "Section X.Y.Z"
+                # lead-in). Reject titles with embedded section numbers
+                # that lack that lead-in.
+                title_has_embedded_section = (
+                    EMBEDDED_SECTION_RE.search(raw_title) is not None
+                )
+                title_has_legitimate_citation = (
+                    LEGITIMATE_SECTION_CITATION_RE.search(raw_title) is not None
+                )
+                is_ghost_citation_heading = (
+                    title_has_embedded_section
+                    and not title_has_legitimate_citation
+                )
                 if (
                     m
                     and first_letter.isupper()
@@ -598,6 +633,7 @@ class Command(BaseCommand):
                         or any(c.islower() for c in raw_title)
                         or is_acronym_title
                     )
+                    and not is_ghost_citation_heading
                     and _is_section_boundary(prev_line)
                     and not self._is_toc_entry(lines, i, prev_line)
                 ):
@@ -713,7 +749,29 @@ class Command(BaseCommand):
             left = [w for w in words if (w["x0"] + w["x1"]) / 2 < mid_x]
             right = [w for w in words if (w["x0"] + w["x1"]) / 2 >= mid_x]
             lines = self._words_to_lines(left) + self._words_to_lines(right)
-        return [ln for ln in lines if not self._is_header_or_footer(ln)]
+        body_lines = [ln for ln in lines if not self._is_header_or_footer(ln)]
+
+        # Chapter-transition pages have a heading like "Chapter 25.32" that
+        # spans the full page width. Two-column extraction fragments it
+        # ("Chapter" alone in one column, "25.32" alone in the other), so
+        # CHAPTER_HEADING_RE never matches and the chapter-flush at line
+        # ~650 never fires — the previous section keeps accreting body
+        # text from a tableonly chapter (e.g. 25.32 TABLE OF HISTORICAL
+        # LANDMARKS swelled 25.30.130 to 280k chars). Recover the heading
+        # from extract_text(), which doesn't column-split, and inject it
+        # at the top so the existing flush logic sees it.
+        if not any(CHAPTER_HEADING_RE.match(ln) for ln in body_lines):
+            try:
+                raw_text = page.extract_text() or ""
+            except Exception:
+                raw_text = ""
+            for raw_line in raw_text.split("\n")[:5]:
+                stripped = raw_line.strip()
+                if CHAPTER_HEADING_RE.match(stripped):
+                    body_lines.insert(0, stripped)
+                    break
+
+        return body_lines
 
     @staticmethod
     def _words_to_lines(words: list[dict]) -> list[str]:


### PR DESCRIPTION
## Summary

Three sections were >150k chars in the DB after the 2026-04-24 re-parse: 25.30.130 (280k), 23.47.004 (207k), 23.54.015 (156k). Two distinct bugs.

### Bug 1 — chapter headings missed on transition pages
================================================
The two-column word extraction in _extract_page_lines fragments full- width chapter headings: on page 4388 "Chapter 25.32" splits into "Chapter" in one column and "25.32" in another, so CHAPTER_HEADING_RE never matches and the chapter-flush branch in _walk_sections never fires. Result: 60+ pages of "25.32 TABLE OF HISTORICAL LANDMARKS" table content kept appending to the preceding section (25.30.130).

Fix: when no CHAPTER_HEADING_RE line exists in the column-split output, recover it from page.extract_text() (which doesn't column-split) and inject it at the top so the existing flush logic sees it.

### Bug 2 — ghost headings from citation lists
==========================================
Body-text lines like "23.47.004 ChartA, 23.50.012 ChartA, 23.54.015 Chart" in the "ORDINANCES CODIFIED" appendix match SECTION_RE and pass all the title checks (uppercase first letter, has lowercase, valid boundary), so they emit a phantom section with the citation list as its title.

Fix: new EMBEDDED_SECTION_RE + LEGITIMATE_SECTION_CITATION_RE pair. Reject the heading if its title contains a section-number-shaped substring AND lacks a "Section(s) X.Y.Z" lead-in. Real titles that legitimately cite sections (e.g. "Penalty for violation of Section 3.30.050.", "Violation of Sections 6.240.020,") have the lead-in and pass through.

## Test plan
  - [x] Dry-run on pages 4385–4500 (catastrophic zone) — emits only the 5 expected real sections (25.30.090 → 25.30.130), no ghosts, no Chapter 25.32 spillover
  - [x] Dry-run on pages 370–390 (regression) — `3.30.060 Penalty for violation of Section 3.30.050.` still emits correctly
  - [ ] **Post-merge:** full re-parse to refresh the DB and triage whether any of the 10 smaller suspicious 30–53k sections are still over-sized

WORK_LOG: catastrophic part moved to Done (PR #17). The 10 smaller suspicious 30-53k-char sections remain in Up next as a separate triage item — a post-merge full re-parse will show whether any of them are still over-sized after these fixes.