### PR TITLE
frontend: relabel Home/City Council + collapse meeting-*/mtg-* CSS to evt-*

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -15,9 +15,6 @@ locked decisions, known follow-up threads, and a chronological merge log.
 
 Prioritized to-do. Quick wins flagged with *(quick)*.
 
-**SPA index/search pages** (each likely its own PR; specifics TBD when we pick them up)
-- **CSS class rename — `.meeting-*` → `.evt-*` / `.mtg-*`.** Class names `.meeting-card-*` / `.mtg-detail-*` weren't renamed when MeetingCard/MeetingDetail → EventCard/EventDetail in PR #31; rename if/when those files get more substantive changes.
-
 **Frontend polish & site chrome**
 - **Events: capture EventTime in pupa scraper** (deferred from the events-filter PR). Every event in the DB has `start_date` set to either `07:00:00+00:00` or `08:00:00+00:00` — exactly midnight Pacific (offset depending on DST). Legistar's API exposes `EventDate` and `EventTime` as separate fields, but the scraper only captures the date and stores it as midnight-local. Real meeting times (9:30 AM, 2:00 PM, etc.) aren't in our DB at all. Frontend currently hides the time portion to avoid showing "midnight" everywhere; restore the `hour` / `minute` / `timeZoneName` keys in `EventCard.formatEventDate` and `EventDetail.formatDateTime` once the scraper picks up `EventTime`. Re-scrape required after the fix.
 - **NavBar mobile hamburger** (deferred from PR #33). NavBar currently wraps via `flex-wrap` on narrow screens; if usability becomes a problem, replace with a proper hamburger menu.
@@ -57,6 +54,13 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### Frontend — relabel "This Week" → "Home", "My Council Members" → "City Council"; rename `meeting-*`/`mtg-*` CSS classes — committed 2026-04-28
+Two threads bundled into one PR.
+
+**Label rename.** `This Week` was the homepage's section heading; using it as a NavBar/breadcrumb label conflated "this week's content" with "the homepage" and got stale once the homepage grew beyond a single weekly view. Renamed to `Home` everywhere it appeared as a navigational label (NavBar landed in PR #53, this PR sweeps the breadcrumbs across every index/detail page, the About copy, and `NotFound`'s default-variant link). The actual homepage section heading still reads "This Week" inside `ThisWeek.jsx` — that's content, not nav. Also renamed `My Council Members` → `City Council` in NavBar + breadcrumbs (RepsIndex, RepDetail, RepDistrict) + About feature list — tighter, less first-person, fits in narrow NavBar widths better.
+
+**CSS class rename.** Closes the last of the index-polish leftovers: vestige `.meeting-*` / `.mtg-*` class names from the pre-PR-31 MeetingCard/MeetingDetail era now align with the rest of the events surface under a single `.evt-*` prefix. EventCard.css's mixed `.meeting-card-*` + `.event-card-*` + `.event-type-*` collapsed to `.evt-card-*` + `.evt-type-chip*`; EventDetail.css's `.mtg-detail-*` / `.mtg-doc-*` / `.mtg-att-*` / `.mtg-agenda-*` / `.meeting-badge*` all → `.evt-*`. `.matter-chip*` left as-is (not a vestige). Verified the built CSS surfaces 40+ `.evt-*` classes and zero `.meeting-*` or `.mtg-*` survivors.
 
 ### Frontend — NavBar trim (drop dead hash stubs) — committed 2026-04-28
 Closes the NavBar piece of the index-polish leftovers. NavBar previously carried three hash-anchor stubs (`#this-week`, `#how-it-works`, `#glossary`) pointing at homepage sections that didn't exist (or, in the case of `#this-week`, only worked on the homepage and silently no-op'd from any other route since `Header` renders NavBar everywhere).

