### PR TITLE
events: capture EventTime in pupa scraper + restore frontend time display

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -16,7 +16,7 @@ locked decisions, known follow-up threads, and a chronological merge log.
 Prioritized to-do. Quick wins flagged with *(quick)*.
 
 **Frontend polish & site chrome**
-- **Events: capture EventTime in pupa scraper** (deferred from the events-filter PR). Every event in the DB has `start_date` set to either `07:00:00+00:00` or `08:00:00+00:00` — exactly midnight Pacific (offset depending on DST). Legistar's API exposes `EventDate` and `EventTime` as separate fields, but the scraper only captures the date and stores it as midnight-local. Real meeting times (9:30 AM, 2:00 PM, etc.) aren't in our DB at all. Frontend currently hides the time portion to avoid showing "midnight" everywhere; restore the `hour` / `minute` / `timeZoneName` keys in `EventCard.formatEventDate` and `EventDetail.formatDateTime` once the scraper picks up `EventTime`. Re-scrape required after the fix.
+- **Events: restore time display in `EventCard` / `EventDetail` after re-scrape.** Scraper picks up `EventTime` as of this PR; existing rows still carry midnight until re-scraped. Sequence: merge → run `update_seattle.sh` (or whatever scrape entrypoint is current) → confirm a sample row has a non-midnight `start_date` → restore `hour` / `minute` / `timeZoneName: 'short'` keys in `EventCard.formatEventDate` and `EventDetail.formatDateTime` (both currently `toLocaleDateString`, swap to `toLocaleString` with the time keys).
 - **NavBar mobile hamburger** (deferred from PR #33). NavBar currently wraps via `flex-wrap` on narrow screens; if usability becomes a problem, replace with a proper hamburger menu.
 
 **LLM summaries — wire up the existing infrastructure**
@@ -54,6 +54,13 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### Events — capture `EventTime` in pupa scraper — committed 2026-04-28
+Closes the long-standing midnight-everywhere bug filed during the events-filter PR. Legistar splits a meeting timestamp across two fields: `EventDate` always carries midnight, with the wall-clock time in `EventTime` as a 12-hour string like `"9:30 AM"`. The scraper was reading only `EventDate`, so every row in the DB had `start_date` set to midnight-Pacific (`07:00:00+00:00` or `08:00:00+00:00` depending on DST).
+
+`SeattleEventScraper._parse_event` now strips and parses `EventTime` with `%I:%M %p`, then composes the result onto the date via `event_date.replace(hour=…, minute=…)` before localizing to Pacific. Defensive: missing or unparseable `EventTime` falls back to midnight (current behavior) and logs a warning rather than dropping the event — verified `12:00 AM`, `12:00 PM`, mixed-case, and trailing-whitespace inputs all parse; `"9:30"` (missing `AM/PM`) raises and is caught.
+
+Re-scrape required to populate real times on existing rows. Frontend display restoration is filed as a separate Up-next item to avoid the "site shows 12:00 AM everywhere" window between merge and re-scrape.
 
 ### Frontend — relabel "This Week" → "Home", "My Council Members" → "City Council"; rename `meeting-*`/`mtg-*` CSS classes — committed 2026-04-28
 Two threads bundled into one PR.

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -16,7 +16,6 @@ locked decisions, known follow-up threads, and a chronological merge log.
 Prioritized to-do. Quick wins flagged with *(quick)*.
 
 **Frontend polish & site chrome**
-- **Events: restore time display in `EventCard` / `EventDetail` after re-scrape.** Scraper picks up `EventTime` as of this PR; existing rows still carry midnight until re-scraped. Sequence: merge → run `update_seattle.sh` (or whatever scrape entrypoint is current) → confirm a sample row has a non-midnight `start_date` → restore `hour` / `minute` / `timeZoneName: 'short'` keys in `EventCard.formatEventDate` and `EventDetail.formatDateTime` (both currently `toLocaleDateString`, swap to `toLocaleString` with the time keys).
 - **NavBar mobile hamburger** (deferred from PR #33). NavBar currently wraps via `flex-wrap` on narrow screens; if usability becomes a problem, replace with a proper hamburger menu.
 
 **LLM summaries — wire up the existing infrastructure**
@@ -55,12 +54,12 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 
 ## Done
 
-### Events — capture `EventTime` in pupa scraper — committed 2026-04-28
+### Events — capture `EventTime` in pupa scraper + restore frontend time display — committed 2026-04-28
 Closes the long-standing midnight-everywhere bug filed during the events-filter PR. Legistar splits a meeting timestamp across two fields: `EventDate` always carries midnight, with the wall-clock time in `EventTime` as a 12-hour string like `"9:30 AM"`. The scraper was reading only `EventDate`, so every row in the DB had `start_date` set to midnight-Pacific (`07:00:00+00:00` or `08:00:00+00:00` depending on DST).
 
-`SeattleEventScraper._parse_event` now strips and parses `EventTime` with `%I:%M %p`, then composes the result onto the date via `event_date.replace(hour=…, minute=…)` before localizing to Pacific. Defensive: missing or unparseable `EventTime` falls back to midnight (current behavior) and logs a warning rather than dropping the event — verified `12:00 AM`, `12:00 PM`, mixed-case, and trailing-whitespace inputs all parse; `"9:30"` (missing `AM/PM`) raises and is caught.
+**Backend:** `SeattleEventScraper._parse_event` now strips and parses `EventTime` with `%I:%M %p`, then composes the result onto the date via `event_date.replace(hour=…, minute=…)` before localizing to Pacific. Defensive: missing or unparseable `EventTime` falls back to midnight (current behavior) and logs a warning rather than dropping the event — verified `12:00 AM`, `12:00 PM`, mixed-case, and trailing-whitespace inputs all parse; `"9:30"` (missing `AM/PM`) raises and is caught.
 
-Re-scrape required to populate real times on existing rows. Frontend display restoration is filed as a separate Up-next item to avoid the "site shows 12:00 AM everywhere" window between merge and re-scrape.
+**Frontend:** `EventCard.formatEventDate` and `EventDetail.formatDateTime` swapped from `toLocaleDateString` to `toLocaleString` with `hour: 'numeric'` + `minute: '2-digit'` (and `timeZoneName: 'short'` on the detail page only — too noisy on the card list). Re-scrape will run on the next scheduled scrape (every few hours); existing rows still display midnight until then.
 
 ### Frontend — relabel "This Week" → "Home", "My Council Members" → "City Council"; rename `meeting-*`/`mtg-*` CSS classes — committed 2026-04-28
 Two threads bundled into one PR.

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -12,15 +12,12 @@ const TYPE_CHIP_CLASSES = {
 function formatEventDate(isoString) {
   if (!isoString) return null;
   const d = new Date(isoString);
-  // Time portion deliberately omitted: Legistar's EventTime isn't in
-  // our scrape, so start_date always carries midnight-Pacific. Showing
-  // it would be misleading. Restore hour/minute once the scraper picks
-  // up EventTime — see the "Events: capture EventTime in pupa scraper"
-  // follow-up in WORK_LOG.
-  return d.toLocaleDateString('en-US', {
+  return d.toLocaleString('en-US', {
     weekday: 'short',
     month:   'short',
     day:     'numeric',
+    hour:    'numeric',
+    minute:  '2-digit',
   });
 }
 

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -6,15 +6,14 @@ import './EventDetail.css'
 function formatDateTime(isoString) {
   if (!isoString) return '—'
   const d = new Date(isoString)
-  // Time portion deliberately omitted: Legistar's EventTime isn't in
-  // our scrape, so start_date always carries midnight-Pacific. Restore
-  // hour/minute/timeZoneName once the scraper picks up EventTime — see
-  // the "Events: capture EventTime in pupa scraper" follow-up.
-  return d.toLocaleDateString('en-US', {
+  return d.toLocaleString('en-US', {
     weekday: 'long',
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
   })
 }
 

--- a/seattle/events.py
+++ b/seattle/events.py
@@ -147,9 +147,24 @@ class SeattleEventScraper(Scraper):
             event_id   = api_event["EventId"]
             event_name = api_event.get("EventBodyName", "Meeting")
             event_date_str = api_event["EventDate"]
+            event_time_str = (api_event.get("EventTime") or "").strip()
             location   = api_event.get("EventLocation", "Location TBD")
 
+            # Legistar splits the meeting timestamp across two fields:
+            # EventDate always carries midnight; the wall-clock time lives
+            # in EventTime as a 12-hour string like "9:30 AM". Fall back to
+            # midnight if EventTime is missing or unparseable so a malformed
+            # row doesn't drop the whole event.
             event_date = datetime.datetime.strptime(event_date_str, "%Y-%m-%dT%H:%M:%S")
+            if event_time_str:
+                try:
+                    event_time = datetime.datetime.strptime(event_time_str, "%I:%M %p").time()
+                    event_date = event_date.replace(hour=event_time.hour, minute=event_time.minute)
+                except ValueError:
+                    logger.warning(
+                        f"Could not parse EventTime {event_time_str!r} for event {event_id}; "
+                        f"falling back to midnight"
+                    )
             event_date = TIMEZONE.localize(event_date)
 
             event = Event(


### PR DESCRIPTION
## Summary
Closes the midnight-everywhere bug end-to-end. Legistar exposes `EventDate` and `EventTime` as separate fields — the scraper was reading only the former (which always carries `T00:00:00`), so every event row had `start_date` pinned to midnight-Pacific.

**Backend (`seattle/events.py`)** — `SeattleEventScraper._parse_event` now:
- Reads `EventTime` (e.g. `"9:30 AM"`) and parses it with `%I:%M %p`.
- Composes it onto the date via `event_date.replace(hour=…, minute=…)` before localizing to Pacific.
- Falls back to midnight + a logged warning if `EventTime` is missing or unparseable, so a single bad row doesn't drop the whole event.

**Frontend (`EventCard.jsx`, `EventDetail.jsx`)** — both formatters swap from `toLocaleDateString` to `toLocaleString` with `hour: 'numeric'` + `minute: '2-digit'`. Detail page also gets `timeZoneName: 'short'` (too noisy on the card list).

## Test plan
- [x] Sample formats parse correctly: `"9:30 AM"` → 09:30, `"2:00 PM"` → 14:00, `"12:00 PM"` → 12:00, `"12:00 AM"` → 00:00, lowercase + extra-whitespace variants all OK
- [x] Malformed input (`"9:30"`) raises `ValueError`, gets caught, logs warning, falls back to midnight
- [x] Module parses cleanly (`ast.parse`)
- [x] Frontend bundle builds
- [ ] After merge: scheduled scrape runs in a few hours; confirm `select start_date from opencivicdata_event order by start_date desc limit 5` returns non-midnight times
- [ ] Visually confirm cards/detail show real meeting times (e.g. "Tue, Apr 28, 9:30 AM") once re-scrape lands

## Note
Existing rows display midnight (`12:00 AM`) until the next scheduled scrape repopulates `start_date`. Bundling frontend with backend per the user's call — gap window is short (a few hours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)