### PR TITLE
legislation: classification filter (Council Bill / Ordinance / Resolution)

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -16,7 +16,7 @@ locked decisions, known follow-up threads, and a chronological merge log.
 Prioritized to-do. Quick wins flagged with *(quick)*.
 
 **SPA index/search pages** (each likely its own PR; specifics TBD when we pick them up)
-- **Index polish** (deferred from PRs #30 and #31). *Legislation:* classification filter (Bill/Resolution/etc.), sort controls, date-range filter, sponsor filter. *Events:* committee-name dropdown (separate from type), date-range filter. *Both:* NavBar's hash-anchor stubs (`#about`, `#how-it-works`, `#my-council-members`, `#glossary`) still point at homepage sections that don't exist yet — wire them up as those sections ship, or convert to real `/path` Links. NavBar isn't shown on the index pages (only on the homepage); think about whether the index pages should get their own header/nav. CSS class names `.meeting-card-*` / `.mtg-detail-*` weren't renamed when MeetingCard/MeetingDetail → EventCard/EventDetail in PR #31; rename if/when those files get more substantive changes.
+- **Index polish** (deferred from PRs #30 and #31). *Legislation:* sort controls, date-range filter, sponsor filter. *Events:* committee-name dropdown (separate from type), date-range filter. *Both:* NavBar's hash-anchor stubs (`#about`, `#how-it-works`, `#my-council-members`, `#glossary`) still point at homepage sections that don't exist yet — wire them up as those sections ship, or convert to real `/path` Links. NavBar isn't shown on the index pages (only on the homepage); think about whether the index pages should get their own header/nav. CSS class names `.meeting-card-*` / `.mtg-detail-*` weren't renamed when MeetingCard/MeetingDetail → EventCard/EventDetail in PR #31; rename if/when those files get more substantive changes.
 
 **Frontend polish & site chrome**
 - **NavBar mobile hamburger** (deferred from PR #33). NavBar currently wraps via `flex-wrap` on narrow screens; if usability becomes a problem, replace with a proper hamburger menu.
@@ -56,6 +56,13 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### Legislation — classification filter (Council Bill / Ordinance / Resolution) — committed 2026-04-28
+First of the index-polish bundle deferred from PR #30. `/legislation/` now has a type dropdown alongside the status dropdown. Filters on Legistar's `MatterTypeName` extra, which carries values like `Council Bill (CB)` / `Ordinance (Ord)` / `Resolution (Res)`. `_CLASSIFICATION_LABELS` maps display labels to raw values so the dropdown reads cleanly.
+
+API: new optional `classification` query param + `classification_values` exposed alongside `status_values` in the response. Bogus values short-circuit to `qs.none()`, same defensive pattern as the status filter. Verified the cascade: 381 total → 49 resolutions / 20 council bills / 312 ordinances (sums to total).
+
+Frontend: parallel state, dropdown, change handler. URL-synced like the status filter so filtered views are bookmarkable.
 
 ### Municode — scoped search at title and chapter levels — committed 2026-04-28
 Closes the last municode follow-up. The `/api/smc/?title=<n>` and `?chapter=<n>` filters have been wired since PR #36 but weren't surfaced anywhere in the UI; now both the title and chapter detail pages expose scoped search via an input below their header, and the index page renders a `Filtered to Title <n>` or `Filtered to Chapter <n>` pill when either filter is active.

--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -11,11 +11,13 @@ export default function LegislationIndex() {
 
   const q = searchParams.get('q') ?? ''
   const status = searchParams.get('status') ?? ''
+  const classification = searchParams.get('classification') ?? ''
   const offset = Number(searchParams.get('offset') ?? 0)
 
   const [results, setResults] = useState([])
   const [totalCount, setTotalCount] = useState(0)
   const [statusValues, setStatusValues] = useState([])
+  const [classificationValues, setClassificationValues] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
@@ -48,6 +50,7 @@ export default function LegislationIndex() {
     const params = new URLSearchParams()
     if (q) params.set('q', q)
     if (status) params.set('status', status)
+    if (classification) params.set('classification', classification)
     params.set('limit', PAGE_SIZE)
     params.set('offset', offset)
 
@@ -60,15 +63,24 @@ export default function LegislationIndex() {
         setResults(data.results || [])
         setTotalCount(data.total_count ?? 0)
         if (data.status_values) setStatusValues(data.status_values)
+        if (data.classification_values) setClassificationValues(data.classification_values)
       })
       .catch(e => setError(e.message))
       .finally(() => setLoading(false))
-  }, [q, status, offset])
+  }, [q, status, classification, offset])
 
   const handleStatusChange = (e) => {
     const next = new URLSearchParams(searchParams)
     if (e.target.value) next.set('status', e.target.value)
     else next.delete('status')
+    next.delete('offset')
+    setSearchParams(next)
+  }
+
+  const handleClassificationChange = (e) => {
+    const next = new URLSearchParams(searchParams)
+    if (e.target.value) next.set('classification', e.target.value)
+    else next.delete('classification')
     next.delete('offset')
     setSearchParams(next)
   }
