### PR TITLE
llm: include sections with NULL plain_summary in bulk run

### DIFF
--- a/seattle_app/management/commands/summarize_smc_sections.py
+++ b/seattle_app/management/commands/summarize_smc_sections.py
@@ -32,6 +32,7 @@ from typing import Iterable, Optional
 import anthropic
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
 from django.utils import timezone
 
 from seattle_app.models import MunicipalCodeSection
@@ -286,7 +287,10 @@ class Command(BaseCommand):
     ) -> list[MunicipalCodeSection]:
         qs = MunicipalCodeSection.objects.all().order_by("section_number")
         if not force:
-            qs = qs.filter(plain_summary="")
+            # `plain_summary` is `TextField(blank=True)` without `null=True`,
+            # but some legacy rows still have NULL — `field=""` doesn't match
+            # those (NULL = '' is NULL in SQL), so OR isnull to catch both.
+            qs = qs.filter(Q(plain_summary="") | Q(plain_summary__isnull=True))
         if limit is not None:
             qs = qs[:limit]
         return list(qs)


### PR DESCRIPTION
## Summary
Filter fix on the bulk-summarizer's "needs a summary" query. `plain_summary=""` translates to `WHERE plain_summary = ''`, which **doesn't match NULL rows** (`NULL = ''` is `NULL`, falsy). 1,399 of 8,834 sections have `plain_summary IS NULL` (legacy rows from before the field had a default) and were being silently excluded from the batch.

`OR plain_summary__isnull=True` so both empty-string and NULL count as "no summary present".

## Test plan
- [x] Module parses cleanly
- [ ] After merge, re-run `python manage.py summarize_smc_sections --dry-run` — section count should jump from 7,435 → 8,834

🤖 Generated with [Claude Code](https://claude.com/claude-code)