--- a/frontend/src/components/About.jsx
+++ b/frontend/src/components/About.jsx
@@ -9,7 +9,7 @@ export default function About() {
     <main className="about-page">
       <div className="about-container">
         <nav className="about-breadcrumb" aria-label="Breadcrumb">
-          <Link to="/">This Week</Link>
+          <Link to="/">Home</Link>
           <span className="about-breadcrumb-sep" aria-hidden="true">/</span>
           <span className="about-breadcrumb-current">About</span>
         </nav>
@@ -38,7 +38,7 @@ export default function About() {
           <h2 className="about-h2">What's on the site</h2>
           <ul className="about-feature-list">
             <li>
-              <Link to="/">This Week</Link> — recent legislation and upcoming
+              <Link to="/">Home</Link> — recent legislation and upcoming
               meetings at a glance.
             </li>
             <li>
@@ -50,7 +50,7 @@ export default function About() {
               briefings with their agendas and packets.
             </li>
             <li>
-              <Link to="/reps">My Council Members</Link> — district map, address
+              <Link to="/reps">City Council</Link> — district map, address
               lookup, and rep profiles.
             </li>
             <li>

--- a/frontend/src/components/EventCard.css
+++ b/frontend/src/components/EventCard.css
@@ -1,4 +1,4 @@
-.meeting-card {
+.evt-card {
   background: #ffffff;
   border: 2px solid #e5e7eb;
   border-radius: 0.5rem;
@@ -6,12 +6,12 @@
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
-.meeting-card:hover {
+.evt-card:hover {
   border-color: #2E3D5B;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07);
 }
 
-.meeting-card-title {
+.evt-card-title {
   font-size: 1rem;
   font-weight: 700;
   color: #1f2937;
@@ -19,23 +19,23 @@
   line-height: 1.4;
 }
 
-.meeting-card-link {
+.evt-card-link {
   color: inherit;
   text-decoration: none;
 }
 
-.meeting-card-link:hover {
+.evt-card-link:hover {
   text-decoration: underline;
 }
 
-.meeting-card-date {
+.evt-card-date {
   font-size: 0.875rem;
   font-weight: 600;
   color: #6b7280;
   margin: 0;
 }
 
-.meeting-card-description {
+.evt-card-description {
   margin: 0.75rem 0 0;
   font-size: 0.9375rem;
   color: #374151;
@@ -44,7 +44,7 @@
 
 /* ── Event type chip ──────────────────────────────────────────── */
 
-.event-card-title-row {
+.evt-card-title-row {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -52,7 +52,7 @@
   margin-bottom: 0.25rem;
 }
 
-.event-type-chip {
+.evt-type-chip {
   display: inline-flex;
   align-items: center;
   padding: 0.125rem 0.5rem;
@@ -64,15 +64,15 @@
   flex-shrink: 0;
 }
 
-.event-type-chip--council   { background: #dbeafe; color: #1e40af; }
-.event-type-chip--briefing  { background: #fef9c3; color: #854d0e; }
-.event-type-chip--committee { background: #e0e7ff; color: #3730a3; }
-.event-type-chip--hearing   { background: #fee2e2; color: #991b1b; }
-.event-type-chip--other     { background: #f3f4f6; color: #374151; }
+.evt-type-chip--council   { background: #dbeafe; color: #1e40af; }
+.evt-type-chip--briefing  { background: #fef9c3; color: #854d0e; }
+.evt-type-chip--committee { background: #e0e7ff; color: #3730a3; }
+.evt-type-chip--hearing   { background: #fee2e2; color: #991b1b; }
+.evt-type-chip--other     { background: #f3f4f6; color: #374151; }
 
 /* ── Cancelled badge ─────────────────────────────────────────── */
 
-.event-card-cancelled-badge {
+.evt-card-cancelled-badge {
   display: inline-flex;
   align-items: center;
   padding: 0.125rem 0.5rem;
@@ -85,19 +85,19 @@
   color: #991b1b;
 }
 
-.meeting-card--cancelled .meeting-card-title,
-.meeting-card--cancelled .meeting-card-date {
+.evt-card--cancelled .evt-card-title,
+.evt-card--cancelled .evt-card-date {
   color: #9ca3af;
 }
 
-.meeting-card--cancelled .meeting-card-title {
+.evt-card--cancelled .evt-card-title {
   text-decoration: line-through;
   text-decoration-thickness: 1px;
 }
 
 /* ── Document link pills ─────────────────────────────────────── */
 
-.event-card-links {
+.evt-card-links {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -106,7 +106,7 @@
   border-top: 1px solid #f3f4f6;
 }
 
-.event-card-link-pill {
+.evt-card-link-pill {
   display: inline-flex;
   align-items: center;
   padding: 0.25rem 0.625rem;
@@ -120,7 +120,7 @@
   transition: background 0.15s, border-color 0.15s;
 }
 
-.event-card-link-pill:hover {
+.evt-card-link-pill:hover {
   background: #e0e7ff;
   border-color: #2E3D5B;
 }

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -2,11 +2,11 @@ import { Link } from 'react-router-dom'
 import './EventCard.css';
 
 const TYPE_CHIP_CLASSES = {
-  Council:   'event-type-chip--council',
-  Briefing:  'event-type-chip--briefing',
-  Committee: 'event-type-chip--committee',
-  Hearing:   'event-type-chip--hearing',
-  Other:     'event-type-chip--other',
+  Council:   'evt-type-chip--council',
+  Briefing:  'evt-type-chip--briefing',
+  Committee: 'evt-type-chip--committee',
+  Hearing:   'evt-type-chip--hearing',
+  Other:     'evt-type-chip--other',
 };
 
 function formatEventDate(isoString) {
@@ -27,7 +27,7 @@ function formatEventDate(isoString) {
 function TypeChip({ type }) {
   if (!type) return null;
   const cls = TYPE_CHIP_CLASSES[type] || TYPE_CHIP_CLASSES.Other;
-  return <span className={`event-type-chip ${cls}`}>{type}</span>;
+  return <span className={`evt-type-chip ${cls}`}>{type}</span>;
 }
 
 function DocLinks({ agendaUrl, packetUrl, minutesUrl, legistarUrl }) {
@@ -39,14 +39,14 @@ function DocLinks({ agendaUrl, packetUrl, minutesUrl, legistarUrl }) {
   ].filter(Boolean);
   if (links.length === 0) return null;
   return (
-    <div className="event-card-links">
+    <div className="evt-card-links">
       {links.map((l, i) => (
         <a
           key={i}
           href={l.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="event-card-link-pill"
+          className="evt-card-link-pill"
           onClick={(e) => e.stopPropagation()}
         >
           {l.label}
@@ -79,14 +79,14 @@ export default function EventCard({ event, backToSearch }) {
   const linkState = backToSearch ? { backToSearch } : undefined;
 
   return (
-    <article className={`meeting-card${cancelled ? ' meeting-card--cancelled' : ''}`}>
+    <article className={`evt-card${cancelled ? ' evt-card--cancelled' : ''}`}>
       <div>
-        <div className="event-card-title-row">
+        <div className="evt-card-title-row">
           <TypeChip type={type} />
-          {cancelled && <span className="event-card-cancelled-badge">Cancelled</span>}
-          <h4 className="meeting-card-title">
+          {cancelled && <span className="evt-card-cancelled-badge">Cancelled</span>}
+          <h4 className="evt-card-title">
             {slug ? (
-              <Link to={`/events/${slug}`} state={linkState} className="meeting-card-link">
+              <Link to={`/events/${slug}`} state={linkState} className="evt-card-link">
                 {name}
               </Link>
             ) : (
@@ -94,10 +94,10 @@ export default function EventCard({ event, backToSearch }) {
             )}
           </h4>
         </div>
-        <p className="meeting-card-date">{formatEventDate(start_date)}</p>
+        <p className="evt-card-date">{formatEventDate(start_date)}</p>
       </div>
       {description && (
-        <p className="meeting-card-description">{description}</p>
+        <p className="evt-card-description">{description}</p>
       )}
       <DocLinks
         agendaUrl={agenda_file_url}

--- a/frontend/src/components/EventDetail.css
+++ b/frontend/src/components/EventDetail.css
@@ -1,19 +1,19 @@
 /* ── Page wrapper ─────────────────────────────────────────────── */
 
-.mtg-detail-page {
+.evt-detail-page {
   background: #f9fafb;
   min-height: 100vh;
   padding: 2rem 1rem 4rem;
 }
 
-.mtg-detail-container {
+.evt-detail-container {
   max-width: 1100px;
   margin: 0 auto;
 }
 
 /* ── Breadcrumb ───────────────────────────────────────────────── */
 
-.mtg-detail-breadcrumb {
+.evt-detail-breadcrumb {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -23,21 +23,21 @@
   margin-bottom: 1.5rem;
 }
 
-.mtg-detail-breadcrumb a {
+.evt-detail-breadcrumb a {
   color: #2E3D5B;
   text-decoration: none;
 }
 
-.mtg-detail-breadcrumb a:hover {
+.evt-detail-breadcrumb a:hover {
   text-decoration: underline;
 }
 
-.mtg-detail-breadcrumb-sep {
+.evt-detail-breadcrumb-sep {
   color: #9ca3af;
   font-weight: 400;
 }
 
-.mtg-detail-breadcrumb-current {
+.evt-detail-breadcrumb-current {
   color: #6b7280;
   font-weight: 500;
   max-width: 30rem;
@@ -48,7 +48,7 @@
 
 /* ── Header ───────────────────────────────────────────────────── */
 
-.mtg-detail-header {
+.evt-detail-header {
   background: #ffffff;
   border: 2px solid #e5e7eb;
   border-radius: 0.75rem;
@@ -56,7 +56,7 @@
   margin-bottom: 1.5rem;
 }
 
-.mtg-detail-title {
+.evt-detail-title {
   font-size: 1.5rem;
   font-weight: 700;
   color: #111827;
@@ -64,7 +64,7 @@
   margin: 0 0 1rem;
 }
 
-.mtg-detail-meta-row {
+.evt-detail-meta-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -73,7 +73,7 @@
 
 /* ── Status badge ─────────────────────────────────────────────── */
 
-.meeting-badge {
+.evt-badge {
   display: inline-block;
   font-size: 0.8125rem;
   font-weight: 700;
@@ -82,24 +82,24 @@
   text-transform: capitalize;
 }
 
-.meeting-badge--confirmed {
+.evt-badge--confirmed {
   background: #dcfce7;
   color: #166534;
 }
 
-.meeting-badge--tentative {
+.evt-badge--tentative {
   background: #fef9c3;
   color: #854d0e;
 }
 
-.meeting-badge--cancelled {
+.evt-badge--cancelled {
   background: #fee2e2;
   color: #991b1b;
 }
 
 /* ── Body layout ──────────────────────────────────────────────── */
 
-.mtg-detail-body {
+.evt-detail-body {
   display: grid;
   grid-template-columns: 280px 1fr;
   gap: 1.5rem;
@@ -107,14 +107,14 @@
 }
 
 @media (max-width: 768px) {
-  .mtg-detail-body {
+  .evt-detail-body {
     grid-template-columns: 1fr;
   }
 }
 
 /* ── Shared section card ──────────────────────────────────────── */
 
-.mtg-detail-section {
+.evt-detail-section {
   background: #ffffff;
   border: 2px solid #e5e7eb;
   border-radius: 0.75rem;
@@ -122,7 +122,7 @@
   margin-bottom: 1rem;
 }
 
-.mtg-detail-section-title {
+.evt-detail-section-title {
   font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -133,7 +133,7 @@
 
 /* ── Details dl ───────────────────────────────────────────────── */
 
-.mtg-detail-dl {
+.evt-detail-dl {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0.5rem 1rem;
@@ -141,42 +141,42 @@
   font-size: 0.875rem;
 }
 
-.mtg-detail-dl dt {
+.evt-detail-dl dt {
   font-weight: 600;
   color: #6b7280;
   white-space: nowrap;
 }
 
-.mtg-detail-dl dd {
+.evt-detail-dl dd {
   color: #111827;
   margin: 0;
 }
 
-.mtg-detail-location {
+.evt-detail-location {
   white-space: pre-line;
   line-height: 1.5;
 }
 
-.mtg-detail-external-link {
+.evt-detail-external-link {
   color: #2E3D5B;
   font-weight: 600;
   text-decoration: none;
 }
 
-.mtg-detail-external-link:hover {
+.evt-detail-external-link:hover {
   text-decoration: underline;
 }
 
 /* ── Main content ─────────────────────────────────────────────── */
 
-.mtg-detail-main {
+.evt-detail-main {
   background: #ffffff;
   border: 2px solid #e5e7eb;
   border-radius: 0.75rem;
   padding: 1.5rem;
 }
 
-.mtg-detail-description {
+.evt-detail-description {
   font-size: 0.9375rem;
   color: #374151;
   line-height: 1.65;
@@ -185,20 +185,20 @@
 
 /* ── States ───────────────────────────────────────────────────── */
 
-.mtg-detail-loading,
-.mtg-detail-error,
-.mtg-detail-empty {
+.evt-detail-loading,
+.evt-detail-error,
+.evt-detail-empty {
   text-align: center;
   padding: 3rem 1rem;
   color: #6b7280;
   font-size: 1rem;
 }
 
-.mtg-detail-error {
+.evt-detail-error {
   color: #dc2626;
 }
 
-.mtg-detail-empty {
+.evt-detail-empty {
   text-align: left;
   padding: 0;
   font-size: 0.9375rem;
@@ -208,14 +208,14 @@
 
 /* ── Agenda & Minutes document buttons ────────────────────────── */
 
-.mtg-docs-row {
+.evt-docs-row {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
   margin-bottom: 1.5rem;
 }
 
-.mtg-doc-btn {
+.evt-doc-btn {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -227,33 +227,33 @@
   transition: opacity 0.15s;
 }
 
-.mtg-doc-btn:hover {
+.evt-doc-btn:hover {
   opacity: 0.85;
   text-decoration: none;
 }
 
-.mtg-doc-btn--agenda {
+.evt-doc-btn--agenda {
   background: #2E3D5B;
   color: #ffffff;
 }
 
-.mtg-doc-btn--packet {
+.evt-doc-btn--packet {
   background: #f0f4ff;
   color: #2E3D5B;
   border: 2px solid #c7d2fe;
 }
 
-.mtg-doc-btn--minutes {
+.evt-doc-btn--minutes {
   background: #ffffff;
   color: #2E3D5B;
   border: 2px solid #2E3D5B;
 }
 
-.mtg-doc-btn-icon {
+.evt-doc-btn-icon {
   font-size: 1rem;
 }
 
-.mtg-doc-btn-status {
+.evt-doc-btn-status {
   font-size: 0.75rem;
   font-weight: 500;
   opacity: 0.75;
@@ -262,7 +262,7 @@
 
 /* ── Agenda items list ────────────────────────────────────────── */
 
-.mtg-agenda-list {
+.evt-agenda-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -271,22 +271,22 @@
   gap: 0;
 }
 
-.mtg-agenda-item {
+.evt-agenda-item {
   padding: 1rem 0;
   border-bottom: 1px solid #f3f4f6;
 }
 
-.mtg-agenda-item:last-child {
+.evt-agenda-item:last-child {
   border-bottom: none;
 }
 
-.mtg-agenda-item-header {
+.evt-agenda-item-header {
   display: flex;
   gap: 0.75rem;
   align-items: flex-start;
 }
 
-.mtg-agenda-seq {
+.evt-agenda-seq {
   font-size: 0.875rem;
   font-weight: 700;
   color: #9ca3af;
@@ -295,35 +295,35 @@
   flex-shrink: 0;
 }
 
-.mtg-agenda-item-body {
+.evt-agenda-item-body {
   flex: 1;
 }
 
-.mtg-agenda-title-row {
+.evt-agenda-title-row {
   display: flex;
   align-items: flex-start;
   gap: 0.5rem;
   margin-bottom: 0.375rem;
 }
 
-.mtg-agenda-title {
+.evt-agenda-title {
   font-size: 0.9375rem;
   font-weight: 600;
   color: #111827;
   line-height: 1.45;
 }
 
-.mtg-agenda-link {
+.evt-agenda-link {
   color: #2E3D5B;
   text-decoration: none;
   font-weight: 600;
 }
 
-.mtg-agenda-link:hover {
+.evt-agenda-link:hover {
   text-decoration: underline;
 }
 
-.mtg-agenda-meta {
+.evt-agenda-meta {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -331,19 +331,19 @@
   margin-bottom: 0.5rem;
 }
 
-.mtg-agenda-file {
+.evt-agenda-file {
   font-size: 0.8125rem;
   font-weight: 700;
   color: #6b7280;
   font-family: monospace;
 }
 
-.mtg-agenda-status {
+.evt-agenda-status {
   font-size: 0.75rem;
   color: #9ca3af;
 }
 
-.mtg-agenda-action {
+.evt-agenda-action {
   font-size: 0.75rem;
   font-weight: 700;
   color: #16a34a;
@@ -387,7 +387,7 @@
 
 /* ── Agenda item attachments ──────────────────────────────────── */
 
-.mtg-att-list {
+.evt-att-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -396,13 +396,13 @@
   gap: 0.375rem;
 }
 
-.mtg-att-item {
+.evt-att-item {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-.mtg-att-icon {
+.evt-att-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -416,23 +416,23 @@
   color: #374151;
 }
 
-.mtg-att-icon--pdf {
+.evt-att-icon--pdf {
   background: #fee2e2;
   color: #991b1b;
 }
 
-.mtg-att-icon--doc {
+.evt-att-icon--doc {
   background: #dbeafe;
   color: #1e40af;
 }
 
-.mtg-att-link {
+.evt-att-link {
   font-size: 0.8125rem;
   color: #2E3D5B;
   font-weight: 600;
   text-decoration: none;
 }
 
-.mtg-att-link:hover {
+.evt-att-link:hover {
   text-decoration: underline;
 }

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -20,12 +20,12 @@ function formatDateTime(isoString) {
 
 function StatusBadge({ status }) {
   const MAP = {
-    confirmed: { label: 'Confirmed', cls: 'meeting-badge--confirmed' },
-    tentative:  { label: 'Tentative', cls: 'meeting-badge--tentative' },
-    cancelled:  { label: 'Cancelled', cls: 'meeting-badge--cancelled' },
+    confirmed: { label: 'Confirmed', cls: 'evt-badge--confirmed' },
+    tentative:  { label: 'Tentative', cls: 'evt-badge--tentative' },
+    cancelled:  { label: 'Cancelled', cls: 'evt-badge--cancelled' },
   }
   const { label, cls } = MAP[status?.toLowerCase()] ?? { label: status, cls: '' }
-  return <span className={`meeting-badge ${cls}`}>{label}</span>
+  return <span className={`evt-badge ${cls}`}>{label}</span>
 }
 
 function MatterChip({ type }) {
@@ -41,33 +41,33 @@ function MatterChip({ type }) {
 }
 
 function DocIcon({ mediaType }) {
-  if (mediaType === 'application/pdf') return <span className="mtg-att-icon mtg-att-icon--pdf">PDF</span>
-  if (mediaType?.includes('word'))     return <span className="mtg-att-icon mtg-att-icon--doc">DOC</span>
-  return <span className="mtg-att-icon">FILE</span>
+  if (mediaType === 'application/pdf') return <span className="evt-att-icon evt-att-icon--pdf">PDF</span>
+  if (mediaType?.includes('word'))     return <span className="evt-att-icon evt-att-icon--doc">DOC</span>
+  return <span className="evt-att-icon">FILE</span>
 }
 
 function AgendaDocButtons({ agendaUrl, agendaStatus, packetUrl, minutesUrl, minutesStatus }) {
   if (!agendaUrl && !packetUrl && !minutesUrl) return null
   return (
-    <div className="mtg-docs-row">
+    <div className="evt-docs-row">
       {agendaUrl && (
-        <a href={agendaUrl} target="_blank" rel="noopener noreferrer" className="mtg-doc-btn mtg-doc-btn--agenda">
-          <span className="mtg-doc-btn-icon">📄</span>
+        <a href={agendaUrl} target="_blank" rel="noopener noreferrer" className="evt-doc-btn evt-doc-btn--agenda">
+          <span className="evt-doc-btn-icon">📄</span>
           Agenda
-          {agendaStatus && <span className="mtg-doc-btn-status">{agendaStatus}</span>}
+          {agendaStatus && <span className="evt-doc-btn-status">{agendaStatus}</span>}
         </a>
       )}
       {packetUrl && (
-        <a href={packetUrl} target="_blank" rel="noopener noreferrer" className="mtg-doc-btn mtg-doc-btn--packet">
-          <span className="mtg-doc-btn-icon">📦</span>
+        <a href={packetUrl} target="_blank" rel="noopener noreferrer" className="evt-doc-btn evt-doc-btn--packet">
+          <span className="evt-doc-btn-icon">📦</span>
           Agenda Packet
         </a>
       )}
       {minutesUrl && (
-        <a href={minutesUrl} target="_blank" rel="noopener noreferrer" className="mtg-doc-btn mtg-doc-btn--minutes">
-          <span className="mtg-doc-btn-icon">📋</span>
+        <a href={minutesUrl} target="_blank" rel="noopener noreferrer" className="evt-doc-btn evt-doc-btn--minutes">
+          <span className="evt-doc-btn-icon">📋</span>
           Minutes
-          {minutesStatus && <span className="mtg-doc-btn-status">{minutesStatus}</span>}
+          {minutesStatus && <span className="evt-doc-btn-status">{minutesStatus}</span>}
         </a>
       )}
     </div>
@@ -78,31 +78,31 @@ function AgendaItemRow({ item, index }) {
   const { description, matter_file, matter_type, matter_status, bill_slug, attachments, action_text } = item
 
   const titleNode = bill_slug ? (
-    <Link to={`/legislation/${bill_slug}`} className="mtg-agenda-link">{description}</Link>
+    <Link to={`/legislation/${bill_slug}`} className="evt-agenda-link">{description}</Link>
   ) : (
     <span>{description}</span>
   )
 
   return (
-    <li className="mtg-agenda-item">
-      <div className="mtg-agenda-item-header">
-        <span className="mtg-agenda-seq">{index + 1}.</span>
-        <div className="mtg-agenda-item-body">
-          <div className="mtg-agenda-title-row">
+    <li className="evt-agenda-item">
+      <div className="evt-agenda-item-header">
+        <span className="evt-agenda-seq">{index + 1}.</span>
+        <div className="evt-agenda-item-body">
+          <div className="evt-agenda-title-row">
             <MatterChip type={matter_type} />
-            <span className="mtg-agenda-title">{titleNode}</span>
+            <span className="evt-agenda-title">{titleNode}</span>
           </div>
-          <div className="mtg-agenda-meta">
-            {matter_file && <span className="mtg-agenda-file">{matter_file}</span>}
-            {matter_status && <span className="mtg-agenda-status">{matter_status}</span>}
-            {action_text && <span className="mtg-agenda-action">{action_text}</span>}
+          <div className="evt-agenda-meta">
+            {matter_file && <span className="evt-agenda-file">{matter_file}</span>}
+            {matter_status && <span className="evt-agenda-status">{matter_status}</span>}
+            {action_text && <span className="evt-agenda-action">{action_text}</span>}
           </div>
           {attachments?.length > 0 && (
-            <ul className="mtg-att-list">
+            <ul className="evt-att-list">
               {attachments.map((att, i) => (
-                <li key={i} className="mtg-att-item">
+                <li key={i} className="evt-att-item">
                   <DocIcon mediaType={att.media_type} />
-                  <a href={att.url} target="_blank" rel="noopener noreferrer" className="mtg-att-link">
+                  <a href={att.url} target="_blank" rel="noopener noreferrer" className="evt-att-link">
                     {att.name}
                   </a>
                 </li>
@@ -151,9 +151,9 @@ export default function EventDetail() {
       .catch(e => { setError(e.message); setLoading(false) })
   }, [slug])
 
-  if (loading)  return <div className="mtg-detail-loading">Loading…</div>
+  if (loading)  return <div className="evt-detail-loading">Loading…</div>
   if (notFound) return <NotFound kind="event" />
-  if (error)    return <div className="mtg-detail-error">Could not load event: {error}</div>
+  if (error)    return <div className="evt-detail-error">Could not load event: {error}</div>
 
   const legistarUrl = event.legistar_url || null
   // Filter out items that have no matter_file and no attachments (pure procedural notes)
@@ -162,22 +162,22 @@ export default function EventDetail() {
   )
 
   return (
-    <main className="mtg-detail-page">
-      <div className="mtg-detail-container">
+    <main className="evt-detail-page">
+      <div className="evt-detail-container">
 
         {/* Breadcrumb */}
-        <nav className="mtg-detail-breadcrumb" aria-label="Breadcrumb">
-          <Link to="/">This Week</Link>
-          <span className="mtg-detail-breadcrumb-sep" aria-hidden="true">/</span>
+        <nav className="evt-detail-breadcrumb" aria-label="Breadcrumb">
+          <Link to="/">Home</Link>
+          <span className="evt-detail-breadcrumb-sep" aria-hidden="true">/</span>
           <Link to={eventsHref}>Events</Link>
-          <span className="mtg-detail-breadcrumb-sep" aria-hidden="true">/</span>
-          <span className="mtg-detail-breadcrumb-current">{event.name}</span>
+          <span className="evt-detail-breadcrumb-sep" aria-hidden="true">/</span>
+          <span className="evt-detail-breadcrumb-current">{event.name}</span>
         </nav>
 
         {/* Header */}
-        <header className="mtg-detail-header">
-          <h1 className="mtg-detail-title">{event.name}</h1>
-          <div className="mtg-detail-meta-row">
+        <header className="evt-detail-header">
+          <h1 className="evt-detail-title">{event.name}</h1>
+          <div className="evt-detail-meta-row">
             <StatusBadge status={event.status} />
           </div>
         </header>
@@ -192,13 +192,13 @@ export default function EventDetail() {
         />
 
         {/* Body */}
-        <div className="mtg-detail-body">
+        <div className="evt-detail-body">
 
           {/* Sidebar: key facts */}
-          <aside className="mtg-detail-sidebar">
-            <section className="mtg-detail-section">
-              <h2 className="mtg-detail-section-title">Details</h2>
-              <dl className="mtg-detail-dl">
+          <aside className="evt-detail-sidebar">
+            <section className="evt-detail-section">
+              <h2 className="evt-detail-section-title">Details</h2>
+              <dl className="evt-detail-dl">
                 <dt>Date &amp; Time</dt>
                 <dd>{formatDateTime(event.start_date)}</dd>
 
@@ -212,7 +212,7 @@ export default function EventDetail() {
                 {event.location && (
                   <>
                     <dt>Location</dt>
-                    <dd className="mtg-detail-location">{event.location}</dd>
+                    <dd className="evt-detail-location">{event.location}</dd>
                   </>
                 )}
 
@@ -224,7 +224,7 @@ export default function EventDetail() {
                         href={legistarUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="mtg-detail-external-link"
+                        className="evt-detail-external-link"
                       >
                         View on Legistar ↗
                       </a>
@@ -236,20 +236,20 @@ export default function EventDetail() {
           </aside>
 
           {/* Main: agenda items */}
-          <section className="mtg-detail-main">
-            <h2 className="mtg-detail-section-title">Agenda Items</h2>
+          <section className="evt-detail-main">
+            <h2 className="evt-detail-section-title">Agenda Items</h2>
             {substantiveItems.length === 0 ? (
-              <p className="mtg-detail-empty">
+              <p className="evt-detail-empty">
                 No agenda items available. Check the{' '}
                 {legistarUrl ? (
-                  <a href={legistarUrl} target="_blank" rel="noopener noreferrer" className="mtg-detail-external-link">
+                  <a href={legistarUrl} target="_blank" rel="noopener noreferrer" className="evt-detail-external-link">
                     Legistar event page
                   </a>
                 ) : 'Legistar'}{' '}
                 for the full agenda.
               </p>
             ) : (
-              <ol className="mtg-agenda-list">
+              <ol className="evt-agenda-list">
                 {substantiveItems.map((item, i) => (
                   <AgendaItemRow key={i} item={item} index={i} />
                 ))}

--- a/frontend/src/components/EventsIndex.jsx
+++ b/frontend/src/components/EventsIndex.jsx
@@ -128,7 +128,7 @@ export default function EventsIndex() {
     <main className="evt-index-page">
       <div className="evt-index-container">
         <nav className="evt-index-breadcrumb" aria-label="Breadcrumb">
-          <Link to="/">This Week</Link>
+          <Link to="/">Home</Link>
           <span className="evt-index-breadcrumb-sep" aria-hidden="true">/</span>
           <span className="evt-index-breadcrumb-current">Events</span>
         </nav>

--- a/frontend/src/components/LegislationDetail.jsx
+++ b/frontend/src/components/LegislationDetail.jsx
@@ -77,7 +77,7 @@ export default function LegislationDetail() {
 
         {/* Breadcrumb */}
         <nav className="leg-detail-breadcrumb" aria-label="Breadcrumb">
-          <Link to="/">This Week</Link>
+          <Link to="/">Home</Link>
           <span className="leg-detail-breadcrumb-sep" aria-hidden="true">/</span>
           <Link to={legislationHref}>Legislation</Link>
           <span className="leg-detail-breadcrumb-sep" aria-hidden="true">/</span>

--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -139,7 +139,7 @@ export default function LegislationIndex() {
     <main className="leg-index-page">
       <div className="leg-index-container">
         <nav className="leg-index-breadcrumb" aria-label="Breadcrumb">
-          <Link to="/">This Week</Link>
+          <Link to="/">Home</Link>
           <span className="leg-index-breadcrumb-sep" aria-hidden="true">/</span>
           <span className="leg-index-breadcrumb-current">Legislation</span>
         </nav>

--- a/frontend/src/components/MuniCodeAppendix.jsx
+++ b/frontend/src/components/MuniCodeAppendix.jsx
@@ -33,7 +33,7 @@ export default function MuniCodeAppendix() {
     <main className="smc-detail-page">
       <div className="smc-detail-container">
         <Breadcrumb crumbs={[
-          { to: '/', label: 'This Week' },
+          { to: '/', label: 'Home' },
           { to: '/municode', label: 'Municipal Code' },
           { to: `/municode/${data.title_number}`, label: `Title ${data.title_number}` },
           { current: `Appendix ${data.label}` },

--- a/frontend/src/components/MuniCodeChapter.jsx
+++ b/frontend/src/components/MuniCodeChapter.jsx
@@ -71,7 +71,7 @@ export default function MuniCodeChapter() {
     <main className="smc-detail-page">
       <div className="smc-detail-container">
         <Breadcrumb crumbs={[
-          { to: '/', label: 'This Week' },
+          { to: '/', label: 'Home' },
           { to: '/municode', label: 'Municipal Code' },
           { to: `/municode/${data.title_number}`, label: `Title ${data.title_number}` },
           { current: `Chapter ${data.chapter_number}` },

--- a/frontend/src/components/MuniCodeIndex.jsx
+++ b/frontend/src/components/MuniCodeIndex.jsx
@@ -134,7 +134,7 @@ export default function MuniCodeIndex() {
     <main className="smc-index-page">
       <div className="smc-index-container">
         <nav className="smc-breadcrumb" aria-label="Breadcrumb">
-          <Link to="/">This Week</Link>
+          <Link to="/">Home</Link>
           <span className="smc-breadcrumb-sep" aria-hidden="true">/</span>
           <span className="smc-breadcrumb-current">Municipal Code</span>
         </nav>

--- a/frontend/src/components/MuniCodeSection.jsx
+++ b/frontend/src/components/MuniCodeSection.jsx
@@ -35,7 +35,7 @@ export default function MuniCodeSection() {
     <main className="smc-detail-page">
       <div className="smc-detail-container">
         <Breadcrumb crumbs={[
-          { to: '/', label: 'This Week' },
+          { to: '/', label: 'Home' },
           { to: '/municode', label: 'Municipal Code' },
           { to: `/municode/${data.title_number}`, label: `Title ${data.title_number}` },
           { to: `/municode/${data.title_number}/${data.chapter_number.split('.').slice(1).join('.')}`,

--- a/frontend/src/components/MuniCodeTitle.jsx
+++ b/frontend/src/components/MuniCodeTitle.jsx
@@ -83,7 +83,7 @@ function TitlePage({ titleNumber }) {
     <main className="smc-detail-page">
       <div className="smc-detail-container">
         <Breadcrumb crumbs={[
-          { to: '/', label: 'This Week' },
+          { to: '/', label: 'Home' },
           { to: '/municode', label: 'Municipal Code' },
           { current: `Title ${data.title_number}` },
         ]} />

--- a/frontend/src/components/NavBar.css
+++ b/frontend/src/components/NavBar.css
@@ -10,6 +10,9 @@
   flex-wrap: wrap;
   gap: 0.25rem;
   justify-content: flex-end;
+  /* Pull the rightmost item away from the viewport edge so the active-item
+     pill background and focus outline aren't crowded against it. */
+  padding-right: 1rem;
 }
 
 .navbar-item {

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -7,7 +7,7 @@ const NAV_ITEMS = [
   { label: 'Events',             to: '/events' },
   { label: 'Legislation',        to: '/legislation' },
   { label: 'Municode',           to: '/municode' },
-  { label: 'My Council Members', to: '/reps' },
+  { label: 'City Council',       to: '/reps' },
 ];
 
 function isActive(pathname, item) {

--- a/frontend/src/components/NotFound.jsx
+++ b/frontend/src/components/NotFound.jsx
@@ -19,7 +19,7 @@ const VARIANTS = {
 const DEFAULT_VARIANT = {
   title: 'Page not found',
   message: "We couldn't find the page you were looking for. The link may be broken, or the page may have moved.",
-  linkLabel: '← Back to This Week',
+  linkLabel: '← Back to Home',
   linkTo: '/',
 }
 

--- a/frontend/src/components/RepDetail.jsx
+++ b/frontend/src/components/RepDetail.jsx
@@ -35,9 +35,9 @@ export default function RepDetail() {
     <main className="rep-detail-page">
       <div className="rep-detail-container">
         <nav className="rep-detail-breadcrumb" aria-label="Breadcrumb">
-          <Link to="/">This Week</Link>
+          <Link to="/">Home</Link>
           <span className="rep-detail-breadcrumb-sep" aria-hidden="true">/</span>
-          <Link to="/reps">My Council Members</Link>
+          <Link to="/reps">City Council</Link>
           <span className="rep-detail-breadcrumb-sep" aria-hidden="true">/</span>
           <span className="rep-detail-breadcrumb-current">{data.name}</span>
         </nav>

--- a/frontend/src/components/RepDistrict.jsx
+++ b/frontend/src/components/RepDistrict.jsx
@@ -38,9 +38,9 @@ export default function RepDistrict() {
     <main className="rep-district-page">
       <div className="rep-district-container">
         <nav className="rep-district-breadcrumb" aria-label="Breadcrumb">
-          <Link to="/">This Week</Link>
+          <Link to="/">Home</Link>
           <span className="rep-district-breadcrumb-sep" aria-hidden="true">/</span>
-          <Link to="/reps">My Council Members</Link>
+          <Link to="/reps">City Council</Link>
           <span className="rep-district-breadcrumb-sep" aria-hidden="true">/</span>
           <span className="rep-district-breadcrumb-current">{data.district.name}</span>
         </nav>

--- a/frontend/src/components/RepsIndex.jsx
+++ b/frontend/src/components/RepsIndex.jsx
@@ -24,9 +24,9 @@ export default function RepsIndex() {
     <main className="reps-page">
       <div className="reps-container">
         <nav className="reps-breadcrumb" aria-label="Breadcrumb">
-          <Link to="/">This Week</Link>
+          <Link to="/">Home</Link>
           <span className="reps-breadcrumb-sep" aria-hidden="true">/</span>
-          <span className="reps-breadcrumb-current">My Council Members</span>
+          <span className="reps-breadcrumb-current">City Council</span>
         </nav>
 
         <header className="reps-header">

--- a/frontend/src/components/Search.jsx
+++ b/frontend/src/components/Search.jsx
@@ -61,7 +61,7 @@ export default function Search() {
     <main className="search-page">
       <div className="search-container">
         <nav className="search-breadcrumb" aria-label="Breadcrumb">
-          <Link to="/">This Week</Link>
+          <Link to="/">Home</Link>
           <span className="search-breadcrumb-sep" aria-hidden="true">/</span>
           <span className="search-breadcrumb-current">Search</span>
         </nav>


### PR DESCRIPTION
## Summary
Two threads bundled.

**Label rename.** `This Week` → `Home` and `My Council Members` → `City Council` everywhere they appeared as navigational labels:
- Breadcrumbs across every index/detail page (Events, Legislation, Municode title/chapter/section/appendix, Reps index/detail/district, Search)
- About page copy (lead breadcrumb + feature list)
- `NotFound` default-variant link (`← Back to This Week` → `← Back to Home`)

`ThisWeek.jsx`'s section heading still reads "This Week" — that's content, not nav.

**CSS class rename.** Closes the last of the index-polish leftovers (PR #53 trimmed NavBar; this finishes the surface). Vestige `.meeting-*` / `.mtg-*` class names from the pre-PR-31 `MeetingCard`/`MeetingDetail` era now align with the rest of the events surface under a single `.evt-*` prefix:
- `.meeting-card*` → `.evt-card*`
- `.event-card-*` / `.event-type-chip` → `.evt-card-*` / `.evt-type-chip` (collapsing the partial PR-31 rename into the same prefix)
- `.meeting-badge*` → `.evt-badge*`
- `.mtg-detail-*` → `.evt-detail-*`
- `.mtg-doc*` → `.evt-doc*`
- `.mtg-att-*` → `.evt-att-*`
- `.mtg-agenda-*` → `.evt-agenda-*`

`.matter-chip*` left untouched (not a vestige). Built CSS now surfaces 40+ `.evt-*` classes and zero `.meeting-*` / `.mtg-*` survivors.

## Test plan
- [x] Bundle drops `meeting-card`, `meeting-badge`, `mtg-detail`, `mtg-agenda`, `mtg-doc`, `mtg-att` from CSS and JS
- [x] Bundle gains `Home` and `City Council` strings; loses `This Week` and `My Council Members` as label strings
- [ ] Visually confirm event cards still render styled (border, hover, status badge, type chip, doc pills, cancelled state)
- [ ] Visually confirm event detail page still renders styled (breadcrumb, header, sidebar, agenda items, attachments, doc buttons)
- [ ] All breadcrumbs across the site read "Home / …"; rep pages read "Home / City Council / …"

🤖 Generated with [Claude Code](https://claude.com/claude-code)