### PR TITLE
fix(parser): gate extract_text() fallback to chapter-transition pages

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -59,6 +59,9 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 
 ## Done
 
+### Parser — gate `extract_text()` fallback to transition pages — merged 2026-04-24 (PR #18)
+PR #17's `_extract_page_lines` fallback called `page.extract_text()` on every page where no `CHAPTER_HEADING_RE` matched — which is most pages. `extract_text()` re-runs the full layout pipeline, so this roughly doubled per-page work and made a full re-parse churn for hours. New `CHAPTER_FRAGMENT_RE` matches a bare `Chapter` line or a bare chapter-number like `25.32`; the fallback only fires when such a fragment is present AND no `CHAPTER_HEADING_RE` line matched. Body pages have neither, so the fast path is restored. Caught when the user noticed the re-parse churning on Title 15 like before the parser improvements.
+
 ### Parser — section-boundary leak (catastrophic) — merged 2026-04-24 (PR #17)
 Fixed the three catastrophic over-sized sections (`25.30.130` 280k chars, `23.47.004` 207k, `23.54.015` 156k). Two distinct bugs:
 1. **`Chapter 25.32` not detected** because two-column extraction fragments full-width chapter headings ("Chapter" alone in one column, "25.32" in the other). Chapter-flush at `_walk_sections` never fires, so 60+ pages of `25.32 TABLE OF HISTORICAL LANDMARKS` table content kept appending to `25.30.130`. Fix: in `_extract_page_lines`, when no `CHAPTER_HEADING_RE` line exists in the column-split output, recover it from `extract_text()` (which doesn't column-split) and inject at the top.

--- a/seattle_app/management/commands/parse_smc_pdf.py
+++ b/seattle_app/management/commands/parse_smc_pdf.py
@@ -60,6 +60,14 @@ LEGITIMATE_SECTION_CITATION_RE = re.compile(
 # "ORDINANCES CODIFIED" appendix have section numbers without this
 # lead-in (e.g. "ChartA, 23.50.012 ChartA, 23.54.015 Chart").
 
+CHAPTER_FRAGMENT_RE = re.compile(r"^(?:Chapter|\d+[A-Z]?\.\d+[A-Z]?)\s*$")
+# Matches a single fragment of a "Chapter X.Y" heading on its own line —
+# either the bare word "Chapter" or a bare chapter-number like "25.32".
+# Two-column extraction sometimes splits a full-width chapter heading
+# this way, leaving CHAPTER_HEADING_RE unable to match. Used as the gate
+# for the extract_text() fallback in _extract_page_lines so the fallback
+# only runs on the rare transition pages, not every body page.
+
 SUBCHAPTER_RE = re.compile(r"^Subchapter\s+[IVXLCDM]+\b")
 # Matches a subchapter heading like "Subchapter IX Categorical Exemptions"
 # or a bare "Subchapter III". Also a section terminator: without this,
@@ -751,16 +759,25 @@ class Command(BaseCommand):
             lines = self._words_to_lines(left) + self._words_to_lines(right)
         body_lines = [ln for ln in lines if not self._is_header_or_footer(ln)]
 
-        # Chapter-transition pages have a heading like "Chapter 25.32" that
-        # spans the full page width. Two-column extraction fragments it
-        # ("Chapter" alone in one column, "25.32" alone in the other), so
-        # CHAPTER_HEADING_RE never matches and the chapter-flush at line
-        # ~650 never fires — the previous section keeps accreting body
-        # text from a tableonly chapter (e.g. 25.32 TABLE OF HISTORICAL
-        # LANDMARKS swelled 25.30.130 to 280k chars). Recover the heading
-        # from extract_text(), which doesn't column-split, and inject it
-        # at the top so the existing flush logic sees it.
-        if not any(CHAPTER_HEADING_RE.match(ln) for ln in body_lines):
+        # Chapter-transition pages have a heading like "Chapter 25.32"
+        # that spans the full page width. Two-column extraction fragments
+        # it ("Chapter" alone in one column, "25.32" alone in the other),
+        # so CHAPTER_HEADING_RE never matches and the chapter-flush in
+        # _walk_sections never fires — the previous section keeps
+        # accreting body text from a table-only chapter (e.g. 25.32
+        # TABLE OF HISTORICAL LANDMARKS swelled 25.30.130 to 280k chars).
+        # When we see a fragment ("Chapter" alone or a bare chapter
+        # number like "25.32") AND no real CHAPTER_HEADING_RE match,
+        # recover the heading from extract_text() (which doesn't
+        # column-split) and inject it at the top.
+        #
+        # Gating on the fragment signal is essential — extract_text() re-
+        # runs the full layout pipeline, so calling it on every body
+        # page (which has no chapter heading) roughly doubles per-page
+        # work and makes a full re-parse churn for hours.
+        has_chapter_heading = any(CHAPTER_HEADING_RE.match(ln) for ln in body_lines)
+        has_chapter_fragment = any(CHAPTER_FRAGMENT_RE.match(ln) for ln in body_lines)
+        if has_chapter_fragment and not has_chapter_heading:
             try:
                 raw_text = page.extract_text() or ""
             except Exception:


### PR DESCRIPTION
## Summary
PR #17 added an extract_text() fallback inside _extract_page_lines so column-split fragmentation of "Chapter X.Y" headings on transition pages could be recovered. The gate was "no CHAPTER_HEADING_RE line in column-split output" — but most body pages have no chapter heading, so extract_text() was firing on almost every page during a full re- parse. extract_text() re-runs the full layout pipeline, roughly doubling per-page work and making a full re-parse churn for hours.

**Fix:** new `CHAPTER_FRAGMENT_RE` matches a bare `Chapter` line or a bare chapter-number like `25.32`. The fallback only fires when such a fragment is present AND no `CHAPTER_HEADING_RE` line matched. Body pages have neither, so the fast path is restored.
  Chapter-transition pages still trigger the fallback and recover the heading.

  ## Test plan
  - [x] Kill any running re-parse first (the bug made it churn)
  - [ ] Re-run the dry-run on pages 4385–4500 — should still emit only 5 sections (25.30.090–.130), no ghosts
  - [ ] Full re-parse should now run at the same pace as before PR #17

  ## Notes
  Caught when the user noticed the re-parse churning on Title 15. Sorry — should have load-tested PR #17 on more than the failure window.