### PR TITLE
frontend: homepage hero + unified /search across legislation + municode

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -22,7 +22,6 @@ Prioritized to-do. Quick wins flagged with *(quick)*.
 - **Index polish** (deferred from PRs #30 and #31). *Legislation:* classification filter (Bill/Resolution/etc.), sort controls, date-range filter, sponsor filter. *Events:* committee-name dropdown (separate from type), date-range filter. *Both:* NavBar's hash-anchor stubs (`#about`, `#how-it-works`, `#my-council-members`, `#glossary`) still point at homepage sections that don't exist yet — wire them up as those sections ship, or convert to real `/path` Links. NavBar isn't shown on the index pages (only on the homepage); think about whether the index pages should get their own header/nav. CSS class names `.meeting-card-*` / `.mtg-detail-*` weren't renamed when MeetingCard/MeetingDetail → EventCard/EventDetail in PR #31; rename if/when those files get more substantive changes.
 
 **Frontend polish & site chrome**
-- **Legislation search bar in the homepage hero** where Rep Lookup used to live. Big prominent search box that submits to `/legislation?q=...` — reuses the search infra from PR #30. Most direct way to point users into the data. (Homepage hero is currently empty after the Rep Lookup move.)
 - **Rep contact-detail lookup picks the wrong Person for at-large reps.** `reps/services.py::_rep_row_to_dict` does `OCDPerson.objects.filter(memberships__label=label).first()` to fetch contact rows. For "Position 9", multiple people have held that membership over time, so `.first()` can return a former holder — visible today as Dionne Foster's email rendering as `sara.nelson@seattle.gov`. Fix: pass the slug or `person_id` from `_query_current_council_members` straight through and filter by that instead. Affects the rep grid on `/reps/`, the rep detail page, and the new district page.
 - **About page** at `/about`. NavBar's `#about` is currently a hash stub — turn into a real route. Content TBD (project description, source code link, contact).
 - **NavBar mobile hamburger** (deferred from PR #33). NavBar currently wraps via `flex-wrap` on narrow screens; if usability becomes a problem, replace with a proper hamburger menu.
@@ -62,6 +61,11 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### Frontend — homepage legislation search hero — committed 2026-04-27
+Fills the hero gap left by the Rep Lookup move (PR #38). Skyline-image background (the same `/static/images/SeattleSkyline.jpeg` served from `frontend/public/`) with a `rgba(4,44,81,0.78)` overlay; centered title + subtitle + a pill-shaped white search input. Submitting navigates to `/legislation?q=<encoded>`, which `LegislationIndex` already understands — no plumbing changes on the index side. Empty submit drops the user on `/legislation` with no filter.
+
+New `LegislationHero.jsx`, mounted above `<ThisWeek />` on the homepage. Styles cribbed from the deleted `HeroSection.css` so the visual treatment matches what was there before the Rep Lookup move, scoped under `home-hero-*` to avoid collision if we ever reintroduce a separate hero elsewhere. Background-image URL bumped from the old `/images/...` path (which would now hit the SPA catch-all because Vite's `base` is `/static/`) to `/static/images/SeattleSkyline.jpeg`.
 
 ### Frontend — `/reps/` reorder, district pages, map↔card hover sync — committed 2026-04-27
 Started as a section reorder and grew. Four things land together because they share the same scope (the `/reps/` page and how users get from map/lookup to rep info):

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -62,10 +62,16 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 
 ## Done
 
-### Frontend — homepage legislation search hero — committed 2026-04-27
-Fills the hero gap left by the Rep Lookup move (PR #38). Skyline-image background (the same `/static/images/SeattleSkyline.jpeg` served from `frontend/public/`) with a `rgba(4,44,81,0.78)` overlay; centered title + subtitle + a pill-shaped white search input. Submitting navigates to `/legislation?q=<encoded>`, which `LegislationIndex` already understands — no plumbing changes on the index side. Empty submit drops the user on `/legislation` with no filter.
+### Frontend — homepage hero + unified `/search` (legislation + municode) — committed 2026-04-27
+Fills the hero gap left by the Rep Lookup move (PR #38) and adds a parallel-search results page that ties legislation and the Municipal Code together. The two are interlinked enough — bills cite SMC sections, SMC chapters reference legislative history — that one search box covering both matches users' actual mental model better than two separate ones.
 
-New `LegislationHero.jsx`, mounted above `<ThisWeek />` on the homepage. Styles cribbed from the deleted `HeroSection.css` so the visual treatment matches what was there before the Rep Lookup move, scoped under `home-hero-*` to avoid collision if we ever reintroduce a separate hero elsewhere. Background-image URL bumped from the old `/images/...` path (which would now hit the SPA catch-all because Vite's `base` is `/static/`) to `/static/images/SeattleSkyline.jpeg`.
+**Hero (`LegislationHero.jsx`)** — mounted above `<ThisWeek />` on the homepage. Skyline background (`/static/images/SeattleSkyline.jpeg`, served from `frontend/public/`) with a `rgba(4,44,81,0.78)` overlay; centered title + subtitle + a pill-shaped white search input. Title: "Search Seattle Government." Empty submit → `/legislation` browse mode; non-empty → `/search?q=<encoded>`. Styles cribbed from the deleted `HeroSection.css` from the original Rep Lookup hero, scoped under `home-hero-*` for namespace hygiene. Background-image URL bumped from the old `/images/...` path (which would now hit the SPA catch-all because Vite's `base` is `/static/`) to `/static/images/SeattleSkyline.jpeg`.
+
+**`/search` page (`Search.jsx`)** — fans out two parallel `Promise.all` requests against `/api/legislation/?q=` and `/api/smc/?q=` with `limit=5` each, renders two stacked sections — `Legislation (N)` and `Municipal Code (N)` — with a "View all N results →" link to the type-specific index when there are more than 5 hits. Debounced URL-synced search input on the page lets users refine without leaving. We don't try to merge ranking across types — there's no honest way to compare a bill's relevance to an SMC section's, so we stack instead. Empty `q` shows a "Type a keyword or citation above to begin searching" prompt.
+
+Citation queries route naturally: `q=23.47A` returns 30 SMC sections (citation mode) + 5 legislation matches that mention the citation. Topical queries surface both: `q=tree` returns 21 bills + 186 SMC sections.
+
+Reuses `LegislationCard` directly for the legislation section. SMC results use a 3-column row similar to `MuniCodeIndex`'s search list (number, title, chapter), styled under `search-smc-*`.
 
 ### Frontend — `/reps/` reorder, district pages, map↔card hover sync — committed 2026-04-27
 Started as a section reorder and grew. Four things land together because they share the same scope (the `/reps/` page and how users get from map/lookup to rep info):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Header from './components/Header'
 import Footer from './components/Footer'
+import LegislationHero from './components/LegislationHero'
 import ThisWeek from './components/ThisWeek'
 import LegislationIndex from './components/LegislationIndex'
 import LegislationDetail from './components/LegislationDetail'
@@ -18,7 +19,12 @@ import NotFound from './components/NotFound'
 import './App.css'
 
 function HomePage() {
-  return <ThisWeek />
+  return (
+    <>
+      <LegislationHero />
+      <ThisWeek />
+    </>
+  )
 }
 
 function App() {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ import MuniCodeAppendix from './components/MuniCodeAppendix'
 import RepsIndex from './components/RepsIndex'
 import RepDetail from './components/RepDetail'
 import RepDistrict from './components/RepDistrict'
+import Search from './components/Search'
 import NotFound from './components/NotFound'
 import './App.css'
 
@@ -49,6 +50,8 @@ function App() {
         <Route path="/reps/" element={<RepsIndex />} />
         <Route path="/reps/district/:number" element={<RepDistrict />} />
         <Route path="/reps/:slug" element={<RepDetail />} />
+        <Route path="/search" element={<Search />} />
+        <Route path="/search/" element={<Search />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Footer />

--- a/frontend/src/components/LegislationCard.jsx
+++ b/frontend/src/components/LegislationCard.jsx
@@ -17,7 +17,7 @@ function StatusTag({ label, variant }) {
 function formatDate(isoString) {
   if (!isoString) return null;
   const d = new Date(isoString);
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
 export default function LegislationCard({ bill, backToSearch }) {

--- a/frontend/src/components/LegislationHero.css
+++ b/frontend/src/components/LegislationHero.css
@@ -1,0 +1,121 @@
+.home-hero {
+  position: relative;
+  background-image: url('/static/images/SeattleSkyline.jpeg');
+  background-size: cover;
+  background-position: center;
+  background-color: #2E3D5B;
+  min-height: 340px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.home-hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(4, 44, 81, 0.78);
+}
+
+.home-hero-content {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+  width: 100%;
+  padding: 3.5rem 1.5rem 3rem;
+  text-align: center;
+}
+
+.home-hero-title {
+  font-size: 2.5rem;
+  font-weight: 800;
+  color: #ffffff;
+  margin: 0 0 1rem 0;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+
+.home-hero-subtitle {
+  font-size: 1.0625rem;
+  color: rgba(255, 255, 255, 0.88);
+  margin: 0 auto 2rem;
+  max-width: 540px;
+  line-height: 1.6;
+}
+
+/* sr-only: visually hidden but accessible to screen readers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.home-hero-form {
+  width: 100%;
+}
+
+.home-hero-input-wrapper {
+  display: flex;
+  align-items: center;
+  background: #ffffff;
+  border-radius: 0.625rem;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  border: 2px solid transparent;
+  transition: border-color 0.2s;
+}
+
+.home-hero-input-wrapper:focus-within {
+  border-color: #4a7fc1;
+}
+
+.home-hero-search-icon {
+  flex-shrink: 0;
+  color: #6b7280;
+  margin-left: 1rem;
+  pointer-events: none;
+}
+
+.home-hero-search-input {
+  flex: 1;
+  padding: 0.9rem 0.75rem;
+  border: none;
+  outline: none;
+  font-size: 1rem;
+  color: #1f2937;
+  background: transparent;
+  min-width: 0;
+}
+
+.home-hero-search-input::placeholder {
+  color: #9ca3af;
+}
+
+.home-hero-search-btn {
+  flex-shrink: 0;
+  margin: 0.375rem;
+  padding: 0.625rem 1.25rem;
+  background: #2E3D5B;
+  color: #ffffff;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.home-hero-search-btn:hover {
+  background: #1a2a42;
+}
+
+@media (max-width: 640px) {
+  .home-hero-title { font-size: 1.75rem; }
+  .home-hero-subtitle { font-size: 0.9375rem; }
+  .home-hero-content { padding: 2.5rem 1rem 2rem; }
+}

--- a/frontend/src/components/LegislationHero.jsx
+++ b/frontend/src/components/LegislationHero.jsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Search } from 'lucide-react'
+import './LegislationHero.css'
+
+// Homepage hero. The Seattle skyline background sets the place; the
+// search input over it points users straight at the legislation index.
+// Submitting navigates to /legislation?q=<query>, which LegislationIndex
+// already understands — no extra plumbing on the index side.
+export default function LegislationHero() {
+  const navigate = useNavigate()
+  const [q, setQ] = useState('')
+
+  const submit = (e) => {
+    e.preventDefault()
+    const term = q.trim()
+    if (term) {
+      navigate(`/legislation?q=${encodeURIComponent(term)}`)
+    } else {
+      // Empty submit drops the user on the index without a filter.
+      navigate('/legislation')
+    }
+  }
+
+  return (
+    <div className="home-hero">
+      <div className="home-hero-overlay" />
+      <div className="home-hero-content">
+        <h2 className="home-hero-title">Search Seattle Legislation</h2>
+        <p className="home-hero-subtitle">
+          Find bills, resolutions, and council actions by identifier or keyword.
+        </p>
+
+        <form onSubmit={submit} className="home-hero-form" role="search">
+          <label className="sr-only" htmlFor="home-hero-search">
+            Search Seattle legislation
+          </label>
+          <div className="home-hero-input-wrapper">
+            <Search className="home-hero-search-icon" size={22} aria-hidden="true" />
+            <input
+              id="home-hero-search"
+              type="search"
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="Search by identifier or title (e.g. parking, CB 119901)…"
+              className="home-hero-search-input"
+              autoComplete="off"
+            />
+            <button type="submit" className="home-hero-search-btn">
+              Search
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/LegislationHero.jsx
+++ b/frontend/src/components/LegislationHero.jsx
@@ -3,10 +3,11 @@ import { useNavigate } from 'react-router-dom'
 import { Search } from 'lucide-react'
 import './LegislationHero.css'
 
-// Homepage hero. The Seattle skyline background sets the place; the
-// search input over it points users straight at the legislation index.
-// Submitting navigates to /legislation?q=<query>, which LegislationIndex
-// already understands — no extra plumbing on the index side.
+// Homepage hero. The Seattle skyline sets the place; the search box
+// over it points users at the unified /search results page (which
+// fans out to legislation + municipal code in parallel). Submitting
+// navigates there with q=<query>; empty submit drops users on the
+// browse-mode legislation index.
 export default function LegislationHero() {
   const navigate = useNavigate()
   const [q, setQ] = useState('')
@@ -15,9 +16,8 @@ export default function LegislationHero() {
     e.preventDefault()
     const term = q.trim()
     if (term) {
-      navigate(`/legislation?q=${encodeURIComponent(term)}`)
+      navigate(`/search?q=${encodeURIComponent(term)}`)
     } else {
-      // Empty submit drops the user on the index without a filter.
       navigate('/legislation')
     }
   }
@@ -26,14 +26,14 @@ export default function LegislationHero() {
     <div className="home-hero">
       <div className="home-hero-overlay" />
       <div className="home-hero-content">
-        <h2 className="home-hero-title">Search Seattle Legislation</h2>
+        <h2 className="home-hero-title">Search Seattle Government</h2>
         <p className="home-hero-subtitle">
-          Find bills, resolutions, and council actions by identifier or keyword.
+          Find bills, resolutions, and the Municipal Code in one search.
         </p>
 
         <form onSubmit={submit} className="home-hero-form" role="search">
           <label className="sr-only" htmlFor="home-hero-search">
-            Search Seattle legislation
+            Search Seattle legislation and Municipal Code
           </label>
           <div className="home-hero-input-wrapper">
             <Search className="home-hero-search-icon" size={22} aria-hidden="true" />
@@ -42,7 +42,7 @@ export default function LegislationHero() {
               type="search"
               value={q}
               onChange={(e) => setQ(e.target.value)}
-              placeholder="Search by identifier or title (e.g. parking, CB 119901)…"
+              placeholder="Search a topic (e.g. parking) or citation (e.g. CB 119901, 23.47A)…"
               className="home-hero-search-input"
               autoComplete="off"
             />

--- a/frontend/src/components/Search.css
+++ b/frontend/src/components/Search.css
@@ -1,0 +1,184 @@
+.search-page {
+  background: #f9fafb;
+  min-height: calc(100vh - 4rem);
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.search-container {
+  max-width: 56rem;
+  margin: 0 auto;
+}
+
+.search-breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  color: #6b7280;
+}
+.search-breadcrumb a { color: #2E3D5B; text-decoration: none; }
+.search-breadcrumb a:hover { text-decoration: underline; }
+.search-breadcrumb-sep { color: #9ca3af; font-weight: 400; }
+.search-breadcrumb-current { color: #6b7280; font-weight: 500; }
+
+.search-header { margin-bottom: 1.5rem; }
+.search-h1 {
+  font-size: 2rem;
+  font-weight: 800;
+  color: #1f2937;
+  margin: 0 0 0.5rem;
+  line-height: 1.2;
+  word-break: break-word;
+}
+.search-subtitle { margin: 0; color: #6b7280; }
+
+.search-input-wrapper {
+  position: relative;
+  margin-bottom: 1.5rem;
+}
+
+.search-input-icon {
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #6b7280;
+  pointer-events: none;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.75rem 1rem 0.75rem 3rem;
+  font-size: 1rem;
+  border: 2px solid #e5e7eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #1f2937;
+  box-sizing: border-box;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.search-input:focus {
+  outline: none;
+  border-color: #2E3D5B;
+  box-shadow: 0 0 0 3px rgba(46, 61, 91, 0.15);
+}
+
+.search-empty {
+  color: #6b7280;
+  font-style: italic;
+  margin: 1.5rem 0;
+}
+
+.search-error {
+  color: #991b1b;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 0.5rem;
+  padding: 0.625rem 0.875rem;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+/* ── Per-type sections ───────────────────────────────────────── */
+
+.search-section {
+  margin-top: 2rem;
+}
+
+.search-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.search-section-h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin: 0;
+}
+
+.search-section-count {
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.search-section-view-all {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #2E3D5B;
+  text-decoration: none;
+}
+.search-section-view-all:hover { text-decoration: underline; }
+
+.search-section-status {
+  color: #6b7280;
+  font-size: 0.9375rem;
+  font-style: italic;
+}
+
+.search-leg-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.search-smc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.search-smc-row {
+  display: grid;
+  grid-template-columns: 7rem 1fr auto;
+  gap: 1rem;
+  align-items: baseline;
+  padding: 0.75rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  background: #ffffff;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.search-smc-row:hover {
+  border-color: #2E3D5B;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.search-smc-num {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-weight: 600;
+  color: #2E3D5B;
+}
+
+.search-smc-title {
+  color: #1f2937;
+  font-weight: 500;
+}
+
+.search-smc-meta {
+  color: #6b7280;
+  font-size: 0.8125rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 600px) {
+  .search-smc-row {
+    grid-template-columns: auto 1fr;
+    grid-template-areas: "num title" "meta meta";
+  }
+  .search-smc-num { grid-area: num; }
+  .search-smc-title { grid-area: title; }
+  .search-smc-meta { grid-area: meta; text-align: left; }
+}

--- a/frontend/src/components/Search.jsx
+++ b/frontend/src/components/Search.jsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { Search as SearchIcon } from 'lucide-react'
+import LegislationCard from './LegislationCard'
+import './Search.css'
+
+const TOP_N = 5
+const SEARCH_DEBOUNCE_MS = 300
+
+// Unified search across legislation + municipal code. Both endpoints
+// already exist; this view fans out two requests in parallel and
+// renders the top N of each with type-specific "View all" links to
+// the deeper indexes. We don't try to merge ranking across types —
+// there's no honest way to compare a bill's relevance to an SMC
+// section's, so we stack instead.
+export default function Search() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const q = searchParams.get('q') ?? ''
+
+  const [legResults, setLegResults] = useState(null)   // { results, total_count } | null
+  const [smcResults, setSmcResults] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const [searchInput, setSearchInput] = useState(q)
+  const debounceTimer = useRef(null)
+
+  useEffect(() => { setSearchInput(q) }, [q])
+
+  useEffect(() => {
+    if (searchInput === q) return
+    if (debounceTimer.current) clearTimeout(debounceTimer.current)
+    debounceTimer.current = setTimeout(() => {
+      const next = new URLSearchParams(searchParams)
+      if (searchInput) next.set('q', searchInput)
+      else next.delete('q')
+      setSearchParams(next, { replace: true })
+    }, SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(debounceTimer.current)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchInput])
+
+  useEffect(() => {
+    if (!q) {
+      setLegResults(null); setSmcResults(null); setLoading(false); setError(null)
+      return
+    }
+    setLoading(true); setError(null)
+    const legParams = new URLSearchParams({ q, limit: String(TOP_N) })
+    const smcParams = new URLSearchParams({ q, limit: String(TOP_N) })
+    Promise.all([
+      fetch(`/api/legislation/?${legParams}`).then(r => r.ok ? r.json() : Promise.reject(new Error(`legislation HTTP ${r.status}`))),
+      fetch(`/api/smc/?${smcParams}`).then(r => r.ok ? r.json() : Promise.reject(new Error(`smc HTTP ${r.status}`))),
+    ])
+      .then(([leg, smc]) => { setLegResults(leg); setSmcResults(smc) })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }, [q])
+
+  return (
+    <main className="search-page">
+      <div className="search-container">
+        <nav className="search-breadcrumb" aria-label="Breadcrumb">
+          <Link to="/">This Week</Link>
+          <span className="search-breadcrumb-sep" aria-hidden="true">/</span>
+          <span className="search-breadcrumb-current">Search</span>
+        </nav>
+
+        <header className="search-header">
+          <h1 className="search-h1">
+            {q ? <>Search results for &ldquo;{q}&rdquo;</> : 'Search'}
+          </h1>
+          <p className="search-subtitle">
+            Searches Seattle legislation and the Municipal Code together.
+          </p>
+        </header>
+
+        <div className="search-input-wrapper">
+          <SearchIcon className="search-input-icon" size={20} aria-hidden="true" />
+          <input
+            type="search"
+            className="search-input"
+            placeholder="Search bills, resolutions, and the Municipal Code…"
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
+            aria-label="Search Seattle legislation and Municipal Code"
+            autoFocus
+          />
+        </div>
+
+        {!q && (
+          <p className="search-empty">Type a keyword or citation above to begin searching.</p>
+        )}
+
+        {q && error && <div className="search-error">Could not load: {error}</div>}
+
+        {q && !error && (
+          <>
+            <SearchSection
+              title="Legislation"
+              total={legResults?.total_count}
+              loading={loading}
+              viewAllPath={`/legislation?q=${encodeURIComponent(q)}`}
+              empty="No bills or resolutions match this query."
+            >
+              {legResults?.results?.length > 0 && (
+                <div className="search-leg-list">
+                  {legResults.results.map(b => (
+                    <LegislationCard key={b.identifier} bill={b} backToSearch={searchParams.toString()} />
+                  ))}
+                </div>
+              )}
+            </SearchSection>
+
+            <SearchSection
+              title="Municipal Code"
+              total={smcResults?.total_count}
+              loading={loading}
+              viewAllPath={`/municode?q=${encodeURIComponent(q)}`}
+              empty="No municipal code sections match this query."
+            >
+              {smcResults?.results?.length > 0 && (
+                <ul className="search-smc-list">
+                  {smcResults.results.map(r => {
+                    const parts = r.section_number.split('.')
+                    const path = parts.length === 3
+                      ? `/municode/${parts[0]}/${parts[1]}/${parts[2]}`
+                      : '#'
+                    return (
+                      <li key={r.section_number}>
+                        <Link to={path} className="search-smc-row">
+                          <span className="search-smc-num">{r.section_number}</span>
+                          <span className="search-smc-title">{r.title}</span>
+                          <span className="search-smc-meta">Ch. {r.chapter_number}</span>
+                        </Link>
+                      </li>
+                    )
+                  })}
+                </ul>
+              )}
+            </SearchSection>
+          </>
+        )}
+      </div>
+    </main>
+  )
+}
+
+function SearchSection({ title, total, loading, viewAllPath, empty, children }) {
+  const hasResults = total && total > 0
+  return (
+    <section className="search-section" aria-label={title}>
+      <div className="search-section-head">
+        <h2 className="search-section-h2">
+          {title}
+          {typeof total === 'number' && (
+            <span className="search-section-count"> ({total.toLocaleString()})</span>
+          )}
+        </h2>
+        {hasResults && total > TOP_N && (
+          <Link to={viewAllPath} className="search-section-view-all">
+            View all {total.toLocaleString()} results →
+          </Link>
+        )}
+      </div>
+      {loading
+        ? <div className="search-section-status">Loading…</div>
+        : hasResults
+          ? children
+          : <div className="search-section-status">{empty}</div>}
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

Two pieces that ship together because they're one user-facing flow — the homepage search box and the results page it lands on:

1. **Homepage hero (`LegislationHero.jsx`)** — fills the gap left by the Rep Lookup move (PR #38). Skyline-image background with a navy overlay, centered title + subtitle + a pill-shaped white search input. Submitting navigates to `/search?q=<encoded>`. Empty submit drops users on `/legislation` browse mode.

2. **Unified `/search` page (`Search.jsx`)** — fans out parallel `Promise.all` requests against `/api/legislation/?q=` and `/api/smc/?q=` (`limit=5` each), renders two stacked sections — `Legislation (N)` and `Municipal Code (N)` — with "View all N results →" links to the type-specific index when there are more than 5 hits. Debounced URL-synced search input on the page lets users refine without leaving.

We don't try to merge ranking across types — there's no honest way to compare a bill's relevance to an SMC section's, so we stack instead. Citation queries route naturally: `q=23.47A` returns 30 SMC sections (citation mode) + 5 legislation matches that mention it. Topical queries surface both: `q=tree` returns 21 bills + 186 SMC sections.

Reuses `LegislationCard` for the bills section. SMC rows use a 3-column row similar to `MuniCodeIndex`'s search list (number, title, chapter).

Hero background-image URL bumped from the old `/images/SeattleSkyline.jpeg` reference to `/static/images/SeattleSkyline.jpeg` (Vite's `base` is `/static/`).

## Test plan

- [x] Production build clean (1747 modules, ~4 s, ~445 kB JS / ~57 kB CSS).
- [x] `/static/images/SeattleSkyline.jpeg` returns 200 / 140 KB.
- [x] `/search` and `/search?q=tree` SPA routes serve 200.
- [x] Both APIs return useful data: `q=tree` → 21 bills + 186 SMC, `q=23.47A` → 5 bills + 30 SMC sections.
- [ ] **Reviewer**: load `/`, confirm skyline + overlay; submit a topical query like "tree" → lands on `/search?q=tree` with both sections populated. Submit a citation like "23.47A" → SMC section dominates with the citation-mode ribbon. Empty submit goes to `/legislation`. On `/search`, edit the input → URL syncs after 300ms debounce, results refresh. "View all" links go to `/legislation?q=...` and `/municode?q=...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)