### PR TITLE
llm: bump max_tokens to 4096; richer empty-text error info

### DIFF
--- a/seattle_app/management/commands/summarize_smc_sections.py
+++ b/seattle_app/management/commands/summarize_smc_sections.py
@@ -46,9 +46,14 @@ logger = logging.getLogger(__name__)
 DEFAULT_FEW_SHOTS_PATH = "data/few_shot_section_summaries.json"
 DEFAULT_STATE_PATH = "data/summarize_smc_state.json"
 
-# Per-request output ceiling. Above the prompt's 400-word target so
-# adaptive thinking has headroom and we don't truncate mid-sentence.
-MAX_TOKENS_PER_REQUEST = 1500
+# Per-request token ceiling. With `thinking: adaptive` the budget is
+# shared between the model's thinking blocks and the final output, so
+# we need ample headroom — 1500 was too tight (88 of 7,430 sections in
+# the first bulk run came back with thinking blocks but no text block,
+# i.e. thinking ate all the budget). The prompt still caps the actual
+# summary at ~400 words; this is just so adaptive thinking can't starve
+# the output.
+MAX_TOKENS_PER_REQUEST = 4096
 
 
 def _encode_custom_id(section_number: str) -> str:
@@ -250,7 +255,16 @@ class Command(BaseCommand):
             message = result.result.message
             summary_text = self._extract_text(message)
             if not summary_text:
-                errors.append((section_number, "empty text in response"))
+                # Common cause: `thinking: adaptive` ate the max_tokens
+                # budget so no text block was produced. Capture the
+                # stop_reason and block types so we can tell if it's that
+                # vs. a refusal vs. something else.
+                block_types = sorted({getattr(b, "type", "?") for b in message.content})
+                stop_reason = getattr(message, "stop_reason", "?")
+                errors.append((
+                    section_number,
+                    f"empty text (stop_reason={stop_reason} blocks={block_types})",
+                ))
                 continue
 
             section = sections_by_number.get(section_number)


### PR DESCRIPTION
## Summary
First full bulk run completed cleanly: **7,342 / 7,430 succeeded (98.8%)**. The 88 failures were all "empty text in response" — Anthropic returned a successful response with no `text` block in the content list.

Most likely cause: with `thinking: adaptive` on, `max_tokens` is the *shared* budget for thinking blocks AND the final output. `1500` was too tight on some sections — thinking consumed the entire budget and no text block was produced.

Fixes:
1. **`MAX_TOKENS_PER_REQUEST` 1500 → 4096.** Gives adaptive thinking ample headroom. Prompt still caps actual summary length at ~400 words; this is just so thinking can't starve the output.
2. **Richer empty-text error info.** Captures `stop_reason` and the set of content-block types so future runs can distinguish max_tokens exhaustion (`stop_reason=max_tokens, blocks=['thinking']`) from refusals (`stop_reason=refusal, blocks=['refusal']`) from anything novel.

The 88 affected sections still have `plain_summary=''` (we only write on success), so they'll be picked up automatically by the existing filter on the next run — no `--force` needed.

## Test plan
- [x] Module parses cleanly
- [ ] After merge: re-run `python manage.py summarize_smc_sections`. Expected: ~88 sections in the new batch (the previously-failed ones); all should succeed at the higher max_tokens.
- [ ] If any still fail, the new error detail will tell us why

🤖 Generated with [Claude Code](https://claude.com/claude-code)