### PR TITLE
legislation: sort controls

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -16,7 +16,7 @@ locked decisions, known follow-up threads, and a chronological merge log.
 Prioritized to-do. Quick wins flagged with *(quick)*.
 
 **SPA index/search pages** (each likely its own PR; specifics TBD when we pick them up)
-- **Index polish** (deferred from PRs #30 and #31). *Legislation:* classification filter (Bill/Resolution/etc.), sort controls, date-range filter, sponsor filter. *Events:* committee-name dropdown (separate from type), date-range filter. *Both:* NavBar's hash-anchor stubs (`#about`, `#how-it-works`, `#my-council-members`, `#glossary`) still point at homepage sections that don't exist yet — wire them up as those sections ship, or convert to real `/path` Links. NavBar isn't shown on the index pages (only on the homepage); think about whether the index pages should get their own header/nav. CSS class names `.meeting-card-*` / `.mtg-detail-*` weren't renamed when MeetingCard/MeetingDetail → EventCard/EventDetail in PR #31; rename if/when those files get more substantive changes.
+- **Index polish** (deferred from PRs #30 and #31). *Legislation:* classification filter (Bill/Resolution/etc.), date-range filter, sponsor filter. *Events:* committee-name dropdown (separate from type), date-range filter. *Both:* NavBar's hash-anchor stubs (`#about`, `#how-it-works`, `#my-council-members`, `#glossary`) still point at homepage sections that don't exist yet — wire them up as those sections ship, or convert to real `/path` Links. NavBar isn't shown on the index pages (only on the homepage); think about whether the index pages should get their own header/nav. CSS class names `.meeting-card-*` / `.mtg-detail-*` weren't renamed when MeetingCard/MeetingDetail → EventCard/EventDetail in PR #31; rename if/when those files get more substantive changes.
 
 **Frontend polish & site chrome**
 - **NavBar mobile hamburger** (deferred from PR #33). NavBar currently wraps via `flex-wrap` on narrow screens; if usability becomes a problem, replace with a proper hamburger menu.
@@ -56,6 +56,17 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### Legislation — sort controls — committed 2026-04-28
+Second of the index-polish bundle. `/legislation/` gets a sort dropdown alongside the type and status filters. Three options:
+
+- `recent` (default, the previous behavior) — most recent activity first.
+- `introduced` — most recently introduced first. Surfaces newly-filed work even if it hasn't seen action yet.
+- `identifier` — alphabetical by identifier (CB number).
+
+API: new `sort` query param. Bogus values fall back to default rather than 400ing — easier UX, matches the defensive pattern of the other filters. Backend annotates both `Max('actions__date')` and `Min('actions__date')` since `recent` and `introduced` use different aggregates; cost is bounded because we only do this on the post-LIMIT slice. New `sort_values` exposed in the response as `[{value, label}, ...]` so the frontend renders human-readable option text.
+
+Frontend handler omits the default value from the URL (`?sort=recent` would be redundant; absent param implies default). State + dropdown follow the same pattern as the existing status/classification dropdowns.
 
 ### Municode — scoped search at title and chapter levels — committed 2026-04-28
 Closes the last municode follow-up. The `/api/smc/?title=<n>` and `?chapter=<n>` filters have been wired since PR #36 but weren't surfaced anywhere in the UI; now both the title and chapter detail pages expose scoped search via an input below their header, and the index page renders a `Filtered to Title <n>` or `Filtered to Chapter <n>` pill when either filter is active.

--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -11,11 +11,13 @@ export default function LegislationIndex() {
 
   const q = searchParams.get('q') ?? ''
   const status = searchParams.get('status') ?? ''
+  const sort = searchParams.get('sort') ?? ''
   const offset = Number(searchParams.get('offset') ?? 0)
 
   const [results, setResults] = useState([])
   const [totalCount, setTotalCount] = useState(0)
   const [statusValues, setStatusValues] = useState([])
+  const [sortValues, setSortValues] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
@@ -48,6 +50,7 @@ export default function LegislationIndex() {
     const params = new URLSearchParams()
     if (q) params.set('q', q)
     if (status) params.set('status', status)
+    if (sort) params.set('sort', sort)
     params.set('limit', PAGE_SIZE)
     params.set('offset', offset)
 
@@ -60,15 +63,26 @@ export default function LegislationIndex() {
         setResults(data.results || [])
         setTotalCount(data.total_count ?? 0)
         if (data.status_values) setStatusValues(data.status_values)
+        if (data.sort_values) setSortValues(data.sort_values)
       })
       .catch(e => setError(e.message))
       .finally(() => setLoading(false))
-  }, [q, status, offset])
+  }, [q, status, sort, offset])
 
   const handleStatusChange = (e) => {
     const next = new URLSearchParams(searchParams)
     if (e.target.value) next.set('status', e.target.value)
     else next.delete('status')
+    next.delete('offset')
+    setSearchParams(next)
+  }
+
+  const handleSortChange = (e) => {
+    const next = new URLSearchParams(searchParams)
+    // Don't bother carrying the default sort in the URL — it's the
+    // implicit value when the param is absent.
+    if (e.target.value && e.target.value !== 'recent') next.set('sort', e.target.value)
+    else next.delete('sort')
     next.delete('offset')
     setSearchParams(next)
   }
