### PR TITLE
municode: PG FTS infra on MunicipalCodeSection

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -62,6 +62,19 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 
 ## Done
 
+### Municode — Postgres FTS infra on `MunicipalCodeSection` — committed 2026-04-27
+PR 2 of the three-PR `/municode/` build. Adds a tsvector search column + GIN index to `MunicipalCodeSection`; the API endpoint and SPA page land in PR 3.
+
+Implemented as a Postgres **generated column** (`GENERATED ALWAYS AS ... STORED`) rather than a trigger or a Django `save()` override. Generated columns are computed by PG itself on every insert/update of the source columns, so the vector stays in sync regardless of insertion path — Django ORM, parser `bulk_create`, raw SQL, fixtures, admin all benefit equally with zero application code. Requires PG 12+; we're on `postgis/postgis:14-3.2`.
+
+Vector body weights `section_number` (A, the legal citation), `title` (B, the heading), and `full_text` (C, the body) using `english` config. Migration `0014` adds the column via `migrations.RunSQL` (Django's `AddField` doesn't speak `GENERATED ALWAYS AS`) with `state_operations=[AddField(...)]` so Django's migration graph stays consistent with the model. `migrations.AddIndex` builds `smc_section_search_idx` as a `GinIndex`. Model gains `search_vector = SearchVectorField(null=True, editable=False)` plus the `Meta.indexes` entry.
+
+`django.contrib.postgres` added to `INSTALLED_APPS` for migration framework awareness of `SearchVectorField`/`GinIndex`.
+
+Verified end-to-end: migration applies in ~6 s wall-clock (Django bootstrap dominates; PG fills the column inline during `ALTER TABLE` for all 7,435 existing rows — no `RunPython` backfill needed); column shows `is_generated='ALWAYS'` with the expected expression; GIN index exists; 7435/7435 rows have non-null vectors. Sample `SearchRank` query for "short-term rental" returns Chapter 6.600 (Seattle's STR chapter) `6.600.065 Summaries of short-term` → `License fees` → `License applications` → `23.44.051 Bed and breakfasts` — the kind of relevance ranking that motivated keeping this in-database rather than reaching for ES.
+
+`pg_trgm` deferred to PR 3 (when the search endpoint actually needs fuzzy section-number lookup).
+
 ### Search — strip Elasticsearch + Haystack — committed 2026-04-27
 Elasticsearch was plumbed in but not actually serving search: only `update_index` (run nightly) wrote to it, and the SPA's user-facing search bars (`/api/legislation/`, `/api/events/`) bypass it entirely with Postgres `Q(... __icontains=q)` queries. The legacy server-rendered `/search/` page existed via `councilmatic_search.urls` but the SPA never linked there. Net cost: a 1 GB ES container, the `bill_text.txt` packaging-bug surface we vendored around, and the daily `update_index` step that masked the cron env-loss outage in 2026-04.
 

--- a/seattle_app/migrations/0014_municipalcodesection_search_vector.py
+++ b/seattle_app/migrations/0014_municipalcodesection_search_vector.py
@@ -1,0 +1,47 @@
+from django.contrib.postgres.indexes import GinIndex
+from django.contrib.postgres.search import SearchVectorField
+from django.db import migrations
+
+
+# tsvector body: weighted A/B/C across section_number, title, full_text.
+# Stored as a generated column so PG keeps it in sync with no trigger or
+# Django save() override — works for ORM, bulk_create, raw SQL, fixtures.
+SEARCH_VECTOR_EXPR = """
+    setweight(to_tsvector('english', coalesce(section_number, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(title, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(full_text, '')), 'C')
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seattle_app', '0013_titleappendix'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=f"""
+                ALTER TABLE seattle_app_municipalcodesection
+                ADD COLUMN search_vector tsvector
+                GENERATED ALWAYS AS ({SEARCH_VECTOR_EXPR}) STORED;
+            """,
+            reverse_sql=
+                "ALTER TABLE seattle_app_municipalcodesection "
+                "DROP COLUMN search_vector;",
+            state_operations=[
+                migrations.AddField(
+                    model_name='municipalcodesection',
+                    name='search_vector',
+                    field=SearchVectorField(editable=False, null=True),
+                ),
+            ],
+        ),
+        migrations.AddIndex(
+            model_name='municipalcodesection',
+            index=GinIndex(
+                fields=['search_vector'],
+                name='smc_section_search_idx',
+            ),
+        ),
+    ]

--- a/seattle_app/models.py
+++ b/seattle_app/models.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 from django.contrib.gis.db import models as gis_models
+from django.contrib.postgres.indexes import GinIndex
+from django.contrib.postgres.search import SearchVectorField
 from django.db import models
 from councilmatic_core.models import Bill, Event, Person, Organization
 from datetime import datetime
@@ -70,10 +72,16 @@ class MunicipalCodeSection(models.Model):
     created_at = models.DateTimeField(
         auto_now_add=True
     )
+    # PG-generated tsvector. Column is GENERATED ALWAYS AS ... STORED at the
+    # DB level (see migration 0014); Django never writes to it.
+    search_vector = SearchVectorField(null=True, editable=False)
 
     class Meta:
         ordering = ['title_number', 'chapter_number', 'section_number']
         unique_together = ['title_number', 'chapter_number', 'section_number']
+        indexes = [
+            GinIndex(fields=['search_vector'], name='smc_section_search_idx'),
+        ]
         verbose_name = "Municipal Code Section"
         verbose_name_plural = "Municipal Code Sections"
 

--- a/seattle_app/settings.py
+++ b/seattle_app/settings.py
@@ -27,6 +27,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.gis",
     "django.contrib.humanize",
+    "django.contrib.postgres",
     "corsheaders",
     # Core apps
     "opencivicdata.core",


### PR DESCRIPTION
## Summary

PR 2 of three for the `/municode/` build (PR 1 was #34, the ES rip-out). Adds the Postgres FTS infrastructure that the upcoming search endpoint and SPA page (PR 3) will sit on top of.

- New `search_vector` column on `MunicipalCodeSection`, implemented as a Postgres **generated column** (`GENERATED ALWAYS AS ... STORED`). PG computes it on every insert/update of the source columns, so the vector stays in sync regardless of insertion path — ORM, parser `bulk_create`, raw SQL, fixtures all benefit with zero application code. No trigger to maintain, no `save()` override.
- Vector body weights `section_number` (A — the legal citation), `title` (B — heading), `full_text` (C — body) using the `english` config.
- New `GinIndex` `smc_section_search_idx` for `WHERE search_vector @@ query` lookups.
- Migration `0014` uses `RunSQL` with `state_operations` because Django's `AddField` doesn't speak `GENERATED ALWAYS AS`. PG fills the column inline during `ALTER TABLE` for all 7,435 existing rows — no `RunPython` backfill needed.
- `django.contrib.postgres` added to `INSTALLED_APPS` for migration framework awareness of `SearchVectorField`/`GinIndex`.
- `pg_trgm` deferred to PR 3 (only needed when the search endpoint adds fuzzy section-number lookup).

## Test plan

- [x] `python manage.py makemigrations --check --dry-run` shows no `seattle_app` drift after the model change.
- [x] `python manage.py migrate seattle_app 0014` applies in ~6 s wall-clock (Django bootstrap dominates).
- [x] `information_schema.columns` confirms `search_vector` is `tsvector`, `is_generated='ALWAYS'`, with the expected `setweight(...) || setweight(...) || setweight(...)` expression.
- [x] `pg_indexes` confirms `smc_section_search_idx` exists as `USING gin`.
- [x] All 7,435 rows have non-null vectors with weighted lexemes (sample: `'1.01.010':1A` for section 1.01.010).
- [x] `SearchRank` query for "short-term rental" returns Chapter 6.600 (Seattle's STR chapter) at the top: `6.600.065 Summaries of short-term` → `License fees` → `License applications` → `23.44.051 Bed and breakfasts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)