### PR TITLE
fix(parser): scope orphan subchapter cleanup by title, not chapter

### DIFF
--- a/seattle_app/management/commands/parse_smc_pdf.py
+++ b/seattle_app/management/commands/parse_smc_pdf.py
@@ -1542,18 +1542,30 @@ class Command(BaseCommand):
 
         if not self._subchapter_cache:
             return 0
-        # _emitted_section_keys holds (title_number, chapter_number,
-        # section_number); chapter_number is at index 1, not 0.
-        parsed_chapters = {key[1] for key in self._emitted_section_keys}
-        if not parsed_chapters:
+        # Scope by parsed *titles*, not parsed chapters. Subchapters
+        # belonging to a section-less chapter (e.g. 25.32 — the
+        # table-only Historical Landmarks chapter) would otherwise
+        # be invisible to cleanup, since 25.32 itself never appears
+        # in _emitted_section_keys. Phantoms in such chapters
+        # (e.g. `25.32 VI 'of Chapter 23.69; amends'` from a body
+        # cross-ref) wouldn't be cleaned up. Match the title-level
+        # scoping that _cleanup_orphan_sections uses.
+        parsed_titles = {key[0] for key in self._emitted_section_keys}
+        if not parsed_titles:
             return 0
 
-        candidates = Subchapter.objects.filter(
-            chapter_number__in=parsed_chapters
-        ).values_list("id", "chapter_number", "roman", "name")
+        all_subchapters = Subchapter.objects.values_list(
+            "id", "chapter_number", "roman", "name"
+        )
 
         orphan_ids: list[int] = []
-        for row_id, chap, roman, name in candidates:
+        for row_id, chap, roman, name in all_subchapters:
+            # chapter_number always starts with title_number followed by
+            # a dot ('25.32', '23.47A', '12A.14'); split-and-take-first
+            # gives the title number.
+            title = chap.split(".")[0]
+            if title not in parsed_titles:
+                continue
             if (chap, roman) not in self._subchapter_cache:
                 orphan_ids.append(row_id)
                 self.stdout.write(self.style.WARNING(


### PR DESCRIPTION
## Summary
PR #25's `_cleanup_orphan_subchapters` scoped candidates by `parsed_chapters` (chapters where this run emitted ≥1 section). But chapter `25.32` is a table-only chapter (Historical Landmarks) with zero real sections — no section is ever emitted in `25.32`, so it never appears in `parsed_chapters`, so subchapters in `25.32` are invisible to cleanup. The phantom `25.32 VI 'of Chapter 23.69; amends'` (created by a body cross-ref in an older parse) survives every re-parse.

Switched scope to `parsed_titles` (matching `_cleanup_orphan_sections`) and derive title from `chapter_number` via `split('.')[0]`. Subchapter schema doesn't have a `title_number` column, but `chapter_number` always starts with title number followed by a dot:
- `'25.32'` → `'25'`
- `'23.47A'` → `'23'`
- `'12A.14'` → `'12A'`

## Why the previous re-parse looked weird
- `23.47A I 'General Provisions'` was correctly identified as a phantom and deleted by PR #25 — verified that no `Subchapter I` line exists anywhere in chapter 23.47A's pages (2920-2990). Its 18 `declared_section_numbers` were also phantom data from the same old buggy parse. The validation drop (80 → 62, exactly -18) reflects real cleanup of phantom-induced issues, not hidden problems.
- `25.32 VI` survived because of the chapter-vs-title scoping bug fixed here.

## Test plan
- [ ] Full re-parse with `--allow-deletes`: `Orphan subchapters deleted: 1` (the `25.32 VI` phantom).
- [ ] DB query `SELECT * FROM seattle_app_subchapter WHERE toc_source = 'synthesized'` returns at most `23.58A II 'Extra residential floor area'` (the only known partial-match case).
- [ ] No regression in section count / appendix / validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)