### PR TITLE
reps: fix at-large contact lookup hitting former holders

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -22,7 +22,6 @@ Prioritized to-do. Quick wins flagged with *(quick)*.
 - **Index polish** (deferred from PRs #30 and #31). *Legislation:* classification filter (Bill/Resolution/etc.), sort controls, date-range filter, sponsor filter. *Events:* committee-name dropdown (separate from type), date-range filter. *Both:* NavBar's hash-anchor stubs (`#about`, `#how-it-works`, `#my-council-members`, `#glossary`) still point at homepage sections that don't exist yet — wire them up as those sections ship, or convert to real `/path` Links. NavBar isn't shown on the index pages (only on the homepage); think about whether the index pages should get their own header/nav. CSS class names `.meeting-card-*` / `.mtg-detail-*` weren't renamed when MeetingCard/MeetingDetail → EventCard/EventDetail in PR #31; rename if/when those files get more substantive changes.
 
 **Frontend polish & site chrome**
-- **Rep contact-detail lookup picks the wrong Person for at-large reps.** `reps/services.py::_rep_row_to_dict` does `OCDPerson.objects.filter(memberships__label=label).first()` to fetch contact rows. For "Position 9", multiple people have held that membership over time, so `.first()` can return a former holder — visible today as Dionne Foster's email rendering as `sara.nelson@seattle.gov`. Fix: pass the slug or `person_id` from `_query_current_council_members` straight through and filter by that instead. Affects the rep grid on `/reps/`, the rep detail page, and the new district page.
 - **About page** at `/about`. NavBar's `#about` is currently a hash stub — turn into a real route. Content TBD (project description, source code link, contact).
 - **NavBar mobile hamburger** (deferred from PR #33). NavBar currently wraps via `flex-wrap` on narrow screens; if usability becomes a problem, replace with a proper hamburger menu.
 
@@ -61,6 +60,13 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### Reps — fix at-large contact-detail lookup hitting former holders — committed 2026-04-28
+Closes the data quirk filed during PR #39. `_rep_row_to_dict` was fetching contact rows via `OCDPerson.objects.filter(memberships__label=label).first()`, which matches anyone who has *ever* held that membership label. For Position 9 both Sara Nelson (former) and Dionne Foster (current) match, and `.first()` returned Sara — so Dionne's email rendered as `sara.nelson@seattle.gov` everywhere her card appeared (the rep grid on `/reps/`, her own detail page, and the at-large block on the district pages).
+
+Fix: thread `p.id` through `_query_current_council_members` and `_rep_row_to_dict` so the contact-detail lookup filters by Person primary key (always unique) instead of membership label. The query already JOINed on `opencivicdata_person`, so adding `p.id` to the SELECT is free; updated the four call sites (`list_districts_with_reps`, `list_at_large_reps`, `get_rep_by_slug`, `get_district_with_reps`) to pass it through. `get_district_with_reps`'s splat call (`_rep_row_to_dict(*rows[0])`) absorbs the new tuple shape with no change.
+
+Verified end-to-end: `/api/reps/`, `/api/reps/dionne-foster/`, and `/api/reps/districts/7/` all now return Dionne's `dionne.foster@seattle.gov`. District reps unchanged (they don't have collisions because each District N label has had only one current holder in our scrape window, but the new lookup is identically correct for them).
 
 ### Frontend — homepage hero + unified `/search` (legislation + municode) — committed 2026-04-27
 Fills the hero gap left by the Rep Lookup move (PR #38) and adds a parallel-search results page that ties legislation and the Municipal Code together. The two are interlinked enough — bills cite SMC sections, SMC chapters reference legislative history — that one search box covering both matches users' actual mental model better than two separate ones.

--- a/reps/services.py
+++ b/reps/services.py
@@ -317,10 +317,11 @@ class RepLookupService:
 # ---------------------------------------------------------------------------
 
 
-def _rep_row_to_dict(name: str, slug: str, label: str) -> Dict[str, Any]:
-    """Build the canonical rep dict from a (name, slug, membership_label) row.
-    Pulls contact details and links from opencivicdata via the Person model.
-    Used by both /api/reps/ list endpoints and /api/reps/<slug>/ detail."""
+def _rep_row_to_dict(name: str, slug: str, label: str, person_id: str) -> Dict[str, Any]:
+    """Build the canonical rep dict from a (name, slug, membership_label,
+    person_id) row. Pulls contact details and links from opencivicdata
+    via the Person primary key. Used by both /api/reps/ list endpoints
+    and /api/reps/<slug>/ detail."""
     from opencivicdata.core.models import Person as OCDPerson
 
     rep_data = {
@@ -343,8 +344,12 @@ def _rep_row_to_dict(name: str, slug: str, label: str) -> Dict[str, Any]:
     except Exception:
         pass
 
-    # Person contact details + links
-    person = OCDPerson.objects.filter(memberships__label=label).first()
+    # Filter by Person primary key (unique) instead of membership label
+    # — the latter has collisions across former and current holders of
+    # the same seat (e.g. both Sara Nelson and Dionne Foster have held
+    # Position 9, so a label-based .first() can return the wrong one
+    # and pull her predecessor's contact info).
+    person = OCDPerson.objects.filter(id=person_id).first()
     if person:
         for contact in person.contact_details.all():
             if contact.type == 'email':
@@ -362,14 +367,14 @@ def _rep_row_to_dict(name: str, slug: str, label: str) -> Dict[str, Any]:
 
 def _query_current_council_members(extra_filter: str = "", params: Optional[List] = None
                                    ) -> List[tuple]:
-    """Returns [(name, slug, membership_label), ...] for currently serving
-    council members. Centralized so both list and detail endpoints share
-    the same filter (cp.is_current = TRUE plus the org join). is_current
-    lives on councilmatic_core_person via a raw-SQL ALTER (see
-    seattle_app/migrations/0001_add_is_current_to_person.py), which is
-    why we drop to raw SQL instead of using the ORM."""
+    """Returns [(name, slug, membership_label, person_id), ...] for
+    currently serving council members. Centralized so both list and
+    detail endpoints share the same filter (cp.is_current = TRUE plus
+    the org join). is_current lives on councilmatic_core_person via a
+    raw-SQL ALTER (see seattle_app/migrations/0001_add_is_current_to_person.py),
+    which is why we drop to raw SQL instead of using the ORM."""
     base = """
-        SELECT DISTINCT p.name, cp.slug, m.label
+        SELECT DISTINCT p.name, cp.slug, m.label, p.id
         FROM opencivicdata_membership m
         INNER JOIN opencivicdata_person p ON m.person_id = p.id
         INNER JOIN opencivicdata_organization o ON m.organization_id = o.id
@@ -389,7 +394,7 @@ def list_districts_with_reps(simplify_tolerance: float = _OVERVIEW_SIMPLIFY_TOLE
     current rep for each. Geometry simplification is purely a payload
     optimization — address lookup uses the unsimplified DB geometry, so
     visual simplification can never route an address to the wrong rep."""
-    rep_lookup = {label: (name, slug) for name, slug, label in
+    rep_lookup = {label: (name, slug, person_id) for name, slug, label, person_id in
                   _query_current_council_members(
                       extra_filter=" AND m.label LIKE 'District %%'"
                   )}
@@ -399,8 +404,8 @@ def list_districts_with_reps(simplify_tolerance: float = _OVERVIEW_SIMPLIFY_TOLE
         membership_label = f'District {d.number}'
         rep = None
         if membership_label in rep_lookup:
-            name, slug = rep_lookup[membership_label]
-            rep = _rep_row_to_dict(name, slug, membership_label)
+            name, slug, person_id = rep_lookup[membership_label]
+            rep = _rep_row_to_dict(name, slug, membership_label, person_id)
         # Python-side simplify via GEOS — preserve_topology=True keeps the
         # polygon valid (no self-intersections) at our tolerance, which
         # could otherwise corrupt rendering of complex coastline shapes.
@@ -420,7 +425,8 @@ def list_at_large_reps() -> List[Dict[str, Any]]:
     represent the whole city, so they're rendered as cards beside the map
     rather than as polygons on it."""
     rows = _query_current_council_members(extra_filter=" AND m.label LIKE 'Position %%'")
-    return [_rep_row_to_dict(name, slug, label) for name, slug, label in rows]
+    return [_rep_row_to_dict(name, slug, label, pid)
+            for name, slug, label, pid in rows]
 
 
 def get_rep_by_slug(slug: str) -> Optional[Dict[str, Any]]:
@@ -432,8 +438,8 @@ def get_rep_by_slug(slug: str) -> Optional[Dict[str, Any]]:
     )
     if not rows:
         return None
-    name, slug_back, label = rows[0]
-    return _rep_row_to_dict(name, slug_back, label)
+    name, slug_back, label, person_id = rows[0]
+    return _rep_row_to_dict(name, slug_back, label, person_id)
 
 
 def get_district_with_reps(number: str) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
## Summary

Closes the data quirk filed during PR #39. `_rep_row_to_dict` was fetching contact rows via `OCDPerson.objects.filter(memberships__label=label).first()`, which matches *anyone* who has ever held that membership label. For Position 9 both Sara Nelson (former) and Dionne Foster (current) match, and `.first()` returned Sara — so Dionne's email was rendering as `sara.nelson@seattle.gov` everywhere her card appeared (the rep grid on `/reps/`, her own detail page, and the at-large block on district pages).

**Fix**: thread `p.id` through `_query_current_council_members` and `_rep_row_to_dict` so the contact-detail lookup filters by Person primary key (always unique) instead of membership label. The query already JOINed on `opencivicdata_person`, so adding `p.id` to the SELECT is free.

Touched the four call sites (`list_districts_with_reps`, `list_at_large_reps`, `get_rep_by_slug`, `get_district_with_reps`) to pass the new tuple element through. `get_district_with_reps` uses `_rep_row_to_dict(*rows[0])` (splat), so it absorbs the new shape with no code change.

## Reproducer (before)

```
$ curl -s http://localhost:8000/api/reps/ | jq '.at_large[] | {name, email}'
{"name": "Alexis Mercedes Rinck", "email": "alexis.mercedes.rinck@seattle.gov"}
{"name": "Dionne Foster",         "email": "sara.nelson@seattle.gov"}    # ← wrong
```

After:
```
{"name": "Dionne Foster",         "email": "dionne.foster@seattle.gov"}  # ← correct
```

## Test plan

- [x] `/api/reps/` at-large block returns each rep's own email.
- [x] `/api/reps/dionne-foster/` returns `dionne.foster@seattle.gov`.
- [x] `/api/reps/districts/7/` (and other districts) — at-large nested block correct; district rep unchanged.
- [x] District reps (e.g. `rob-saka`) still resolve correctly — they don't have collisions in our scrape window, but the new lookup path is identically correct.
- [x] **Reviewer**: load `/reps/`, click Dionne Foster's card, confirm email matches her name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)