### PR TITLE
fix: LegislationIndex.jsx merge resolution (filters not rendering)

### DIFF
--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -73,22 +73,13 @@ export default function LegislationIndex() {
         setResults(data.results || [])
         setTotalCount(data.total_count ?? 0)
         if (data.status_values) setStatusValues(data.status_values)
+        if (data.classification_values) setClassificationValues(data.classification_values)
         if (data.sponsor_values) setSponsorValues(data.sponsor_values)
-      })
-      .catch(e => setError(e.message))
-      .finally(() => setLoading(false))
-  }, [q, status, sponsor, offset])
         if (data.sort_values) setSortValues(data.sort_values)
       })
       .catch(e => setError(e.message))
       .finally(() => setLoading(false))
-  }, [q, status, introducedAfter, introducedBefore, offset])
-  }, [q, status, sort, offset])
-        if (data.classification_values) setClassificationValues(data.classification_values)
-      })
-      .catch(e => setError(e.message))
-      .finally(() => setLoading(false))
-  }, [q, status, classification, offset])
+  }, [q, status, classification, sponsor, sort, introducedAfter, introducedBefore, offset])
 
   const handleStatusChange = (e) => {
     const next = new URLSearchParams(searchParams)
@@ -98,24 +89,35 @@ export default function LegislationIndex() {
     setSearchParams(next)
   }
 
-  const handleSponsorChange = (e) => {
-    const next = new URLSearchParams(searchParams)
-    if (e.target.value) next.set('sponsor', e.target.value)
-    else next.delete('sponsor')
-  const handleDateChange = (paramName) => (e) => {
-    const next = new URLSearchParams(searchParams)
-    if (e.target.value) next.set(paramName, e.target.value)
-    else next.delete(paramName)
-  const handleSortChange = (e) => {
-    const next = new URLSearchParams(searchParams)
-    // Don't bother carrying the default sort in the URL — it's the
-    // implicit value when the param is absent.
-    if (e.target.value && e.target.value !== 'recent') next.set('sort', e.target.value)
-    else next.delete('sort')
   const handleClassificationChange = (e) => {
     const next = new URLSearchParams(searchParams)
     if (e.target.value) next.set('classification', e.target.value)
     else next.delete('classification')
+    next.delete('offset')
+    setSearchParams(next)
+  }
+
+  const handleSponsorChange = (e) => {
+    const next = new URLSearchParams(searchParams)
+    if (e.target.value) next.set('sponsor', e.target.value)
+    else next.delete('sponsor')
+    next.delete('offset')
+    setSearchParams(next)
+  }
+
+  const handleSortChange = (e) => {
+    const next = new URLSearchParams(searchParams)
+    // Don't carry the default sort in the URL — absent param implies it.
+    if (e.target.value && e.target.value !== 'recent') next.set('sort', e.target.value)
+    else next.delete('sort')
+    next.delete('offset')
+    setSearchParams(next)
+  }
+
+  const handleDateChange = (paramName) => (e) => {
+    const next = new URLSearchParams(searchParams)
+    if (e.target.value) next.set(paramName, e.target.value)
+    else next.delete(paramName)
     next.delete('offset')
     setSearchParams(next)
   }
@@ -191,6 +193,8 @@ export default function LegislationIndex() {
               <option key={s} value={s}>{s}</option>
             ))}
           </select>
+          <select
+            className="leg-index-status"
             value={sort || 'recent'}
             onChange={handleSortChange}
             aria-label="Sort order"


### PR DESCRIPTION
## Summary

Companion hotfix to #50. Same class of merge damage but on the frontend. The four-way merge (#45/#46/#47/#48) of `LegislationIndex.jsx` left three regions malformed:

1. **Fetch useEffect tail** — one good `.then()` body, then orphaned `if (data.sort_values)` / `if (data.classification_values)` setter calls, plus three extra dependency arrays after the correct one. Vite errored at the orphan `})` on line 82 with `Unexpected ")"`.
2. **Handler block** — `handleSponsorChange` opens but never closes its body before `handleDateChange` starts; same pattern continues through `handleSortChange` and `handleClassificationChange`. Net effect: only `handleStatusChange` and (the last one parsed as) `handleClassificationChange` survived as valid functions; the others' bodies were spliced together into one mangled function.
3. **Sort `<select>`** — the opening `<select>` tag was dropped, leaving `value={sort || 'recent'} onChange={...}` as orphaned attributes inside the JSX between the sponsor select and the closing `</div>`.

## Why the user saw stale UI even after merging #50

`#50` fixed the backend so endpoints returned 200 again, but the build had been failing on this file the whole time too. The Django dev server was serving the *last successful* `frontend/dist/` bundle, which predated all four PRs — none of the new filters were in the JS at all. Rebuilding now produces a fresh bundle with all five controls present:

```
$ grep -oE '(All types|All statuses|All sponsors|Sort order|Introduced from)' dist/assets/index-*.js | sort -u
All sponsors
All statuses
All types
Introduced from
Sort order
```

## EventsIndex

Came through the merge clean — only `LegislationIndex` needed surgery.

## Test plan

- [x] `vite build` succeeds.
- [x] All five labels in the new bundle.
- [ ] **Reviewer**: load `/legislation`, confirm all five controls render (search, type, status, sponsor, sort, date range), URL syncs correctly when each is changed, combinations work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)