### PR TITLE
frontend: /reps/ reorder, district pages, map↔card hover

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -64,13 +64,15 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ## Done
 
 ### Frontend — `/reps/` reorder, district pages, map↔card hover sync — committed 2026-04-27
-Started as a section reorder and grew. Three things land together because they share the same scope (the `/reps/` page and how users get from map/lookup to rep info):
+Started as a section reorder and grew. Four things land together because they share the same scope (the `/reps/` page and how users get from map/lookup to rep info):
 
 1. **Address lookup moved above the map.** It's the most goal-directed action on the page; leading with it matches user intent better than asking them to scroll past a map first. New `.reps-section--lead` modifier zeroes `margin-top` so the lookup sits flush under the header. Subtitle copy updated from "Click a district on the map…" to "Find your district representative by address, or browse the full council below."
 
 2. **New `/reps/district/<number>/` page** showing the district + its rep + both at-large reps as click-through links to individual rep details. Replaces the inline lookup-result callout that used to render on `/reps/`. Backend: new `GET /api/reps/districts/<number>/` endpoint returning `{district, rep, at_large}`. Frontend: new `RepDistrict.jsx` component, route `/reps/district/:number`. Header bar uses the district's accent color as a left border for visual continuity with the map.
 
 3. **Map polygon click → district page** instead of straight to a rep, and **hover on a polygon highlights the matching rep card** in the same color (`box-shadow: 0 0 0 2px <color>33` plus `border-color`). Address lookup also navigates to the district page on success. `DISTRICT_COLORS` lifted into `frontend/src/components/districtColors.js` so `CouncilMap` and `RepsIndex` stay in sync.
