### PR TITLE
fix(parser): exit AFTER_CHAPTER state on first lowercase line

### DIFF
--- a/seattle_app/management/commands/parse_smc_pdf.py
+++ b/seattle_app/management/commands/parse_smc_pdf.py
@@ -406,6 +406,20 @@ class _TocScanner:
             self.current_draft.name = (
                 (self.current_draft.name + " " + stripped).strip()
             )
+        elif self.state == self._STATE_AFTER_CHAPTER and any(
+            c.islower() for c in stripped
+        ):
+            # AFTER_CHAPTER expects either an all-caps chapter name
+            # continuation (e.g. `ENVIRONMENTAL POLICIES AND PROCEDURES`
+            # following `Chapter 25.05`) or a `Sections:` marker. The
+            # first line with lowercase content means we've moved into
+            # body — chapters with no `Sections:` marker (table-only
+            # chapters like `25.32 HISTORICAL LANDMARKS`) would
+            # otherwise stay in AFTER_CHAPTER state forever, letting
+            # body cross-references like `'Subchapter VI of Chapter
+            # 23.69; amends'` pass the in_toc_state guard and create
+            # phantom subchapter drafts.
+            self.state = self._STATE_IDLE
         return None
 
     def _finalize_current_draft(self):


### PR DESCRIPTION
## Summary
PR #26's title-scoped orphan cleanup was correct, but the phantom `25.32 VI` survived for a deeper reason: **chapter 25.32 has no `Sections:` marker** (it's a table-only chapter — `HISTORICAL LANDMARKS`), so the `_TocScanner` stayed in `AFTER_CHAPTER` state for the entire chapter. The body cross-reference `'Subchapter VI of Chapter 23.69; amends'` on p4449 then matched `SUBCHAPTER_LINE_RE` and passed the `in_toc_state` guard (because `AFTER_CHAPTER` counts as TOC state), creating a phantom draft. The draft persisted through `_flush_unreferenced_drafts` which added it to `_subchapter_cache` — making the orphan-cleanup pass blind to it.

## Fix
When in `AFTER_CHAPTER` state and a line with lowercase content appears, transition to `IDLE`. Real chapter name continuations are all-caps (e.g. `ENVIRONMENTAL POLICIES AND PROCEDURES`), so legit chapters reach `Sections:` before any lowercase line.

## Verified
- Chapter 25.05 (SEPA, normal layout): all 11 subchapters (I–XI) still detected.
- Chapter 25.32 (table-only): zero drafts (was 1 phantom).

## Test plan
- [ ] Re-parse with `--allow-deletes`: `Orphan subchapters deleted: 1` (the `25.32 VI` phantom).
- [ ] DB query `SELECT * FROM seattle_app_subchapter WHERE name = 'of Chapter 23.69; amends'` returns 0 rows.
- [ ] Synthesized count drops to 1 (just `23.58A II`).
- [ ] No regression in section count or appendix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)