### PR TITLE
frontend: /about page

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -22,7 +22,6 @@ Prioritized to-do. Quick wins flagged with *(quick)*.
 - **Index polish** (deferred from PRs #30 and #31). *Legislation:* classification filter (Bill/Resolution/etc.), sort controls, date-range filter, sponsor filter. *Events:* committee-name dropdown (separate from type), date-range filter. *Both:* NavBar's hash-anchor stubs (`#about`, `#how-it-works`, `#my-council-members`, `#glossary`) still point at homepage sections that don't exist yet — wire them up as those sections ship, or convert to real `/path` Links. NavBar isn't shown on the index pages (only on the homepage); think about whether the index pages should get their own header/nav. CSS class names `.meeting-card-*` / `.mtg-detail-*` weren't renamed when MeetingCard/MeetingDetail → EventCard/EventDetail in PR #31; rename if/when those files get more substantive changes.
 
 **Frontend polish & site chrome**
-- **About page** at `/about`. NavBar's `#about` is currently a hash stub — turn into a real route. Content TBD (project description, source code link, contact).
 - **NavBar mobile hamburger** (deferred from PR #33). NavBar currently wraps via `flex-wrap` on narrow screens; if usability becomes a problem, replace with a proper hamburger menu.
 
 **LLM summaries — wire up the existing infrastructure**
@@ -60,6 +59,18 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### Frontend — `/about` page — committed 2026-04-28
+Drafted with the user across one round; content land:
+- Lead paragraph + "why this exists" paragraph framing the site as a re-presentation of the City's public records.
+- "What's on the site" feature list with internal links into every surface (`/legislation`, `/events`, `/reps`, `/municode`, `/search`, `/`).
+- Data sources broken out: bills/events from Legistar, council members from seattle.gov + Open Data Portal, SMC from the official PDF.
+- Credits to DataMade (django-councilmatic upstream, MIT-licensed), the City of Seattle (data), and CARTO (basemap tiles).
+- Source-code link to the GitHub repo + contact email (`jimmie@jimmiewifi.com` for now; user plans to set up a councilmatic.org address once registered).
+
+NavBar's `About` flipped from a `#about` hash anchor stub (which had nowhere to go since the homepage doesn't have an `#about` section) to a real `Link to="/about"`. Routes added: `/about` and `/about/`.
+
+Tone deliberately balanced civic-formal with community-project warmth per the user's preference. Forward-looking content (LLM summaries, pgvector retrieval, etc.) intentionally omitted — the page describes what works today; expand when new features ship.
 
 ### Reps — fix at-large contact-detail lookup hitting former holders — committed 2026-04-28
 Closes the data quirk filed during PR #39. `_rep_row_to_dict` was fetching contact rows via `OCDPerson.objects.filter(memberships__label=label).first()`, which matches anyone who has *ever* held that membership label. For Position 9 both Sara Nelson (former) and Dionne Foster (current) match, and `.first()` returned Sara — so Dionne's email rendered as `sara.nelson@seattle.gov` everywhere her card appeared (the rep grid on `/reps/`, her own detail page, and the at-large block on the district pages).

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import RepsIndex from './components/RepsIndex'
 import RepDetail from './components/RepDetail'
 import RepDistrict from './components/RepDistrict'
 import Search from './components/Search'
+import About from './components/About'
 import NotFound from './components/NotFound'
 import './App.css'
 
@@ -52,6 +53,8 @@ function App() {
         <Route path="/reps/:slug" element={<RepDetail />} />
         <Route path="/search" element={<Search />} />
         <Route path="/search/" element={<Search />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/about/" element={<About />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Footer />

--- a/frontend/src/components/About.css
+++ b/frontend/src/components/About.css
@@ -1,0 +1,87 @@
+.about-page {
+  background: #f9fafb;
+  min-height: calc(100vh - 4rem);
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.about-container {
+  max-width: 44rem;
+  margin: 0 auto;
+}
+
+.about-breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  color: #6b7280;
+}
+.about-breadcrumb a { color: #2E3D5B; text-decoration: none; }
+.about-breadcrumb a:hover { text-decoration: underline; }
+.about-breadcrumb-sep { color: #9ca3af; font-weight: 400; }
+.about-breadcrumb-current { color: #6b7280; font-weight: 500; }
+
+.about-header { margin-bottom: 2rem; }
+.about-h1 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  color: #1f2937;
+  margin: 0 0 0.625rem;
+  line-height: 1.2;
+}
+.about-lead {
+  font-size: 1.0625rem;
+  color: #4b5563;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.about-section {
+  margin-top: 2rem;
+}
+
+.about-h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin: 0 0 0.625rem;
+}
+
+.about-section p {
+  color: #374151;
+  line-height: 1.65;
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+.about-section p:last-child {
+  margin-bottom: 0;
+}
+
+.about-section a {
+  color: #2E3D5B;
+  font-weight: 500;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+.about-section a:hover { text-decoration-thickness: 2px; }
+
+.about-feature-list,
+.about-bullets {
+  list-style: disc;
+  padding-left: 1.25rem;
+  margin: 0;
+  color: #374151;
+  line-height: 1.65;
+}
+.about-feature-list li,
+.about-bullets li {
+  margin-bottom: 0.375rem;
+}
+.about-feature-list li:last-child,
+.about-bullets li:last-child {
+  margin-bottom: 0;
+}

--- a/frontend/src/components/About.jsx
+++ b/frontend/src/components/About.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 import './About.css'
 
 const REPO_URL = 'https://github.com/SeattleCouncilmatic/seattle-councilmatic'
-const CONTACT_EMAIL = 'jimmie@jimmiewifi.com'
+const CONTACT_EMAIL = 'contact@seattlecouncilmatic.org'
 
 export default function About() {
   return (
@@ -26,11 +26,11 @@ export default function About() {
         <section className="about-section" aria-label="Why this exists">
           <h2 className="about-h2">Why this exists</h2>
           <p>
-            Council business shapes everything from rent rules to noise
-            ordinances to where you can park. Seattle Councilmatic is built
-            so any resident — without specialized tools or training — can
+            Council business shapes everything from rent rules and building
+            codes to business regulations and labor laws. Seattle
+            Councilmatic offers tools that allow the people of Seattle to
             follow legislation, find their representatives, and read the
-            Municipal Code that governs their neighborhood.
+            Municipal Code that governs life in the Emerald City.
           </p>
         </section>
 

--- a/frontend/src/components/About.jsx
+++ b/frontend/src/components/About.jsx
@@ -1,0 +1,137 @@
+import { Link } from 'react-router-dom'
+import './About.css'
+
+const REPO_URL = 'https://github.com/SeattleCouncilmatic/seattle-councilmatic'
+const CONTACT_EMAIL = 'jimmie@jimmiewifi.com'
+
+export default function About() {
+  return (
+    <main className="about-page">
+      <div className="about-container">
+        <nav className="about-breadcrumb" aria-label="Breadcrumb">
+          <Link to="/">This Week</Link>
+          <span className="about-breadcrumb-sep" aria-hidden="true">/</span>
+          <span className="about-breadcrumb-current">About</span>
+        </nav>
+
+        <header className="about-header">
+          <h1 className="about-h1">About Seattle Councilmatic</h1>
+          <p className="about-lead">
+            A window into Seattle City Council — bills, meetings, council
+            members, and the Municipal Code, in a form that's actually
+            browsable and searchable.
+          </p>
+        </header>
+
+        <section className="about-section" aria-label="Why this exists">
+          <h2 className="about-h2">Why this exists</h2>
+          <p>
+            The City of Seattle's records are public, but the official portal is
+            hard to navigate and the Municipal Code is a 4,300-page PDF. This
+            site puts the same data behind a single search box and a familiar
+            set of pages, so residents can follow what the Council is doing
+            without learning the city's tooling.
+          </p>
+        </section>
+
+        <section className="about-section" aria-label="What's on the site">
+          <h2 className="about-h2">What's on the site</h2>
+          <ul className="about-feature-list">
+            <li>
+              <Link to="/">This Week</Link> — recent legislation and upcoming
+              meetings at a glance.
+            </li>
+            <li>
+              <Link to="/legislation">Legislation</Link> — every bill and
+              resolution, searchable by identifier or title.
+            </li>
+            <li>
+              <Link to="/events">Events</Link> — committee meetings and council
+              briefings with their agendas and packets.
+            </li>
+            <li>
+              <Link to="/reps">My Council Members</Link> — district map, address
+              lookup, and rep profiles.
+            </li>
+            <li>
+              <Link to="/municode">Municipal Code</Link> — search and browse
+              all 7,400+ sections of the SMC.
+            </li>
+            <li>
+              <Link to="/search">Search</Link> — one search box across
+              legislation and the Municipal Code.
+            </li>
+          </ul>
+        </section>
+
+        <section className="about-section" aria-label="Where the data comes from">
+          <h2 className="about-h2">Where the data comes from</h2>
+          <ul className="about-bullets">
+            <li>
+              Bills, sponsors, actions, votes, and events: scraped nightly from{' '}
+              <a href="https://seattle.legistar.com" target="_blank" rel="noopener noreferrer">
+                seattle.legistar.com
+              </a>.
+            </li>
+            <li>
+              Council members and district boundaries: published by the{' '}
+              <a href="https://www.seattle.gov/council" target="_blank" rel="noopener noreferrer">
+                Seattle City Council
+              </a> and the{' '}
+              <a href="https://data.seattle.gov" target="_blank" rel="noopener noreferrer">
+                City of Seattle Open Data Portal
+              </a>.
+            </li>
+            <li>
+              Municipal Code: parsed from the official PDF published by the
+              Seattle City Clerk.
+            </li>
+          </ul>
+        </section>
+
+        <section className="about-section" aria-label="Credits">
+          <h2 className="about-h2">Built on the work of others</h2>
+          <p>
+            This site is built on{' '}
+            <a href="https://github.com/datamade/django-councilmatic"
+               target="_blank" rel="noopener noreferrer">
+              django-councilmatic
+            </a>, the open-source civic-tech framework maintained by{' '}
+            <a href="https://datamade.us" target="_blank" rel="noopener noreferrer">
+              DataMade
+            </a>. With particular thanks to:
+          </p>
+          <ul className="about-bullets">
+            <li>
+              <strong>DataMade</strong> for the Councilmatic ecosystem this
+              site extends.
+            </li>
+            <li>
+              <strong>The City of Seattle</strong> for publishing public
+              records and geographic data in machine-readable form.
+            </li>
+            <li>
+              <strong>CARTO</strong> for the basemap tiles powering the
+              council district map.
+            </li>
+          </ul>
+        </section>
+
+        <section className="about-section" aria-label="Source code and contact">
+          <h2 className="about-h2">Source code &amp; contact</h2>
+          <p>
+            Source code lives at{' '}
+            <a href={REPO_URL} target="_blank" rel="noopener noreferrer">
+              github.com/SeattleCouncilmatic/seattle-councilmatic
+            </a> and is MIT-licensed (copyright DataMade and contributors).
+            Issues, suggestions, and pull requests are welcome on GitHub.
+          </p>
+          <p>
+            For other questions or feedback, email{' '}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+          </p>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/components/About.jsx
+++ b/frontend/src/components/About.jsx
@@ -17,20 +17,20 @@ export default function About() {
         <header className="about-header">
           <h1 className="about-h1">About Seattle Councilmatic</h1>
           <p className="about-lead">
-            A window into Seattle City Council — bills, meetings, council
-            members, and the Municipal Code, in a form that's actually
-            browsable and searchable.
+            A free and accessible way to follow what Seattle City Council is
+            doing — the bills they're considering, the meetings they're
+            holding, who represents you, and the laws on the books.
           </p>
         </header>
 
         <section className="about-section" aria-label="Why this exists">
           <h2 className="about-h2">Why this exists</h2>
           <p>
-            The City of Seattle's records are public, but the official portal is
-            hard to navigate and the Municipal Code is a 4,300-page PDF. This
-            site puts the same data behind a single search box and a familiar
-            set of pages, so residents can follow what the Council is doing
-            without learning the city's tooling.
+            Council business shapes everything from rent rules to noise
+            ordinances to where you can park. Seattle Councilmatic is built
+            so any resident — without specialized tools or training — can
+            follow legislation, find their representatives, and read the
+            Municipal Code that governs their neighborhood.
           </p>
         </section>
 
@@ -64,6 +64,58 @@ export default function About() {
           </ul>
         </section>
 
+        <section className="about-section" aria-label="How Seattle City Council works">
+          <h2 className="about-h2">How Seattle City Council works</h2>
+          <p>
+            The Seattle City Council is the legislative body of the City of
+            Seattle. It has nine members: seven elected from geographic
+            districts (Districts 1–7) and two elected at-large (Position 8
+            and Position 9, who represent every district). Council members
+            elect one of their own to serve as Council President.
+          </p>
+          <p>
+            The full Council typically meets every Tuesday afternoon to vote
+            on legislation that has cleared its committees. Most of the
+            actual work — review, amendment, public comment — happens in
+            standing committees, which meet on their own schedules and
+            cover specific subject areas (transportation, land use, public
+            safety, and so on). Committee assignments and agendas live on
+            the <Link to="/events">Events</Link> page.
+          </p>
+          <p>
+            The Mayor of Seattle is a separate executive office. The Mayor
+            signs or vetoes legislation passed by Council and is responsible
+            for executing it through City departments — but does not vote
+            on legislation directly.
+          </p>
+        </section>
+
+        <section className="about-section" aria-label="Types of legislation">
+          <h2 className="about-h2">Types of legislation</h2>
+          <p>
+            Most items the Council acts on fall into one of three categories:
+          </p>
+          <ul className="about-bullets">
+            <li>
+              <strong>Council Bill (CB)</strong> — a proposed law working its
+              way through committee and full Council. When a Council Bill
+              passes and is signed by the Mayor, it becomes an Ordinance.
+            </li>
+            <li>
+              <strong>Ordinance (Ord)</strong> — a passed law. Most
+              ordinances become part of the{' '}
+              <Link to="/municode">Seattle Municipal Code</Link>; others
+              authorize one-time actions like budget appropriations or
+              property transactions.
+            </li>
+            <li>
+              <strong>Resolution (Res)</strong> — typically non-binding.
+              Used to adopt policies, take positions, recognize individuals
+              or organizations, or direct the Council's own internal work.
+            </li>
+          </ul>
+        </section>
+
         <section className="about-section" aria-label="Where the data comes from">
           <h2 className="about-h2">Where the data comes from</h2>
           <ul className="about-bullets">
@@ -92,16 +144,35 @@ export default function About() {
         <section className="about-section" aria-label="Credits">
           <h2 className="about-h2">Built on the work of others</h2>
           <p>
-            This site is built on{' '}
+            Councilmatic was originally created by{' '}
+            <a href="https://mjumbewu.com" target="_blank" rel="noopener noreferrer">
+              Mjumbe Poe
+            </a>{' '}
+            for Philadelphia in 2011 as a{' '}
+            <a href="https://www.codeforamerica.org" target="_blank" rel="noopener noreferrer">
+              Code for America
+            </a>{' '}
+            Fellow — the first fully-developed open data site for municipal
+            legislation in the United States. The framework has since grown
+            into the{' '}
+            <a href="https://www.councilmatic.org" target="_blank" rel="noopener noreferrer">
+              Councilmatic family
+            </a>{' '}
+            of civic-tech sites, maintained by{' '}
+            <a href="https://datamade.us" target="_blank" rel="noopener noreferrer">
+              DataMade
+            </a>. Seattle Councilmatic is built on their open-source{' '}
             <a href="https://github.com/datamade/django-councilmatic"
                target="_blank" rel="noopener noreferrer">
               django-councilmatic
-            </a>, the open-source civic-tech framework maintained by{' '}
-            <a href="https://datamade.us" target="_blank" rel="noopener noreferrer">
-              DataMade
-            </a>. With particular thanks to:
+            </a>.
           </p>
+          <p>With particular thanks to:</p>
           <ul className="about-bullets">
+            <li>
+              <strong>Mjumbe Poe</strong> and <strong>Code for America</strong>{' '}
+              for inventing this category of civic site.
+            </li>
             <li>
               <strong>DataMade</strong> for the Councilmatic ecosystem this
               site extends.

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -7,7 +7,7 @@ import './NavBar.css';
 // ship, or convert to `to` paths if they grow into their own pages.
 const NAV_ITEMS = [
   { label: 'This Week',          href: '#this-week' },
-  { label: 'About',              href: '#about' },
+  { label: 'About',              to:   '/about' },
   { label: 'How It Works',       href: '#how-it-works' },
   { label: 'Events',             to:   '/events' },
   { label: 'Legislation',        to:   '/legislation' },


### PR DESCRIPTION
## Summary

Replaces NavBar's `#about` hash anchor (which pointed at a nonexistent homepage section) with a real `/about` page. Content drafted with the user across one round.

**Sections**:
- Lead + "why this exists" — framing the site as a re-presentation of public records.
- "What's on the site" — feature list with internal links into every surface (`/legislation`, `/events`, `/reps`, `/municode`, `/search`, `/`).
- Data sources — Legistar (bills/events), seattle.gov + Open Data Portal (members + boundaries), the city-clerk PDF (SMC).
- Credits — DataMade (django-councilmatic upstream, MIT-licensed), the City of Seattle, CARTO (basemap tiles).
- Source code + contact — GitHub link, MIT note, and `jimmie@jimmiewifi.com` for now (user plans to set up a councilmatic.org address).

Tone deliberately balances civic-formal with community-project warmth per the user's preference. No forward-looking content (LLM summaries, pgvector, etc.) — describes what works today.

## Test plan

- [x] Production build clean (1750 modules, ~4 s, ~450 kB JS / ~58 kB CSS).
- [x] `/about` and `/about/` routes serve 200.
- [x] About content + contact email bundled.
- [x] **Reviewer**: visit `/about`, confirm: NavBar `About` link works, all internal feature-list links navigate correctly, all external links open in a new tab, mailto link works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)