+
+4. **District mini-map on the detail page.** New `DistrictMiniMap.jsx` renders a single-district close-up — Carto tiles, the district outline filled with its accent color, fitBounds-zoomed, no scroll-zoom or click handlers. Sister to `CouncilMap` (full council with click-through behavior). District detail endpoint now includes the same simplified geometry as the overview map (~10 KB per district), so visual continuity carries from the council overview through the district page. Mirrors the original `DistrictMap` behavior on the old homepage RepLookup result.
 
 Pre-existing data quirk surfaced while testing the district endpoint: `_rep_row_to_dict`'s contact-detail lookup uses `OCDPerson.objects.filter(memberships__label=label).first()`, which can return any historical holder of e.g. "Position 9" — Dionne Foster's email currently shows as Sara Nelson's. Filed under Up next; not a regression and out of scope here.
 

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -22,12 +22,8 @@ Prioritized to-do. Quick wins flagged with *(quick)*.
 - **Index polish** (deferred from PRs #30 and #31). *Legislation:* classification filter (Bill/Resolution/etc.), sort controls, date-range filter, sponsor filter. *Events:* committee-name dropdown (separate from type), date-range filter. *Both:* NavBar's hash-anchor stubs (`#about`, `#how-it-works`, `#my-council-members`, `#glossary`) still point at homepage sections that don't exist yet — wire them up as those sections ship, or convert to real `/path` Links. NavBar isn't shown on the index pages (only on the homepage); think about whether the index pages should get their own header/nav. CSS class names `.meeting-card-*` / `.mtg-detail-*` weren't renamed when MeetingCard/MeetingDetail → EventCard/EventDetail in PR #31; rename if/when those files get more substantive changes.
 
 **Frontend polish & site chrome**
-<<<<<<< HEAD
-- **Move Rep Lookup to its own index page** (`/reps/` or `/my-council-members/`). Currently lives in the homepage hero; pattern matches `/legislation/` and `/events/`. Frees the hero space for the next item.
-- **Legislation search bar in the homepage hero** where Rep Lookup currently lives. Big prominent search box that submits to `/legislation?q=...` — reuses the search infra from PR #30. Most direct way to point users into the data.
-=======
 - **Legislation search bar in the homepage hero** where Rep Lookup used to live. Big prominent search box that submits to `/legislation?q=...` — reuses the search infra from PR #30. Most direct way to point users into the data. (Homepage hero is currently empty after the Rep Lookup move.)
->>>>>>> 7193c8c (frontend: /reps/ council overview map + rep detail pages)
+- **Rep contact-detail lookup picks the wrong Person for at-large reps.** `reps/services.py::_rep_row_to_dict` does `OCDPerson.objects.filter(memberships__label=label).first()` to fetch contact rows. For "Position 9", multiple people have held that membership over time, so `.first()` can return a former holder — visible today as Dionne Foster's email rendering as `sara.nelson@seattle.gov`. Fix: pass the slug or `person_id` from `_query_current_council_members` straight through and filter by that instead. Affects the rep grid on `/reps/`, the rep detail page, and the new district page.
 - **About page** at `/about`. NavBar's `#about` is currently a hash stub — turn into a real route. Content TBD (project description, source code link, contact).
 - **NavBar mobile hamburger** (deferred from PR #33). NavBar currently wraps via `flex-wrap` on narrow screens; if usability becomes a problem, replace with a proper hamburger menu.
 
@@ -67,10 +63,16 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 
 ## Done
 
-### Frontend — `/reps/` reorder: address lookup above the map — committed 2026-04-27
-Reordered `/reps/` so the address lookup form sits directly under the page header, ahead of the council map. Reasoning: the lookup is the most goal-directed action on the page ("which district am I in"), so leading with it matches user intent better than asking them to scroll past a map first. The map and rep cards still follow below for browse-style navigation. Subtitle copy updated from "Click a district on the map…" to "Find your district representative by address, or browse the full council below."
+### Frontend — `/reps/` reorder, district pages, map↔card hover sync — committed 2026-04-27
+Started as a section reorder and grew. Three things land together because they share the same scope (the `/reps/` page and how users get from map/lookup to rep info):
 
-New `.reps-section--lead` modifier zeroes the `margin-top` so the lookup section doesn't carry the same 2.5rem gap that's appropriate for stacked browse sections.
+1. **Address lookup moved above the map.** It's the most goal-directed action on the page; leading with it matches user intent better than asking them to scroll past a map first. New `.reps-section--lead` modifier zeroes `margin-top` so the lookup sits flush under the header. Subtitle copy updated from "Click a district on the map…" to "Find your district representative by address, or browse the full council below."
+
+2. **New `/reps/district/<number>/` page** showing the district + its rep + both at-large reps as click-through links to individual rep details. Replaces the inline lookup-result callout that used to render on `/reps/`. Backend: new `GET /api/reps/districts/<number>/` endpoint returning `{district, rep, at_large}`. Frontend: new `RepDistrict.jsx` component, route `/reps/district/:number`. Header bar uses the district's accent color as a left border for visual continuity with the map.
+
+3. **Map polygon click → district page** instead of straight to a rep, and **hover on a polygon highlights the matching rep card** in the same color (`box-shadow: 0 0 0 2px <color>33` plus `border-color`). Address lookup also navigates to the district page on success. `DISTRICT_COLORS` lifted into `frontend/src/components/districtColors.js` so `CouncilMap` and `RepsIndex` stay in sync.
+
+Pre-existing data quirk surfaced while testing the district endpoint: `_rep_row_to_dict`'s contact-detail lookup uses `OCDPerson.objects.filter(memberships__label=label).first()`, which can return any historical holder of e.g. "Position 9" — Dionne Foster's email currently shows as Sara Nelson's. Filed under Up next; not a regression and out of scope here.
 
 ### Frontend — `/reps/` council overview map + rep detail pages — committed 2026-04-27
 Rep Lookup graduated off the homepage into a dedicated `/reps/` index, plus a chicago.councilmatic.org-style council map showing all 7 districts at once and per-rep detail pages. Closes both "Move Rep Lookup to its own index page" and the new "interactive map highlighting reps" idea in one PR.

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -67,6 +67,11 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 
 ## Done
 
+### Frontend — `/reps/` reorder: address lookup above the map — committed 2026-04-27
+Reordered `/reps/` so the address lookup form sits directly under the page header, ahead of the council map. Reasoning: the lookup is the most goal-directed action on the page ("which district am I in"), so leading with it matches user intent better than asking them to scroll past a map first. The map and rep cards still follow below for browse-style navigation. Subtitle copy updated from "Click a district on the map…" to "Find your district representative by address, or browse the full council below."
+
+New `.reps-section--lead` modifier zeroes the `margin-top` so the lookup section doesn't carry the same 2.5rem gap that's appropriate for stacked browse sections.
+
 ### Frontend — `/reps/` council overview map + rep detail pages — committed 2026-04-27
 Rep Lookup graduated off the homepage into a dedicated `/reps/` index, plus a chicago.councilmatic.org-style council map showing all 7 districts at once and per-rep detail pages. Closes both "Move Rep Lookup to its own index page" and the new "interactive map highlighting reps" idea in one PR.
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import MuniCodeSection from './components/MuniCodeSection'
 import MuniCodeAppendix from './components/MuniCodeAppendix'
 import RepsIndex from './components/RepsIndex'
 import RepDetail from './components/RepDetail'
+import RepDistrict from './components/RepDistrict'
 import NotFound from './components/NotFound'
 import './App.css'
 
@@ -40,6 +41,7 @@ function App() {
         <Route path="/municode/:slug" element={<MuniCodeTitle />} />
         <Route path="/reps" element={<RepsIndex />} />
         <Route path="/reps/" element={<RepsIndex />} />
+        <Route path="/reps/district/:number" element={<RepDistrict />} />
         <Route path="/reps/:slug" element={<RepDetail />} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/frontend/src/components/CouncilMap.jsx
+++ b/frontend/src/components/CouncilMap.jsx
@@ -2,21 +2,10 @@ import { useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
+import { DISTRICT_COLORS } from './districtColors'
 import './CouncilMap.css'
 
-// One distinguishable colour per district. Tab10 palette for D1-D6, the
-// site brand navy for D7 so it sits next to the rest visually.
-const DISTRICT_COLORS = {
-  '1': '#1f77b4', // blue
-  '2': '#ff7f0e', // orange
-  '3': '#2ca02c', // green
-  '4': '#d62728', // red
-  '5': '#9467bd', // purple
-  '6': '#8c564b', // brown
-  '7': '#2E3D5B', // site navy
-}
-
-export default function CouncilMap({ districts }) {
+export default function CouncilMap({ districts, onDistrictHover }) {
   const mapRef = useRef(null)
   const mapInstanceRef = useRef(null)
   const navigate = useNavigate()
@@ -61,20 +50,22 @@ export default function CouncilMap({ districts }) {
         },
         onEachFeature: (_feature, lyr) => {
           const repName = d.rep?.name ?? 'Vacant'
-          const repSlug = d.rep?.slug
           lyr.bindTooltip(
             `<strong>${d.name}</strong><br/>${repName}`,
             { sticky: true, direction: 'top' }
           )
           lyr.on('mouseover', () => {
             lyr.setStyle({ weight: 3, fillOpacity: 0.5 })
+            onDistrictHover?.(d.number)
           })
           lyr.on('mouseout', () => {
             lyr.setStyle({ weight: 2, fillOpacity: 0.3 })
+            onDistrictHover?.(null)
           })
-          if (repSlug) {
-            lyr.on('click', () => navigate(`/reps/${repSlug}`))
-          }
+          // Click goes to the district page (rep + at-large), not straight
+          // to the district rep — gives users the full picture of who
+          // represents them before drilling into a single profile.
+          lyr.on('click', () => navigate(`/reps/district/${d.number}`))
         },
       }).addTo(mapInstanceRef.current)
       allBounds.extend(layer.getBounds())

--- a/frontend/src/components/DistrictMiniMap.css
+++ b/frontend/src/components/DistrictMiniMap.css
@@ -1,0 +1,12 @@
+.district-mini-map {
+  width: 100%;
+  height: 320px;
+  border-radius: 0.5rem;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  z-index: 1;
+}
+
+@media (max-width: 600px) {
+  .district-mini-map { height: 240px; }
+}

--- a/frontend/src/components/DistrictMiniMap.jsx
+++ b/frontend/src/components/DistrictMiniMap.jsx
@@ -47,7 +47,15 @@ export default function DistrictMiniMap({ geometry, districtNumber }) {
       },
     }).addTo(mapInstanceRef.current)
 
-    mapInstanceRef.current.fitBounds(layer.getBounds(), { padding: [20, 20] })
+    // Defer fitBounds + invalidateSize to the next paint so Leaflet
+    // measures the container after the browser has finished layout.
+    // Without this, the map can render at 0×0 if the parent's height
+    // hasn't been computed yet on first mount.
+    requestAnimationFrame(() => {
+      if (!mapInstanceRef.current) return
+      mapInstanceRef.current.invalidateSize()
+      mapInstanceRef.current.fitBounds(layer.getBounds(), { padding: [20, 20] })
+    })
   }, [geometry, districtNumber])
 
   useEffect(() => {

--- a/frontend/src/components/DistrictMiniMap.jsx
+++ b/frontend/src/components/DistrictMiniMap.jsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+import { DISTRICT_COLORS } from './districtColors'
+import './DistrictMiniMap.css'
+
+// Close-up of a single district — rendered on /reps/district/<n>/. Sister
+// to CouncilMap (which shows all 7 with click-through behavior). This one
+// is non-interactive: no scroll-zoom, no click-to-navigate; it's purely
+// "here's the area you're looking at."
+export default function DistrictMiniMap({ geometry, districtNumber }) {
+  const mapRef = useRef(null)
+  const mapInstanceRef = useRef(null)
+
+  useEffect(() => {
+    if (!mapRef.current || !geometry) return
+
+    if (!mapInstanceRef.current) {
+      mapInstanceRef.current = L.map(mapRef.current, {
+        center: [47.6062, -122.3321],
+        zoom: 11,
+        zoomControl: true,
+        scrollWheelZoom: false,
+      })
+      L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+        subdomains: 'abcd',
+        maxZoom: 20,
+      }).addTo(mapInstanceRef.current)
+    }
+
+    // Replace any existing district layer
+    mapInstanceRef.current.eachLayer((layer) => {
+      if (layer instanceof L.GeoJSON) {
+        mapInstanceRef.current.removeLayer(layer)
+      }
+    })
+
+    const color = DISTRICT_COLORS[districtNumber] || '#2E3D5B'
+    const layer = L.geoJSON(geometry, {
+      style: {
+        color,
+        weight: 3,
+        opacity: 1,
+        fillColor: color,
+        fillOpacity: 0.35,
+      },
+    }).addTo(mapInstanceRef.current)
+
+    mapInstanceRef.current.fitBounds(layer.getBounds(), { padding: [20, 20] })
+  }, [geometry, districtNumber])
+
+  useEffect(() => {
+    return () => {
+      if (mapInstanceRef.current) {
+        mapInstanceRef.current.remove()
+        mapInstanceRef.current = null
+      }
+    }
+  }, [])
+
+  if (!geometry) return null
+  return <div ref={mapRef} className="district-mini-map" />
+}

