### PR TITLE
llm: align admin rule with the categorize-and-map shape

### DIFF
--- a/seattle_app/services/claude_service.py
+++ b/seattle_app/services/claude_service.py
@@ -30,10 +30,14 @@ SECTION_SYSTEM_PROMPT = (
     "applies to a person; use third person only for procedural mechanics "
     "that don't require action from the reader. "
     "If the section is purely administrative (definitions, severability, "
-    "scope of chapter), write one or two short sentences noting that and "
-    "giving a general sense of what the section covers (e.g. naming the "
-    "kinds of terms a definitions section sets up). Do not explain "
-    "individual terms or sub-rules."
+    "scope of chapter), open by noting that it is administrative, then "
+    "give the reader a navigation map: group what the section covers into "
+    "a few functional categories (e.g. for a long definitions section, "
+    "categories like \"people and businesses involved,\" \"how work is "
+    "arranged,\" \"pay and time,\" \"agencies and officials,\" etc.) and "
+    "name the terms or topics within each category. Do not explain what "
+    "any individual term means. Aim for 150-300 words; small admin "
+    "sections may be shorter."
 )
 
 


### PR DESCRIPTION
## Summary
Tiny prompt alignment. Previous "one or two short sentences" rule didn't match what we actually wanted in practice — Opus's longer categorized output for `8.37.020` (grouping terms into people/businesses, work arrangement, pay/time, conduct, agencies, scope) is more useful for navigation than a 2-sentence summary, but it reads as if the model is breaking the rule. If Sonnet sees a "1-2 sentence" prompt paired with a 2k-char categorized example in the few-shots, it'll be confused which to follow.

Updated prompt now asks directly for the categorize-and-map shape: open with the administrative-section noting, then group what the section covers into functional categories and name the terms/topics within each. Still forbids explaining individual term meanings.

## Test plan
- [x] `claude_service.py` parses cleanly
- [ ] After merge, re-run only `8.37.020` (saves 4 Opus calls): `python manage.py bootstrap_section_summaries --sections 8.37.020`
- [ ] Confirm the new output keeps the categorized-map shape from the previous run with the prompt now matching that intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)