### PR TITLE
legislation: group sponsor dropdown by current vs former council

### DIFF
--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -21,7 +21,7 @@ export default function LegislationIndex() {
   const [results, setResults] = useState([])
   const [totalCount, setTotalCount] = useState(0)
   const [statusValues, setStatusValues] = useState([])
-  const [sponsorValues, setSponsorValues] = useState([])
+  const [sponsorValues, setSponsorValues] = useState({ current: [], former: [] })
   const [sortValues, setSortValues] = useState([])
   const [classificationValues, setClassificationValues] = useState([])
   const [loading, setLoading] = useState(true)
@@ -189,9 +189,20 @@ export default function LegislationIndex() {
             aria-label="Filter by sponsor"
           >
             <option value="">All sponsors</option>
-            {sponsorValues.map(s => (
-              <option key={s} value={s}>{s}</option>
-            ))}
+            {sponsorValues.current.length > 0 && (
+              <optgroup label="Current council">
+                {sponsorValues.current.map(s => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </optgroup>
+            )}
+            {sponsorValues.former.length > 0 && (
+              <optgroup label="Former members">
+                {sponsorValues.former.map(s => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </optgroup>
+            )}
           </select>
           <select
             className="leg-index-status"

--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -73,22 +73,13 @@ export default function LegislationIndex() {
         setResults(data.results || [])
         setTotalCount(data.total_count ?? 0)
         if (data.status_values) setStatusValues(data.status_values)
+        if (data.classification_values) setClassificationValues(data.classification_values)
         if (data.sponsor_values) setSponsorValues(data.sponsor_values)
-      })
-      .catch(e => setError(e.message))
-      .finally(() => setLoading(false))
-  }, [q, status, sponsor, offset])
         if (data.sort_values) setSortValues(data.sort_values)
       })
       .catch(e => setError(e.message))
       .finally(() => setLoading(false))
-  }, [q, status, introducedAfter, introducedBefore, offset])
-  }, [q, status, sort, offset])
-        if (data.classification_values) setClassificationValues(data.classification_values)
-      })
-      .catch(e => setError(e.message))
-      .finally(() => setLoading(false))
-  }, [q, status, classification, offset])
+  }, [q, status, classification, sponsor, sort, introducedAfter, introducedBefore, offset])
 
   const handleStatusChange = (e) => {
     const next = new URLSearchParams(searchParams)
@@ -98,24 +89,35 @@ export default function LegislationIndex() {
     setSearchParams(next)
   }
 
-  const handleSponsorChange = (e) => {
-    const next = new URLSearchParams(searchParams)
-    if (e.target.value) next.set('sponsor', e.target.value)
-    else next.delete('sponsor')
-  const handleDateChange = (paramName) => (e) => {
-    const next = new URLSearchParams(searchParams)
-    if (e.target.value) next.set(paramName, e.target.value)
-    else next.delete(paramName)
-  const handleSortChange = (e) => {
-    const next = new URLSearchParams(searchParams)
-    // Don't bother carrying the default sort in the URL — it's the
-    // implicit value when the param is absent.
-    if (e.target.value && e.target.value !== 'recent') next.set('sort', e.target.value)
-    else next.delete('sort')
   const handleClassificationChange = (e) => {
     const next = new URLSearchParams(searchParams)
     if (e.target.value) next.set('classification', e.target.value)
     else next.delete('classification')
+    next.delete('offset')
+    setSearchParams(next)
+  }
+
+  const handleSponsorChange = (e) => {
+    const next = new URLSearchParams(searchParams)
+    if (e.target.value) next.set('sponsor', e.target.value)
+    else next.delete('sponsor')
+    next.delete('offset')
+    setSearchParams(next)
+  }
+
+  const handleSortChange = (e) => {
+    const next = new URLSearchParams(searchParams)
+    // Don't carry the default sort in the URL — absent param implies it.
+    if (e.target.value && e.target.value !== 'recent') next.set('sort', e.target.value)
+    else next.delete('sort')
+    next.delete('offset')
+    setSearchParams(next)
+  }
+
+  const handleDateChange = (paramName) => (e) => {
+    const next = new URLSearchParams(searchParams)
+    if (e.target.value) next.set(paramName, e.target.value)
+    else next.delete(paramName)
     next.delete('offset')
     setSearchParams(next)
   }
@@ -191,6 +193,8 @@ export default function LegislationIndex() {
               <option key={s} value={s}>{s}</option>
             ))}
           </select>
+          <select
+            className="leg-index-status"
             value={sort || 'recent'}
             onChange={handleSortChange}
             aria-label="Sort order"

--- a/seattle_app/api_views.py
+++ b/seattle_app/api_views.py
@@ -8,6 +8,7 @@ from functools import reduce
 from operator import or_
 
 from django.conf import settings
+from django.db import connection
 from django.http import JsonResponse
 from django.views.decorators.http import require_GET
 from django.utils import timezone
@@ -149,21 +150,45 @@ def _safe_int(raw, default, max_value=None):
     return v
 
 
-def _list_legislation_sponsors() -> list[str]:
+def _current_council_member_names() -> set[str]:
+    """Set of person names where councilmatic_core_person.is_current is
+    TRUE. Used to bucket the sponsor-filter dropdown into "current
+    council" / "former members" groups. Drops to raw SQL because
+    is_current was added by raw ALTER (see
+    seattle_app/migrations/0001_add_is_current_to_person.py) and isn't
+    on the Person model."""
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            SELECT p.name
+            FROM opencivicdata_person p
+            INNER JOIN councilmatic_core_person cp ON cp.person_id = p.id
+            WHERE cp.is_current = TRUE
+        """)
+        return {row[0] for row in cursor.fetchall() if row[0]}
+
+
+def _list_legislation_sponsors() -> dict[str, list[str]]:
     """All distinct sponsorship names that appear on bills, minus
-    Legistar's '(No Sponsor Required)'-style placeholders, sorted
-    alphabetically. Used for the sponsor-filter dropdown values; the
-    filter itself matches against this same canonical set.
+    Legistar's '(No Sponsor Required)'-style placeholders, bucketed
+    into `current` (still serving) and `former` (no longer on the
+    council) — each group sorted alphabetically. Used for the
+    sponsor-filter dropdown values; the filter validates against the
+    union of both groups.
 
     Note: BillSponsorship.entity_name is a Python property, not a DB
     field — Django can't traverse it in a queryset. The actual column
     is `name`, which equals entity_name for person-typed sponsors
     (which is everyone in our data)."""
     raw = Bill.objects.values_list('sponsorships__name', flat=True).distinct()
-    return sorted({
+    all_sponsors = sorted({
         name.strip() for name in raw
         if name and 'No Sponsor' not in name
     })
+    current_set = _current_council_member_names()
+    return {
+        'current': [n for n in all_sponsors if n in current_set],
+        'former':  [n for n in all_sponsors if n not in current_set],
+    }
 
 
 @require_GET
@@ -233,8 +258,9 @@ def legislation_index(request):
             bills = bills.filter(extras__MatterTypeName=raw)
 
     sponsor_values = _list_legislation_sponsors()
+    valid_sponsors = set(sponsor_values['current']) | set(sponsor_values['former'])
     if sponsor_filter:
-        if sponsor_filter not in sponsor_values:
+        if sponsor_filter not in valid_sponsors:
             bills = bills.none()
         else:
             # distinct() guards against duplicate Bill rows when a bill


### PR DESCRIPTION
## Summary
- Splits the sponsor filter dropdown into two `<optgroup>`s: "Current council" (9) and "Former members" (5), keyed off `councilmatic_core_person.is_current`.
- Backend `_list_legislation_sponsors()` now returns `{current: [...], former: [...]}` instead of a flat list. Filter validation accepts names from either bucket.
- New `_current_council_member_names()` helper uses raw SQL since `is_current` was added by a raw ALTER and isn't on the Person model.

## Test plan
- [x] `/api/legislation/?limit=1` returns `sponsor_values.current` (9) and `sponsor_values.former` (5)
- [x] Filtering by Dan Strauss (current) returns 173 bills; Sara Nelson (former) returns 49
- [x] Bogus sponsor name returns 0 results (validation still rejects)
- [x] Built bundle contains both optgroup labels
- [ ] Visually confirm the divider renders in the dropdown after merge

> Based on `fix/legislation-index-frontend-merge-damage` (PR #51) so it picks up the working frontend bundle. Targets `main`; rebase if PR #51 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)