@@ -111,6 +123,17 @@ export default function LegislationIndex() {
             aria-label="Search legislation"
             autoFocus
           />
+          <select
+            className="leg-index-status"
+            value={classification}
+            onChange={handleClassificationChange}
+            aria-label="Filter by type"
+          >
+            <option value="">All types</option>
+            {classificationValues.map(c => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
           <select
             className="leg-index-status"
             value={status}

--- a/seattle_app/api_views.py
+++ b/seattle_app/api_views.py
@@ -109,6 +109,16 @@ def recent_legislation(request):
 _STATUS_FILTER_VALUES = ['Passed', 'Adopted', 'Signed', 'Failed', 'Vetoed',
                          'Tabled', 'In Committee', 'Full Council', 'Introduced']
 
+# Classification filter — Legistar's MatterTypeName values include the
+# parenthesized abbreviation, but we display the clean label and translate
+# back when filtering. Order is display order on the dropdown.
+_CLASSIFICATION_LABELS = {
+    'Council Bill': 'Council Bill (CB)',
+    'Ordinance':    'Ordinance (Ord)',
+    'Resolution':   'Resolution (Res)',
+}
+_CLASSIFICATION_VALUES = list(_CLASSIFICATION_LABELS.keys())
+
 
 def _safe_int(raw, default, max_value=None):
     try:
@@ -125,15 +135,18 @@ def _safe_int(raw, default, max_value=None):
 @require_GET
 def legislation_index(request):
     """
-    GET /api/legislation/?q=<text>&status=<label>&limit=20&offset=0
+    GET /api/legislation/?q=<text>&status=<label>&classification=<label>&limit=20&offset=0
 
     Search and filter all legislation; paginated. Sorted by latest action
     descending (same as recent_legislation). `status` is one of the
     normalized labels from _STATUS_VARIANTS (case-sensitive); the filter
     expands to all raw `MatterStatusName` values that map to that label.
+    `classification` is one of _CLASSIFICATION_VALUES (Council Bill,
+    Ordinance, Resolution) and matches MatterTypeName.
     """
     q = request.GET.get('q', '').strip()
     status_filter = request.GET.get('status', '').strip()
+    classification_filter = request.GET.get('classification', '').strip()
     limit = _safe_int(request.GET.get('limit'), default=20, max_value=100)
     offset = _safe_int(request.GET.get('offset'), default=0)
 
@@ -154,6 +167,13 @@ def legislation_index(request):
                 bills = bills.filter(status_q)
             else:
                 bills = bills.none()
+
+    if classification_filter:
+        if classification_filter not in _CLASSIFICATION_VALUES:
+            bills = bills.none()
+        else:
+            raw = _CLASSIFICATION_LABELS[classification_filter]
+            bills = bills.filter(extras__MatterTypeName=raw)
 
     total_count = bills.count()
 
@@ -187,11 +207,12 @@ def legislation_index(request):
         })
 
     return JsonResponse({
-        'results':       results,
-        'total_count':   total_count,
-        'limit':         limit,
-        'offset':        offset,
-        'status_values': _STATUS_FILTER_VALUES,
+        'results':              results,
+        'total_count':          total_count,
+        'limit':                limit,
+        'offset':               offset,
+        'status_values':        _STATUS_FILTER_VALUES,
+        'classification_values': _CLASSIFICATION_VALUES,
     })
 
 


### PR DESCRIPTION
## Summary

First of the index-polish bundle deferred from PR #30. `/legislation/` now has a type dropdown next to the existing status dropdown.

- API: new optional `classification` query param. Filters on Legistar's `MatterTypeName` extra; display labels (`Council Bill`, `Ordinance`, `Resolution`) map to the raw `Council Bill (CB)` / `Ordinance (Ord)` / `Resolution (Res)` values via `_CLASSIFICATION_LABELS` so the dropdown reads cleanly. Bogus values short-circuit to `qs.none()` — same defensive pattern as the status filter. `classification_values` exposed in the response alongside `status_values`.
- Frontend: parallel state, dropdown, change handler. URL-synced like the status filter so filtered views are bookmarkable.

## Test plan

- [x] API cascade: 381 total → 49 resolutions / 20 council bills / 312 ordinances (sums to total).
- [x] `?classification=Bogus` → 0 results.
- [x] Production build clean.
- [ ] **Reviewer**: load `/legislation`, pick "Resolution" from the type dropdown — only resolutions render. Combine with status filter; combine with text query. URL updates correctly and is shareable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)