### PR TITLE
llm: refine section prompt — length, format, voice, admin-rule

### DIFF
--- a/seattle_app/management/commands/bootstrap_section_summaries.py
+++ b/seattle_app/management/commands/bootstrap_section_summaries.py
@@ -112,6 +112,10 @@ class Command(BaseCommand):
                 title=section.title,
                 full_text=section.full_text,
                 model=model,
+                # Cap above the prompt's 400-word target so adaptive thinking
+                # has headroom and we don't truncate mid-sentence on the long
+                # substantive-policy archetype (25.05.675 hit the 1024 default).
+                max_tokens=1500,
             )
 
             self.stdout.write(summary)

--- a/seattle_app/services/claude_service.py
+++ b/seattle_app/services/claude_service.py
@@ -21,9 +21,17 @@ SECTION_SYSTEM_PROMPT = (
     "  - Accurate. Do not add rules that are not in the text.\n"
     "  - Concrete. Use everyday language and concrete examples where useful.\n"
     "  - Neutral. Describe what the law does, not whether it is good or bad.\n"
-    "  - Brief. One to three short paragraphs.\n"
-    "Write in second person where natural ('you must...'). If the section is "
-    "purely administrative (definitions, severability, etc.), say so in one sentence."
+    "  - Brief. 150 to 300 words for short or procedural sections; up to "
+    "400 words for long substantive policy. Hard cap 400 words.\n"
+    "  - Plain prose only. No markdown headers, bullet lists, or bold / "
+    "italic formatting. The section number and title are displayed "
+    "alongside your summary — do not repeat them.\n"
+    "Write in second person ('you must', 'you can') for any rule that "
+    "applies to a person; use third person only for procedural mechanics "
+    "that don't require action from the reader. "
+    "If the section is purely administrative (definitions, severability, "
+    "scope of chapter), write a single sentence noting that and stop — "
+    "do not enumerate individual terms or sub-rules."
 )
 
 


### PR DESCRIPTION
## Summary
First Opus run on the curated 5 produced consistently good *content* but oversized, over-formatted output. Refining the system prompt + bumping bootstrap `max_tokens` so the next iteration is closer to spec.

### What was wrong with v1 output
- **Length 2–3x target.** Prompt said "1-3 short paragraphs"; outputs ran 1.5k–3k chars. Worst was `25.05.675` which **truncated mid-bullet** at the 1024 `max_tokens` default.
- **Markdown formatting we never asked for.** `##` headers repeating the section title, bulleted lists, bold subheadings — the frontend isn't set up to render markdown.
- **The "purely administrative" rule was acknowledged but ignored.** `8.37.020` said "this section is purely administrative" up front, then continued for 5 more paragraphs anyway.
- **Voice inconsistent** between second and third person.

### Prompt revisions
- Explicit word ranges: 150–300 for short/procedural, up to 400 for long substantive policy. Hard cap 400.
- "Plain prose only. No markdown headers, bullet lists, or bold/italic. The section number and title are displayed alongside your summary — do not repeat them."
- Lock voice in second person for any rule that applies to the reader; third person only for pure procedural mechanics.
- Stricter admin rule: "write a single sentence noting that and stop — do not enumerate individual terms or sub-rules."

### Bootstrap command
- `max_tokens` bumped to 1500 — gives adaptive thinking headroom; the prompt does the actual compressing.

## Test plan
- [x] Both touched modules parse cleanly
- [ ] After merge: re-run `python manage.py bootstrap_section_summaries`. Expected: 5 summaries each ≤ ~2.5k chars (target ~1.5k–2k), no markdown, no truncation, second-person voice, `8.37.020` is one sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)