### PR TITLE
llm: bootstrap command for few-shot section summary calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@ db.sqlite3
 _data/seattle/*.json
 _data/*.pdf
 
+# Bootstrap iteration outputs — timestamped runs of
+# bootstrap_section_summaries pile up during prompt calibration. The
+# curated final at data/few_shot_section_summaries.json (no timestamp)
+# is checked in.
+data/few_shot_section_summaries_*.json
+
 # JavaScript
 frontend/node_modules/
 frontend/dist/

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -17,11 +17,14 @@ Prioritized to-do. Quick wins flagged with *(quick)*.
 
 **LLM summaries — wire up the existing infrastructure**
 - Models, service module, and prompts already exist (`seattle_app/models.py:47,84` for `MunicipalCodeSection.plain_summary` + `LegislationSummary`; `seattle_app/services/claude_service.py` for `summarize_section`/`summarize_legislation` with full prompts). Nothing runs them and nothing surfaces them to users yet.
-- Three pieces to ship the feature end-to-end:
-  1. **Management command** to batch-summarize sections and bills (e.g., `summarize_smc_sections`, `summarize_legislation`) — handle prompt caching, rate limits, resumability, and skip already-summarized rows.
-  2. **API**: extend `/api/legislation/<slug>/` to include `llm_summary` (summary, impact_analysis, key_changes); add `/api/smc/<section>/` (or similar) for section summaries.
-  3. **Frontend**: render summary in `LegislationDetail` (probably above the action history). Decide whether to surface SMC section summaries — depends on whether there's a user-facing SMC browser yet.
-- Open design questions: which Claude model? per-section caching strategy? batch via Anthropic Batch API to halve cost?
+- Locked decisions: bulk SMC section summaries via **Sonnet 4.6** (Haiku 4.5 is too inconsistent for legal-summary work, Opus is overkill on 8,800+ sections); legislation summaries stay on **Opus 4.7** (structured JSON output, much smaller volume); few-shot bootstrap via **Opus 4.7** (5 curated examples for in-prompt calibration of Sonnet); cost contained via prompt caching on the system prompt + Anthropic **Batch API** (~50% discount, 24h SLA) for the bulk run.
+- Pieces to ship the feature end-to-end:
+  1. **Bootstrap command** to generate gold-standard summaries for the curated 5 archetypes via Opus, output to JSON for human review and curation. *(committed, this PR.)*
+  2. **Curate** Opus output → final 5–8 few-shot examples in `data/few_shot_section_summaries.json` (no timestamp; checked in).
+  3. **Bulk command** `summarize_smc_sections` — reads the curated JSON to build cached few-shot system prompt; submits Batch API jobs over sections without `plain_summary`; resumable via persisted batch IDs; idempotent on re-run.
+  4. **Bills command** `summarize_legislation` — Opus on each bill, structured JSON via existing `output_config`. Smaller volume; streaming or batched is fine.
+  5. **API**: extend `/api/legislation/<slug>/` to include `llm_summary` (summary, impact_analysis, key_changes); add `/api/smc/<section>/` (or extend the existing endpoint) for section summaries.
+  6. **Frontend**: render summary in `LegislationDetail` (probably above the action history) and `MuniCodeSection` (above the full text).
 
 **Parser quality** (post-fix re-parse 2026-04-26 after `93cb885`: 7,435 sections + 1 `TitleAppendix` / 28 `ParseValidationIssue` rows / 234 official + 1 synthesized subchapter / 8 declared-but-empty)
 - **Last 1 missing section** (`23.48.235`). The PDF lacks a clean section heading: section number lives in the running header (`'SEATTLEMIXED 23.48.235'`) and the title `'Upper-Level Setbacks'` appears on its own line after a figure caption (`'Map A for 23.48.235'`). Probably PDF source data issue — defer unless we find a generalizable fix. (`23.50A.160`, `23.76.067`, `25.24.030` all recovered this session — see Done. `12A.14.160` confirmed nonexistent: not in PDF, TOC jumps from `.150` to `.175`, no `ParseValidationIssue` row for it, dropped from the missing list. `5.48.050` recovered via PR #28's `Ord. + §` boundary rule.)
@@ -49,6 +52,13 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### LLM — bootstrap command for few-shot section summary calibration — committed 2026-04-28
+First piece of the LLM-summaries pipeline. `bootstrap_section_summaries` calls Opus on 5 curated SMC sections (one per archetype: definitions, long substantive policy, penalty/enforcement, permit-procedural, LUC use restrictions) and writes the results to a timestamped JSON in `data/`. Outputs are not written to the DB — they're calibration artifacts that exist to teach Sonnet via few-shot prompting on the bulk run.
+
+The 5 curated picks: `8.37.020` (Definitions), `25.05.675` (Specific environmental policies — longest in corpus at 52k chars), `22.170.170` (Violations and Penalties), `23.76.012` (Notice of application), `23.50.012` (Permitted and prohibited uses). Excludes `23.47A.004` (master Table A is the known-gap from the open thread; full text incomplete) and several near-duplicate samples.
+
+Settings: new `CLAUDE_BOOTSTRAP_MODEL` (defaults to `claude-opus-4-7`), and `CLAUDE_CODE_SECTION_MODEL` default flipped from `claude-haiku-4-5` to `claude-sonnet-4-6` after planning concluded Haiku was too inconsistent for the legal-summary task. Timestamped iteration outputs in `data/few_shot_section_summaries_*.json` are gitignored; the curated final at `data/few_shot_section_summaries.json` (no timestamp) gets checked in once locked.
 
 ### Parser — table-aware extraction for permission tables in LUC sections — committed 2026-04-28
 Closes the long-standing "permission tables come out as bare-code soup" bug for sections like `23.47A.004` and `23.54.015`. pdfplumber's word-level reader splits each page at `mid_x = page.width / 2`; a permission table that spans both columns gets its cell values randomly assigned to left/right based on column-relative position, producing strings like `X X X CCU CCU` / `P P P P P` with no row labels attached.

--- a/seattle_app/management/commands/bootstrap_section_summaries.py
+++ b/seattle_app/management/commands/bootstrap_section_summaries.py
@@ -1,0 +1,146 @@
+"""Generate gold-standard SMC section summaries via Opus for few-shot bootstrap.
+
+Calls the bootstrap model (Opus by default) on a small curated set of
+representative sections and writes the outputs to a timestamped JSON file
+under ``data/`` for human review and curation. NOT written to the DB —
+these are calibration artifacts, not production summaries. Once the
+curated set is locked, the bulk Sonnet command will read the chosen
+file to build its cached few-shot system prompt.
+
+Usage:
+    python manage.py bootstrap_section_summaries
+    python manage.py bootstrap_section_summaries --sections 8.37.020 25.05.675
+    python manage.py bootstrap_section_summaries --output-dir data/iter
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone as dt_timezone
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from seattle_app.models import MunicipalCodeSection
+from seattle_app.services.claude_service import ClaudeService
+
+
+# Curated sample picks. Each represents a distinct SMC section archetype
+# the bulk Sonnet run will encounter; together they teach voice + format
+# across the buckets that matter (definitions, long substantive policy,
+# enforcement, permit procedural, use restrictions).
+DEFAULT_SECTIONS = [
+    "8.37.020",   # Definitions archetype
+    "25.05.675",  # Long substantive policy (longest in corpus)
+    "22.170.170", # Penalty/enforcement
+    "23.76.012",  # Permit-procedural
+    "23.50.012",  # LUC permitted/prohibited uses
+]
+
+# Truncated copy of the section input retained alongside each summary for
+# review. Full text is recoverable from the DB by section number; this
+# excerpt is what we'd want to embed in the cached few-shot prompt.
+EXCERPT_CHARS = 1000
+
+
+class Command(BaseCommand):
+    help = (
+        "Generate gold-standard section summaries via the bootstrap model "
+        "(Opus by default) for few-shot calibration. Writes JSON to data/."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--sections",
+            nargs="+",
+            default=None,
+            metavar="SECTION_NUMBER",
+            help=(
+                "Section numbers to summarize. Defaults to the curated set "
+                "of 5 archetypes."
+            ),
+        )
+        parser.add_argument(
+            "--output-dir",
+            default="data",
+            help="Directory to write the timestamped JSON output (default: data/).",
+        )
+        parser.add_argument(
+            "--model",
+            default=None,
+            help=(
+                "Override the bootstrap model. Defaults to "
+                "settings.CLAUDE_BOOTSTRAP_MODEL."
+            ),
+        )
+
+    def handle(self, *args, **opts):
+        section_numbers = opts["sections"] or DEFAULT_SECTIONS
+        output_dir = Path(opts["output_dir"])
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        service = ClaudeService()
+        model = opts["model"] or settings.CLAUDE_BOOTSTRAP_MODEL
+
+        timestamp = datetime.now(dt_timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        output_path = output_dir / f"few_shot_section_summaries_{timestamp}.json"
+
+        self.stdout.write(
+            f"Bootstrapping {len(section_numbers)} section summaries via {model}"
+        )
+        self.stdout.write(f"Writing to {output_path}\n")
+
+        examples: list[dict] = []
+        for section_number in section_numbers:
+            try:
+                section = MunicipalCodeSection.objects.get(
+                    section_number=section_number
+                )
+            except MunicipalCodeSection.DoesNotExist:
+                self.stderr.write(self.style.ERROR(
+                    f"  ! {section_number}: not in DB, skipping"
+                ))
+                continue
+
+            self.stdout.write(self.style.NOTICE(
+                f"\n--- {section_number}: {section.title} "
+                f"({len(section.full_text)} chars) ---"
+            ))
+
+            summary, model_version = service.summarize_code_section(
+                section_number=section.section_number,
+                title=section.title,
+                full_text=section.full_text,
+                model=model,
+            )
+
+            self.stdout.write(summary)
+
+            examples.append({
+                "section_number": section.section_number,
+                "title": section.title,
+                "input_chars": len(section.full_text),
+                "input_excerpt": section.full_text[:EXCERPT_CHARS],
+                "summary": summary,
+                "summary_chars": len(summary),
+                "model_version": model_version,
+                "generated_at": datetime.now(dt_timezone.utc).isoformat(),
+            })
+
+            # Persist incrementally so a partial run isn't lost on later error.
+            output_path.write_text(
+                json.dumps(
+                    {
+                        "generated_at": datetime.now(dt_timezone.utc).isoformat(),
+                        "model": model,
+                        "examples": examples,
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+
+        self.stdout.write(self.style.SUCCESS(
+            f"\nWrote {len(examples)} example(s) to {output_path}"
+        ))

--- a/seattle_app/settings.py
+++ b/seattle_app/settings.py
@@ -188,10 +188,15 @@ OCD_CITY_COUNCIL_NAME = os.getenv("OCD_CITY_COUNCIL_NAME", WAGTAIL_SITE_NAME)
 
 # Claude / Anthropic API for plain-English summaries
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
-# Haiku: cheap, high-volume backfill of municipal code sections.
-CLAUDE_CODE_SECTION_MODEL = os.getenv("CLAUDE_CODE_SECTION_MODEL", "claude-haiku-4-5")
+# Sonnet: balanced cost/quality for the bulk SMC-section summary backfill.
+# Cached few-shot system prompt + Anthropic Batch API keep cost reasonable;
+# Haiku 4.5 was tried and is too inconsistent for legal-summary work.
+CLAUDE_CODE_SECTION_MODEL = os.getenv("CLAUDE_CODE_SECTION_MODEL", "claude-sonnet-4-6")
 # Opus: top-tier analysis of new legislation with structured output.
 CLAUDE_LEGISLATION_MODEL = os.getenv("CLAUDE_LEGISLATION_MODEL", "claude-opus-4-7")
+# Opus: gold-standard summaries of a curated section set; the outputs become
+# few-shot examples for the bulk Sonnet run. Calibration only — not bulk.
+CLAUDE_BOOTSTRAP_MODEL = os.getenv("CLAUDE_BOOTSTRAP_MODEL", "claude-opus-4-7")
 # Sonnet: balanced cost/quality for interactive chat.
 CLAUDE_CHAT_MODEL = os.getenv("CLAUDE_CHAT_MODEL", "claude-sonnet-4-6")
 


### PR DESCRIPTION
## Summary
First piece of the LLM-summaries pipeline. `bootstrap_section_summaries` calls Opus on 5 curated SMC sections (one per archetype: definitions, long substantive policy, penalty/enforcement, permit-procedural, LUC use restrictions) and writes the results to a timestamped JSON in `data/` for human review and curation.

**Not a DB write.** These are calibration artifacts that exist to teach Sonnet via few-shot prompting on the bulk run. Once the curated set is locked, the bulk Sonnet command will read the chosen file (`data/few_shot_section_summaries.json`, no timestamp) to build its cached few-shot system prompt.

### Picks
| # | Section | Title | Archetype |
|---|---|---|---|
| 1 | `8.37.020` | Definitions | Generic definitions list |
| 2 | `25.05.675` | Specific environmental policies | Longest in corpus (52k) — substantive policy |
| 3 | `22.170.170` | Violations and Penalties | Enforcement |
| 4 | `23.76.012` | Notice of application | Permit procedural |
| 5 | `23.50.012` | Permitted and prohibited uses | LUC use restrictions |

Excludes `23.47A.004` (master Table A is the known gap from the open thread; full text incomplete) and several near-duplicate samples within buckets.

### Settings
- New `CLAUDE_BOOTSTRAP_MODEL` env var, default `claude-opus-4-7`.
- `CLAUDE_CODE_SECTION_MODEL` default flipped from `claude-haiku-4-5` → `claude-sonnet-4-6` after planning concluded Haiku is too inconsistent for legal-summary work.
- Timestamped iteration outputs (`data/few_shot_section_summaries_*.json`) are gitignored; only the curated final (no timestamp) gets checked in once locked.

## Test plan
- [x] Both touched modules parse cleanly (`ast.parse`)
- [ ] After merge: `python manage.py bootstrap_section_summaries` → confirms 5 summaries print to stdout and a JSON lands in `data/`
- [ ] Voice / length review on the 5 outputs; iterate prompt + re-run if needed
- [ ] Curate down to 5–8 final shots → save canonical to `data/few_shot_section_summaries.json` and check in

🤖 Generated with [Claude Code](https://claude.com/claude-code)