### PR TITLE
NavBar in header, site-wide footer, copy fix

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -25,7 +25,11 @@
   .header-content {
     display: flex;
     align-items: center;
-    height: 64px;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    min-height: 64px;
+    padding: 0.5rem 0;
   }
   
   .logo-section {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Header from './components/Header'
-import NavBar from './components/NavBar'
+import Footer from './components/Footer'
 import RepLookup from './components/RepLookup'
 import ThisWeek from './components/ThisWeek'
 import LegislationIndex from './components/LegislationIndex'
@@ -14,7 +14,6 @@ function HomePage() {
   return (
     <>
       <RepLookup />
-      <NavBar activeItem="This Week" />
       <ThisWeek />
     </>
   )
@@ -34,6 +33,7 @@ function App() {
         <Route path="/events/:slug" element={<EventDetail />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
+      <Footer />
     </BrowserRouter>
   )
 }

--- a/frontend/src/components/Footer.css
+++ b/frontend/src/components/Footer.css
@@ -1,0 +1,43 @@
+.site-footer {
+  margin-top: auto;
+  background: #1f2937;
+  color: #d1d5db;
+  padding: 1.5rem 1rem;
+}
+
+.site-footer-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.site-footer-copyright {
+  margin: 0;
+  font-weight: 500;
+}
+
+.site-footer-links {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.site-footer-links a {
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.site-footer-links a:hover {
+  text-decoration: underline;
+}
+
+.site-footer-sep {
+  color: #6b7280;
+}

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,0 +1,25 @@
+import './Footer.css'
+
+const REPO_URL = 'https://github.com/SeattleCouncilmatic/seattle-councilmatic'
+const COUNCILMATIC_URL = 'https://councilmatic.org/'
+
+export default function Footer() {
+  const year = new Date().getFullYear()
+  return (
+    <footer className="site-footer">
+      <div className="site-footer-inner">
+        <p className="site-footer-copyright">© {year} Seattle Councilmatic</p>
+        <div className="site-footer-links">
+          <a href={REPO_URL} target="_blank" rel="noopener noreferrer">GitHub</a>
+          <span className="site-footer-sep" aria-hidden="true">·</span>
+          <span>
+            Powered by{' '}
+            <a href={COUNCILMATIC_URL} target="_blank" rel="noopener noreferrer">
+              Councilmatic
+            </a>
+          </span>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Landmark } from 'lucide-react';
+import NavBar from './NavBar';
 
 export default function Header() {
   return (
@@ -24,6 +25,7 @@ export default function Header() {
             </div>
           </Link>
 
+          <NavBar />
         </div>
       </div>
     </header>

--- a/frontend/src/components/NavBar.css
+++ b/frontend/src/components/NavBar.css
@@ -1,29 +1,21 @@
+/* NavBar lives inside Header now — no own background or container; just
+   the inline list of links. Header handles the bar background. */
 .navbar {
-  background: #ffffff;
-  border-bottom: 2px solid #e5e7eb;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  /* hide scrollbar but keep it functional */
-  scrollbar-width: none;
-}
-
-.navbar::-webkit-scrollbar {
-  display: none;
+  display: flex;
+  align-items: center;
 }
 
 .navbar-inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 0 1.5rem;
   display: flex;
+  flex-wrap: wrap;
   gap: 0.25rem;
-  min-width: max-content;
+  justify-content: flex-end;
 }
 
 .navbar-item {
   display: inline-block;
-  padding: 0.875rem 1.125rem;
-  font-size: 0.9375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: #374151;
   text-decoration: none;

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import './NavBar.css';
 
 // Items with `to` use React Router (full-page surfaces); items with `href`
@@ -15,13 +15,23 @@ const NAV_ITEMS = [
   { label: 'Glossary',           href: '#glossary' },
 ];
 
-export default function NavBar({ activeItem = 'This Week' }) {
+function isActive(pathname, item) {
+  if (item.to) return pathname === item.to || pathname.startsWith(item.to + '/');
+  // Hash items are only "active" on the homepage's This Week stub.
+  if (item.label === 'This Week') return pathname === '/';
+  return false;
+}
+
+export default function NavBar() {
+  const { pathname } = useLocation();
   return (
     <nav className="navbar" aria-label="Main Navigation">
       <div className="navbar-inner">
-        {NAV_ITEMS.map(({ label, href, to }) => {
-          const className = `navbar-item${label === activeItem ? ' navbar-item--active' : ''}`;
-          const ariaCurrent = label === activeItem ? 'page' : undefined;
+        {NAV_ITEMS.map((item) => {
+          const { label, href, to } = item;
+          const active = isActive(pathname, item);
+          const className = `navbar-item${active ? ' navbar-item--active' : ''}`;
+          const ariaCurrent = active ? 'page' : undefined;
           return to ? (
             <Link key={label} to={to} className={className} aria-current={ariaCurrent}>
               {label}

--- a/frontend/src/components/ThisWeek.jsx
+++ b/frontend/src/components/ThisWeek.jsx
@@ -70,7 +70,7 @@ export default function ThisWeek() {
           <div>
             <SectionHeader
               icon={Gavel}
-              title="New Legislation"
+              title="Recent Legislation"
               subtitle="Bills and resolutions introduced recently."
             />
             {billsLoading && <LoadingSpinner />}


### PR DESCRIPTION
## Summary

Three items from the frontend polish backlog (added to WORK_LOG in `31a16d2`).

- **NavBar in Header.** NavBar moved from a separate row below the Header into the Header itself, right-aligned beside the logo. Drops the `activeItem` prop in favor of URL-driven detection (`useLocation`) so the active link is correct on every route — `Legislation` highlights on `/legislation*`, `Events` on `/events*`, `This Week` on `/`. Hash-anchor items (About, How It Works, etc.) only highlight when on the homepage. NavBar removed from `HomePage` in App.jsx since it's now global. NavBar's `.css` simplified to drop the standalone background/container — Header owns those.
- **Site-wide Footer.** New `Footer.jsx` rendered in `App.jsx` outside `<Routes>` so every page inherits it. Contents: copyright (auto-current-year), GitHub link, "Powered by Councilmatic". Uses `margin-top: auto` + the existing `#root` flex-column so it sticks to the bottom of short pages.
- **Copy fix.** "New Legislation" → "Recent Legislation" in `ThisWeek.jsx`.

Mobile NavBar wraps via `flex-wrap` — a proper hamburger menu is filed as a follow-up if narrow-screen usability becomes a problem.

## Test plan

- [x] Frontend `npm run build` succeeds (1730 modules, no warnings)
- [x] Browser:
  - Homepage `/` — header has logo on left, NavBar on right (no separate row); `This Week` is active
  - `/legislation` — `Legislation` is active in nav
  - `/events` — `Events` is active in nav
  - Detail pages (`/legislation/<slug>`, `/events/<slug>`) — same Header + Footer
  - "Recent Legislation" displays in the homepage's section header
  - Footer renders on every route, sticks to bottom on short pages
  - Footer GitHub + Councilmatic links open in new tabs
  - Narrow viewport — NavBar items wrap below the logo instead of overflowing horizontally
  - All Link clicks (Legislation/Events/logo) navigate without full page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)