### PR TITLE
fix(parser): use chapter_number not title_number for Subchapter orphan scope

### DIFF
--- a/seattle_app/management/commands/parse_smc_pdf.py
+++ b/seattle_app/management/commands/parse_smc_pdf.py
@@ -1542,7 +1542,9 @@ class Command(BaseCommand):
 
         if not self._subchapter_cache:
             return 0
-        parsed_chapters = {key[0] for key in self._emitted_section_keys}
+        # _emitted_section_keys holds (title_number, chapter_number,
+        # section_number); chapter_number is at index 1, not 0.
+        parsed_chapters = {key[1] for key in self._emitted_section_keys}
         if not parsed_chapters:
             return 0
 


### PR DESCRIPTION
## Summary
PR #24's `_cleanup_orphan_subchapters` had an off-by-one indexing bug:

```python
parsed_chapters = {key[0] for key in self._emitted_section_keys}  # title_number, e.g. '25'
candidates = Subchapter.objects.filter(chapter_number__in=parsed_chapters)  # but rows have '25.32'
```

`_emitted_section_keys` holds tuples `(title_number, chapter_number, section_number)`. `key[0]` is the title number (`'25'`) but the filter compares against `chapter_number` (`'25.32'`) — so the `IN` filter matched zero rows and **no orphans were ever deleted**.

Caught when the post-merge re-parse logged `Orphan subchapters deleted: 0` despite the known phantom `25.32 VI 'of Chapter 23.69; amends'` still being in the DB.

Fix: use `key[1]` (chapter_number).

## Test plan
- [ ] Re-parse with `--allow-deletes`: log shows `Orphan subchapters deleted: 1` (the `25.32 VI` phantom).
- [ ] DB query: `SELECT * FROM seattle_app_subchapter WHERE chapter_number = '25.32' AND roman = 'VI'` returns 0 rows after re-parse.
- [ ] No regression in section count, appendix count, or validation count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)