--- a/frontend/src/components/RepDistrict.css
+++ b/frontend/src/components/RepDistrict.css
@@ -1,0 +1,124 @@
+.rep-district-page {
+  background: #f9fafb;
+  min-height: calc(100vh - 4rem);
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.rep-district-container {
+  max-width: 56rem;
+  margin: 0 auto;
+}
+
+.rep-district-breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  color: #6b7280;
+}
+.rep-district-breadcrumb a { color: #2E3D5B; text-decoration: none; }
+.rep-district-breadcrumb a:hover { text-decoration: underline; }
+.rep-district-breadcrumb-sep { color: #9ca3af; font-weight: 400; }
+.rep-district-breadcrumb-current { color: #6b7280; font-weight: 500; }
+
+.rep-district-header {
+  margin-bottom: 2rem;
+  padding: 1rem 1.25rem;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-left: 6px solid #2E3D5B;
+  border-radius: 0.5rem;
+}
+
+.rep-district-eyebrow {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.25rem;
+}
+
+.rep-district-h1 {
+  font-size: 2rem;
+  font-weight: 800;
+  color: #1f2937;
+  margin: 0 0 0.375rem;
+  line-height: 1.2;
+}
+
+.rep-district-sub {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.rep-district-section {
+  margin-top: 2rem;
+}
+
+.rep-district-h2 {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin: 0 0 0.75rem;
+}
+
+.rep-district-section-sub {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin: -0.25rem 0 0.875rem;
+}
+
+.rep-district-card-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.625rem;
+}
+
+.rep-district-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-left: 4px solid #2E3D5B;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.rep-district-card:hover {
+  border-color: #2E3D5B;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.rep-district-card-position {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #2E3D5B;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.rep-district-card-name {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.rep-district-card-meta {
+  font-size: 0.8125rem;
+  color: #6b7280;
+}
+
+.rep-district-empty {
+  color: #9ca3af;
+  font-style: italic;
+}

--- a/frontend/src/components/RepDistrict.jsx
+++ b/frontend/src/components/RepDistrict.jsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import NotFound from './NotFound'
+import { DISTRICT_COLORS } from './districtColors'
+import './RepDistrict.css'
+
+export default function RepDistrict() {
+  const { number } = useParams()
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+  const [status, setStatus] = useState(null)
+
+  useEffect(() => {
+    setData(null); setError(null); setStatus(null)
+    fetch(`/api/reps/districts/${encodeURIComponent(number)}/`)
+      .then(r => {
+        setStatus(r.status)
+        if (r.status === 404) return null
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.json()
+      })
+      .then(setData)
+      .catch(e => setError(e.message))
+  }, [number])
+
+  if (status === 404) return <NotFound />
+  if (error) return (
+    <main className="rep-district-page"><div className="rep-district-container">Could not load: {error}</div></main>
+  )
+  if (!data) return (
+    <main className="rep-district-page"><div className="rep-district-container">Loading…</div></main>
+  )
+
+  const accent = DISTRICT_COLORS[data.district.number] || '#2E3D5B'
+
+  return (
+    <main className="rep-district-page">
+      <div className="rep-district-container">
+        <nav className="rep-district-breadcrumb" aria-label="Breadcrumb">
+          <Link to="/">This Week</Link>
+          <span className="rep-district-breadcrumb-sep" aria-hidden="true">/</span>
+          <Link to="/reps">My Council Members</Link>
+          <span className="rep-district-breadcrumb-sep" aria-hidden="true">/</span>
+          <span className="rep-district-breadcrumb-current">{data.district.name}</span>
+        </nav>
+
+        <header className="rep-district-header" style={{ borderLeftColor: accent }}>
+          <div className="rep-district-eyebrow" style={{ color: accent }}>District</div>
+          <h1 className="rep-district-h1">{data.district.name}</h1>
+          {data.district.description && (
+            <p className="rep-district-sub">{data.district.description}</p>
+          )}
+        </header>
+
+        <section className="rep-district-section" aria-label="Your district representative">
+          <h2 className="rep-district-h2">Your District Representative</h2>
+          {data.rep ? (
+            <RepCardLink rep={data.rep} accent={accent} />
+          ) : (
+            <p className="rep-district-empty">This district seat is currently vacant.</p>
+          )}
+        </section>
+
+        <section className="rep-district-section" aria-label="At-large representatives">
+          <h2 className="rep-district-h2">At-Large Council Members</h2>
+          <p className="rep-district-section-sub">
+            These council members represent every resident of Seattle, including you.
+          </p>
+          <ul className="rep-district-card-grid">
+            {data.at_large.map(rep => (
+              <li key={rep.slug}>
+                <RepCardLink rep={rep} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </main>
+  )
+}
+
+function RepCardLink({ rep, accent }) {
+  return (
+    <Link
+      to={`/reps/${rep.slug}`}
+      className="rep-district-card"
+      style={accent ? { borderLeftColor: accent } : undefined}
+    >
+      <div className="rep-district-card-position">{rep.district}</div>
+      <div className="rep-district-card-name">{rep.name}</div>
+      {rep.email && <div className="rep-district-card-meta">{rep.email}</div>}
+    </Link>
+  )
+}

--- a/frontend/src/components/RepDistrict.jsx
+++ b/frontend/src/components/RepDistrict.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import NotFound from './NotFound'
+import DistrictMiniMap from './DistrictMiniMap'
 import { DISTRICT_COLORS } from './districtColors'
 import './RepDistrict.css'
 
@@ -51,6 +52,15 @@ export default function RepDistrict() {
             <p className="rep-district-sub">{data.district.description}</p>
           )}
         </header>
+
+        {data.district.geometry && (
+          <section className="rep-district-section" aria-label="District map">
+            <DistrictMiniMap
+              geometry={data.district.geometry}
+              districtNumber={data.district.number}
+            />
+          </section>
+        )}
 
         <section className="rep-district-section" aria-label="Your district representative">
           <h2 className="rep-district-h2">Your District Representative</h2>

--- a/frontend/src/components/RepsIndex.css
+++ b/frontend/src/components/RepsIndex.css
@@ -77,7 +77,12 @@
   background: #ffffff;
   text-decoration: none;
   color: inherit;
+  /* Border + shadow are also driven by inline style when the matching
+     polygon is hovered on the map — keep the transition smooth. */
   transition: border-color 0.15s, box-shadow 0.15s;
+}
+.rep-mini-card--accented {
+  border-left: 4px solid #2E3D5B;
 }
 .rep-mini-card:hover {
   border-color: #2E3D5B;
@@ -162,24 +167,3 @@
   font-size: 0.875rem;
 }
 
-.reps-lookup-result {
-  background: #eef2ff;
-  border: 1px solid #c7d2fe;
-  border-radius: 0.5rem;
-  padding: 0.875rem 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  color: #1e1b4b;
-  font-size: 0.9375rem;
-}
-
-.reps-lookup-rep-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-.reps-lookup-rep-list li {
-  padding: 0.25rem 0;
-  font-size: 0.875rem;
-}

--- a/frontend/src/components/RepsIndex.css
+++ b/frontend/src/components/RepsIndex.css
@@ -38,6 +38,13 @@
   margin-top: 2.5rem;
 }
 
+/* Lead section follows the header directly with tighter spacing — used
+   for the address lookup that now sits at the top of the page. */
+.reps-section--lead {
+  margin-top: 0;
+  margin-bottom: 2rem;
+}
+
 .reps-section-h2 {
   font-size: 1.125rem;
   font-weight: 700;

--- a/frontend/src/components/RepsIndex.jsx
+++ b/frontend/src/components/RepsIndex.jsx
@@ -99,20 +99,29 @@ function RepMiniCard({ rep, districtName, description, districtNumber, highlight
     : undefined
   const accentBar = accent ? { borderLeftColor: accent } : undefined
 
+  // District cards mirror map polygon click — navigate to the district
+  // page (rep + at-large). At-large cards have no districtNumber, so they
+  // navigate straight to the rep's detail page.
+  const target = districtNumber ? `/reps/district/${districtNumber}` : `/reps/${rep?.slug}`
+
   if (!rep) {
+    // Vacant seat still wants to surface the district context, so keep
+    // the link active even without a rep — the district page handles
+    // the "currently vacant" copy.
     return (
-      <div
+      <Link
+        to={target}
         className={`rep-mini-card rep-mini-card--empty${accent ? ' rep-mini-card--accented' : ''}`}
         style={{ ...accentBar, ...highlightStyle }}
       >
         <div className="rep-mini-card-district">{districtName}</div>
         <div className="rep-mini-card-name">Vacant</div>
-      </div>
+      </Link>
     )
   }
   return (
     <Link
-      to={`/reps/${rep.slug}`}
+      to={target}
       className={`rep-mini-card${accent ? ' rep-mini-card--accented' : ''}`}
       style={{ ...accentBar, ...highlightStyle }}
     >

--- a/frontend/src/components/RepsIndex.jsx
+++ b/frontend/src/components/RepsIndex.jsx
@@ -1,12 +1,17 @@
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { MapPin, AlertCircle } from 'lucide-react'
+import { Link, useNavigate } from 'react-router-dom'
+import { AlertCircle } from 'lucide-react'
 import CouncilMap from './CouncilMap'
+import { DISTRICT_COLORS } from './districtColors'
 import './RepsIndex.css'
 
 export default function RepsIndex() {
   const [data, setData] = useState(null)
   const [loadError, setLoadError] = useState(null)
+  // Hover sync between CouncilMap and the district cards: hovering a
+  // polygon highlights the matching card (and vice versa would be nice
+  // someday, but one direction is enough for the visual correlation).
+  const [hoveredDistrict, setHoveredDistrict] = useState(null)
 
   useEffect(() => {
     fetch('/api/reps/')
@@ -45,7 +50,7 @@ export default function RepsIndex() {
         {data && (
           <>
             <section aria-label="Council map" className="reps-section">
-              <CouncilMap districts={data.districts} />
+              <CouncilMap districts={data.districts} onDistrictHover={setHoveredDistrict} />
             </section>
 
             <section aria-label="District representatives" className="reps-section">
@@ -53,7 +58,13 @@ export default function RepsIndex() {
               <ul className="reps-card-grid">
                 {data.districts.map(d => (
                   <li key={d.number}>
-                    <RepMiniCard rep={d.rep} districtName={d.name} description={d.description} />
+                    <RepMiniCard
+                      rep={d.rep}
+                      districtName={d.name}
+                      description={d.description}
+                      districtNumber={d.number}
+                      highlighted={hoveredDistrict === d.number}
+                    />
                   </li>
                 ))}
               </ul>
@@ -79,17 +90,32 @@ export default function RepsIndex() {
   )
 }
 
-function RepMiniCard({ rep, districtName, description }) {
+function RepMiniCard({ rep, districtName, description, districtNumber, highlighted }) {
+  const accent = districtNumber ? DISTRICT_COLORS[districtNumber] : null
+  // Inline style applied only when the matching polygon is hovered, so
+  // the card visibly correlates with the map without a permanent paint.
+  const highlightStyle = highlighted && accent
+    ? { borderColor: accent, boxShadow: `0 0 0 2px ${accent}33` }
+    : undefined
+  const accentBar = accent ? { borderLeftColor: accent } : undefined
+
   if (!rep) {
     return (
-      <div className="rep-mini-card rep-mini-card--empty">
+      <div
+        className={`rep-mini-card rep-mini-card--empty${accent ? ' rep-mini-card--accented' : ''}`}
+        style={{ ...accentBar, ...highlightStyle }}
+      >
         <div className="rep-mini-card-district">{districtName}</div>
         <div className="rep-mini-card-name">Vacant</div>
       </div>
     )
   }
   return (
-    <Link to={`/reps/${rep.slug}`} className="rep-mini-card">
+    <Link
+      to={`/reps/${rep.slug}`}
+      className={`rep-mini-card${accent ? ' rep-mini-card--accented' : ''}`}
+      style={{ ...accentBar, ...highlightStyle }}
+    >
       <div className="rep-mini-card-district">{districtName}</div>
       <div className="rep-mini-card-name">{rep.name}</div>
       {description && <div className="rep-mini-card-desc">{description}</div>}
@@ -98,9 +124,9 @@ function RepMiniCard({ rep, districtName, description }) {
 }
 
 function AddressLookup() {
+  const navigate = useNavigate()
   const [address, setAddress] = useState('')
   const [loading, setLoading] = useState(false)
-  const [result, setResult] = useState(null)
   const [error, setError] = useState(null)
 
   const submit = async (e) => {
@@ -109,7 +135,7 @@ function AddressLookup() {
       setError('Please enter an address')
       return
     }
-    setLoading(true); setError(null); setResult(null)
+    setLoading(true); setError(null)
     try {
       const r = await fetch('/api/reps/lookup/', {
         method: 'POST',
@@ -117,8 +143,11 @@ function AddressLookup() {
         body: JSON.stringify({ address: address.trim() }),
       })
       const data = await r.json()
-      if (data.success) setResult(data.data)
-      else setError(data.error || 'Address not found')
+      if (data.success && data.data?.district?.number) {
+        navigate(`/reps/district/${data.data.district.number}`)
+      } else {
+        setError(data.error || 'Address not found')
+      }
     } catch (err) {
       setError('Failed to connect to the server. Please try again.')
     } finally {
@@ -146,22 +175,6 @@ function AddressLookup() {
         <div className="reps-alert" role="alert">
           <AlertCircle size={18} aria-hidden="true" />
           <span>{error}</span>
-        </div>
-      )}
-
-      {result && (
-        <div className="reps-lookup-result" role="status">
-          <MapPin size={18} aria-hidden="true" />
-          <span>
-            Your address is in <strong>{result.district.name}</strong>.
-          </span>
-          <ul className="reps-lookup-rep-list">
-            {result.representatives.map(r => (
-              <li key={r.district + r.name}>
-                <strong>{r.name}</strong> · {r.district}
-              </li>
-            ))}
-          </ul>
         </div>
       )}
     </div>

--- a/frontend/src/components/RepsIndex.jsx
+++ b/frontend/src/components/RepsIndex.jsx
@@ -27,9 +27,13 @@ export default function RepsIndex() {
         <header className="reps-header">
           <h1 className="reps-h1">Seattle City Council</h1>
           <p className="reps-subtitle">
-            Click a district on the map to see its representative, or look up your reps by address.
+            Find your district representative by address, or browse the full council below.
           </p>
         </header>
+
+        <section aria-label="Address lookup" className="reps-section reps-section--lead">
+          <AddressLookup />
+        </section>
 
         {loadError && (
           <div className="reps-alert" role="alert">
@@ -40,7 +44,7 @@ export default function RepsIndex() {
 
         {data && (
           <>
-            <section aria-label="Council map">
+            <section aria-label="Council map" className="reps-section">
               <CouncilMap districts={data.districts} />
             </section>
 
@@ -67,11 +71,6 @@ export default function RepsIndex() {
                   </li>
                 ))}
               </ul>
-            </section>
-
-            <section aria-label="Address lookup" className="reps-section">
-              <h2 className="reps-section-h2">Find Your Representatives by Address</h2>
-              <AddressLookup />
             </section>
           </>
         )}

--- a/frontend/src/components/districtColors.js
+++ b/frontend/src/components/districtColors.js
@@ -1,0 +1,13 @@
+// One distinguishable colour per district. Tab10 palette for D1-D6, the
+// site brand navy for D7 so it sits next to the rest visually. Shared
+// between CouncilMap (polygon fill) and RepsIndex (rep card highlight on
+// hover) so the two stay in sync.
+export const DISTRICT_COLORS = {
+  '1': '#1f77b4', // blue
+  '2': '#ff7f0e', // orange
+  '3': '#2ca02c', // green
+  '4': '#d62728', // red
+  '5': '#9467bd', // purple
+  '6': '#8c564b', // brown
+  '7': '#2E3D5B', // site navy
+}

--- a/reps/services.py
+++ b/reps/services.py
@@ -438,9 +438,11 @@ def get_rep_by_slug(slug: str) -> Optional[Dict[str, Any]]:
 
 def get_district_with_reps(number: str) -> Optional[Dict[str, Any]]:
     """Combined payload for /reps/district/<number>: the district rep
-    plus both at-large reps (who represent every district). Returns None
-    if the district doesn't exist. Numeric districts only — the catch-all
-    'At Large' District row isn't a valid argument here."""
+    plus both at-large reps (who represent every district), plus the
+    district's simplified GeoJSON geometry for the close-up map on the
+    detail page. Returns None if the district doesn't exist. Numeric
+    districts only — the catch-all 'At Large' District row isn't a valid
+    argument here."""
     if number == 'At Large':
         return None
     try:
@@ -456,11 +458,18 @@ def get_district_with_reps(number: str) -> Optional[Dict[str, Any]]:
     if rows:
         district_rep = _rep_row_to_dict(*rows[0])
 
+    # Same simplification as the overview map — fine enough at the
+    # zoomed-in single-district view that artifacts aren't visible.
+    simple_geom = district.geometry.simplify(
+        tolerance=_OVERVIEW_SIMPLIFY_TOLERANCE, preserve_topology=True
+    )
+
     return {
         'district': {
             'number':      district.number,
             'name':        district.name,
             'description': district.description,
+            'geometry':    json.loads(simple_geom.geojson) if simple_geom else None,
         },
         'rep':      district_rep,
         'at_large': list_at_large_reps(),

--- a/reps/services.py
+++ b/reps/services.py
@@ -434,3 +434,34 @@ def get_rep_by_slug(slug: str) -> Optional[Dict[str, Any]]:
         return None
     name, slug_back, label = rows[0]
     return _rep_row_to_dict(name, slug_back, label)
+
+
+def get_district_with_reps(number: str) -> Optional[Dict[str, Any]]:
+    """Combined payload for /reps/district/<number>: the district rep
+    plus both at-large reps (who represent every district). Returns None
+    if the district doesn't exist. Numeric districts only — the catch-all
+    'At Large' District row isn't a valid argument here."""
+    if number == 'At Large':
+        return None
+    try:
+        district = District.objects.get(number=number)
+    except District.DoesNotExist:
+        return None
+
+    district_rep = None
+    rows = _query_current_council_members(
+        extra_filter=" AND m.label = %s",
+        params=[f'District {number}'],
+    )
+    if rows:
+        district_rep = _rep_row_to_dict(*rows[0])
+
+    return {
+        'district': {
+            'number':      district.number,
+            'name':        district.name,
+            'description': district.description,
+        },
+        'rep':      district_rep,
+        'at_large': list_at_large_reps(),
+    }

--- a/reps/urls.py
+++ b/reps/urls.py
@@ -10,5 +10,6 @@ app_name = 'reps'
 urlpatterns = [
     path('lookup/', views.lookup_reps, name='lookup'),
     path('', views.reps_index, name='index'),
+    path('districts/<str:number>/', views.district_detail, name='district_detail'),
     path('<slug:slug>/', views.rep_detail, name='detail'),
 ]

--- a/reps/views.py
+++ b/reps/views.py
@@ -8,6 +8,7 @@ from django.views.decorators.http import require_http_methods, require_GET
 from django.views.decorators.csrf import csrf_exempt
 from .services import (
     RepLookupService,
+    get_district_with_reps,
     get_rep_by_slug,
     list_at_large_reps,
     list_districts_with_reps,
@@ -115,3 +116,18 @@ def rep_detail(request, slug):
     if not rep:
         return JsonResponse({'error': 'Representative not found'}, status=404)
     return JsonResponse(rep)
+
+
+@require_GET
+def district_detail(request, number):
+    """
+    GET /api/reps/districts/<number>/
+
+    District info + the district's rep + both at-large reps. Powers the
+    /reps/district/<number>/ SPA page that map clicks and address
+    lookups land on.
+    """
+    data = get_district_with_reps(number)
+    if not data:
+        return JsonResponse({'error': 'District not found'}, status=404)
+    return JsonResponse(data)


### PR DESCRIPTION
## Summary

Started as a small section reorder and grew into three changes that share scope (`/reps/` and how users get from the map/lookup to rep info):

1. **Address lookup moved above the map.** Most goal-directed action on the page; leading with it matches user intent better than scrolling past a map first. New `.reps-section--lead` modifier zeroes margin-top so the lookup sits flush under the header. Subtitle copy updated.

2. **New `/reps/district/<number>/` page** showing the district + its rep + both at-large reps as click-through links to individual rep details. Replaces the inline lookup-result callout that used to render on `/reps/`. Backend: new `GET /api/reps/districts/<number>/` returning `{district, rep, at_large}`. Frontend: new `RepDistrict.jsx`, route `/reps/district/:number`. Header bar uses the district's accent color as a left border for visual continuity with the map.

3. **Map polygon click → district page** instead of straight to a rep, and **hover highlights the matching rep card** in the district's color (border + soft shadow). Address lookup also navigates to the district page on success. `DISTRICT_COLORS` lifted into `frontend/src/components/districtColors.js` so `CouncilMap` and `RepsIndex` stay in sync.

## Tangents resolved here

- Cleaned up two leftover merge conflict markers in `WORK_LOG.md` from the earlier rebase pass (lines 25–30 in the pre-fix file).
- Filed pre-existing data quirk under Up next: `_rep_row_to_dict`'s contact lookup uses `OCDPerson.objects.filter(memberships__label=label).first()`, which can return any historical holder of e.g. "Position 9" — visible today as Dionne Foster's email rendering as `sara.nelson@seattle.gov`. Not introduced by this PR; fix is to thread the slug through and filter by `cp.slug`.

## Test plan

- [x] `GET /api/reps/districts/7/` → 200 with `{district, rep, at_large}`; `/api/reps/districts/99/` → 404.
- [x] Production build clean (1744 modules, ~21 s, ~439 kB JS / ~52 kB CSS).
- [x] All SPA paths return 200, including new `/reps/district/<n>`.
- [ ] **Reviewer**: load `/reps/`, confirm lookup form is the lead element. Hover a district polygon → matching rep card gets a colored border + soft shadow. Click a polygon → lands on `/reps/district/<number>` with the rep + 2 at-large links. Submit a Seattle address in the lookup form → redirects to the same district page. Click any rep card from the district page → lands on `/reps/<slug>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)