### PR TITLE
Index breadcrumbs + clickable Header logo + far-left layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -15,8 +15,9 @@
   }
   
   .header-container {
-    max-width: 1280px;
-    margin: 0 auto;
+    /* Full-width header so the logo sits in the far-left viewport corner,
+       matching the convention on other councilmatic sites. */
+    width: 100%;
     padding: 0 1rem;
     display: block;
   }
@@ -31,6 +32,18 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
+    color: inherit;
+    text-decoration: none;
+    border-radius: 0.375rem;
+  }
+
+  .logo-section:hover .title {
+    color: #2E3D5B;
+  }
+
+  .logo-section:focus-visible {
+    outline: 2px solid #2E3D5B;
+    outline-offset: 2px;
   }
   
   .logo-icon {

--- a/frontend/src/components/EventsIndex.css
+++ b/frontend/src/components/EventsIndex.css
@@ -9,6 +9,35 @@
   margin: 0 auto;
 }
 
+.evt-index-breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+}
+
+.evt-index-breadcrumb a {
+  color: #2E3D5B;
+  text-decoration: none;
+}
+
+.evt-index-breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.evt-index-breadcrumb-sep {
+  color: #9ca3af;
+  font-weight: 400;
+}
+
+.evt-index-breadcrumb-current {
+  color: #6b7280;
+  font-weight: 500;
+}
+
 .evt-index-header {
   margin-bottom: 2rem;
 }

--- a/frontend/src/components/EventsIndex.jsx
+++ b/frontend/src/components/EventsIndex.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams, Link } from 'react-router-dom'
 import EventCard from './EventCard'
 import './EventsIndex.css'
 
@@ -103,6 +103,11 @@ export default function EventsIndex() {
   return (
     <main className="evt-index-page">
       <div className="evt-index-container">
+        <nav className="evt-index-breadcrumb" aria-label="Breadcrumb">
+          <Link to="/">This Week</Link>
+          <span className="evt-index-breadcrumb-sep" aria-hidden="true">/</span>
+          <span className="evt-index-breadcrumb-current">Events</span>
+        </nav>
         <header className="evt-index-header">
           <h1 className="evt-index-title">Events</h1>
           <p className="evt-index-subtitle">

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { Landmark } from 'lucide-react';
 
 export default function Header() {
@@ -6,8 +7,8 @@ export default function Header() {
       <div className="header-container">
         <div className="header-content">
 
-          {/* logo and title */}
-          <div className="logo-section">
+          {/* Logo + title — clickable, returns to homepage from any page */}
+          <Link to="/" className="logo-section" aria-label="Seattle Councilmatic — Home">
 
             {/* logo icon */}
             <div className="logo-icon">
@@ -21,7 +22,7 @@ export default function Header() {
                 An easy way to follow Seattle City Council activity and find local bills.
               </p>
             </div>
-          </div>
+          </Link>
 
         </div>
       </div>

--- a/frontend/src/components/LegislationIndex.css
+++ b/frontend/src/components/LegislationIndex.css
@@ -9,6 +9,35 @@
   margin: 0 auto;
 }
 
+.leg-index-breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+}
+
+.leg-index-breadcrumb a {
+  color: #2E3D5B;
+  text-decoration: none;
+}
+
+.leg-index-breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.leg-index-breadcrumb-sep {
+  color: #9ca3af;
+  font-weight: 400;
+}
+
+.leg-index-breadcrumb-current {
+  color: #6b7280;
+  font-weight: 500;
+}
+
 .leg-index-header {
   margin-bottom: 2rem;
 }

--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams, Link } from 'react-router-dom'
 import LegislationCard from './LegislationCard'
 import './LegislationIndex.css'
 
@@ -89,6 +89,11 @@ export default function LegislationIndex() {
   return (
     <main className="leg-index-page">
       <div className="leg-index-container">
+        <nav className="leg-index-breadcrumb" aria-label="Breadcrumb">
+          <Link to="/">This Week</Link>
+          <span className="leg-index-breadcrumb-sep" aria-hidden="true">/</span>
+          <span className="leg-index-breadcrumb-current">Legislation</span>
+        </nav>
         <header className="leg-index-header">
           <h1 className="leg-index-title">Legislation</h1>
           <p className="leg-index-subtitle">


### PR DESCRIPTION
## Summary

Three small navigation polish items.

- **Breadcrumbs on `/legislation` and `/events`.** Each index page now shows `This Week / <name>` at the top, matching the detail-page pattern. Gives an explicit way back to the homepage from the index.
- **Header logo is a Link to `/`.** The Seattle Councilmatic logo + title in the sticky header now navigates to `/` on click — works from any page (homepage, indexes, detail). Hover shifts the title color; focus-visible adds an outline.
- **Logo moved to far-left corner.** Header container changed from `max-width: 1280px; margin: 0 auto` (centered) to `width: 100%` (full-bleed), so the logo sits in the viewport's far-left corner with just the `1rem` padding for breathing room — matches the convention on other Councilmatic sites.

## Test plan

- [x] Frontend `npm run build` succeeds (no warnings)
- [x] Browser:
  - `/legislation` shows breadcrumb at top; `This Week` link returns to `/`
  - `/events` shows breadcrumb at top; `This Week` link returns to `/`
  - Header logo is clickable from any page; clicking returns to `/` without full reload
  - Title shows hover color shift on logo
  - Tab key reveals focus ring on the logo
  - Logo sits in the far-left viewport corner on wide screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)