@@ -120,6 +134,16 @@ export default function LegislationIndex() {
             <option value="">All statuses</option>
             {statusValues.map(s => (
               <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          <select
+            className="leg-index-status"
+            value={sort || 'recent'}
+            onChange={handleSortChange}
+            aria-label="Sort order"
+          >
+            {sortValues.map(s => (
+              <option key={s.value} value={s.value}>{s.label}</option>
             ))}
           </select>
         </div>

--- a/seattle_app/api_views.py
+++ b/seattle_app/api_views.py
@@ -12,7 +12,7 @@ from django.http import JsonResponse
 from django.views.decorators.http import require_GET
 from django.utils import timezone
 from django.contrib.postgres.search import SearchHeadline, SearchQuery, SearchRank
-from django.db.models import Count, Max, Q
+from django.db.models import Count, Max, Min, Q
 from councilmatic_core.models import Bill, Event
 from django.shortcuts import get_object_or_404
 
@@ -109,6 +109,19 @@ def recent_legislation(request):
 _STATUS_FILTER_VALUES = ['Passed', 'Adopted', 'Signed', 'Failed', 'Vetoed',
                          'Tabled', 'In Committee', 'Full Council', 'Introduced']
 
+# Sort options. `recent` is the default and matches the previous
+# (un-parametrized) behavior — bills with the most recent action surface
+# first. `introduced` orders by the earliest action date (i.e. when a
+# bill first hit the docket) so the sort surfaces newly-filed work
+# regardless of subsequent activity. `identifier` is alphabetical for
+# users who know the citation they're after.
+_SORT_VALUES = {
+    'recent':     ('-latest_action_date', 'Most recent activity'),
+    'introduced': ('-earliest_action_date', 'Most recently introduced'),
+    'identifier': ('identifier',           'Identifier (CB number)'),
+}
+_DEFAULT_SORT = 'recent'
+
 
 def _safe_int(raw, default, max_value=None):
     try:
@@ -125,15 +138,19 @@ def _safe_int(raw, default, max_value=None):
 @require_GET
 def legislation_index(request):
     """
-    GET /api/legislation/?q=<text>&status=<label>&limit=20&offset=0
+    GET /api/legislation/?q=<text>&status=<label>&sort=<key>&limit=20&offset=0
 
-    Search and filter all legislation; paginated. Sorted by latest action
-    descending (same as recent_legislation). `status` is one of the
-    normalized labels from _STATUS_VARIANTS (case-sensitive); the filter
-    expands to all raw `MatterStatusName` values that map to that label.
+    Search and filter all legislation; paginated. `sort` is one of
+    _SORT_VALUES (defaults to `recent` — the previous behavior). `status`
+    is one of the normalized labels from _STATUS_VARIANTS (case-
+    sensitive); the filter expands to all raw `MatterStatusName` values
+    that map to that label.
     """
     q = request.GET.get('q', '').strip()
     status_filter = request.GET.get('status', '').strip()
+    sort = request.GET.get('sort', '').strip() or _DEFAULT_SORT
+    if sort not in _SORT_VALUES:
+        sort = _DEFAULT_SORT
     limit = _safe_int(request.GET.get('limit'), default=20, max_value=100)
     offset = _safe_int(request.GET.get('offset'), default=0)
 
@@ -157,11 +174,15 @@ def legislation_index(request):
 
     total_count = bills.count()
 
+    sort_field, _sort_label = _SORT_VALUES[sort]
     bills = (
         bills
         .prefetch_related('actions', 'sponsorships')
-        .annotate(latest_action_date=Max('actions__date'))
-        .order_by('-latest_action_date')[offset:offset + limit]
+        .annotate(
+            latest_action_date=Max('actions__date'),
+            earliest_action_date=Min('actions__date'),
+        )
+        .order_by(sort_field)[offset:offset + limit]
     )
 
     results = []
@@ -191,7 +212,9 @@ def legislation_index(request):
         'total_count':   total_count,
         'limit':         limit,
         'offset':        offset,
+        'sort':          sort,
         'status_values': _STATUS_FILTER_VALUES,
+        'sort_values':   [{'value': k, 'label': v[1]} for k, v in _SORT_VALUES.items()],
     })
 
 


### PR DESCRIPTION
## Summary

Second of the index-polish bundle (after #45). `/legislation/` gets a sort dropdown alongside the existing status and type filters.

Three sort options:
- **`recent`** (default — previous behavior): most recent activity first.
- **`introduced`**: most recently introduced first. Surfaces newly-filed work even if it hasn't seen action yet.
- **`identifier`**: alphabetical by identifier (CB number).

## Backend

- New `sort` query param on `/api/legislation/`. Bogus values fall back to the default rather than 400ing — defensive pattern matching the other filters.
- Annotates both `Max('actions__date')` and `Min('actions__date')` since `recent` and `introduced` need different aggregates; cost is bounded by the post-`LIMIT` slice.
- New `sort_values` field in the response shaped as `[{value, label}, ...]` so the frontend renders human-readable option text.

## Frontend

- New `sort` URL param + state + dropdown alongside the status filter.
- Handler omits the default value from the URL — `?sort=recent` would be redundant since absent param implies default.

## Conflict note

This branched off `main` before #45 (classification filter) merged. They both touch the same controls block in `LegislationIndex.jsx`, the same `legislation_index` view, and the same `Up next` line in WORK_LOG. Conflicts will be small and mechanical (both adding a dropdown in the same row, both adding a state variable, both adding to the response payload). I'll resolve them when this lands after #45.

## Test plan

- [x] Default sort returns the same first row as before.
- [x] `?sort=introduced` returns CB 121198 (introduced 2026-04-21) first; default returns CB 121185 (older intro, recent action).
- [x] `?sort=identifier` returns CB 120848, 120861, 120862 in alphabetical order.
- [x] `?sort=bogus` falls back to `sort=recent`.
- [x] Production build clean.
- [ ] **Reviewer**: load `/legislation`, switch through the three sort options. Combine with status + (after #45) classification filter. URL should be shareable and back-button should restore the previous sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)