### PR TITLE
llm: explicit thinking budget instead of adaptive

### DIFF
--- a/seattle_app/management/commands/summarize_smc_sections.py
+++ b/seattle_app/management/commands/summarize_smc_sections.py
@@ -46,14 +46,16 @@ logger = logging.getLogger(__name__)
 DEFAULT_FEW_SHOTS_PATH = "data/few_shot_section_summaries.json"
 DEFAULT_STATE_PATH = "data/summarize_smc_state.json"
 
-# Per-request token ceiling. With `thinking: adaptive` the budget is
-# shared between the model's thinking blocks and the final output, so
-# we need ample headroom — 1500 was too tight (88 of 7,430 sections in
-# the first bulk run came back with thinking blocks but no text block,
-# i.e. thinking ate all the budget). The prompt still caps the actual
-# summary at ~400 words; this is just so adaptive thinking can't starve
-# the output.
-MAX_TOKENS_PER_REQUEST = 4096
+# Per-request token ceiling and explicit thinking budget. Together
+# these guarantee output room: the model gets at most THINKING_BUDGET
+# tokens of thinking, leaving (MAX_TOKENS - THINKING_BUDGET) for the
+# actual response. We previously used `thinking: adaptive`, but adaptive
+# mode is unbounded — it ate the entire budget on 14 of 88 retried
+# sections in the second run (stop_reason=max_tokens, blocks=['thinking']).
+# Explicit `enabled` mode with a fixed budget makes output starvation
+# impossible by math.
+MAX_TOKENS_PER_REQUEST = 8192
+THINKING_BUDGET_TOKENS = 4096
 
 
 def _encode_custom_id(section_number: str) -> str:
@@ -341,7 +343,10 @@ class Command(BaseCommand):
                 "messages": [{"role": "user", "content": user_content}],
             }
             if _supports_adaptive_thinking(model):
-                params["thinking"] = {"type": "adaptive"}
+                params["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": THINKING_BUDGET_TOKENS,
+                }
             requests.append({
                 "custom_id": _encode_custom_id(section.section_number),
                 "params": params,


### PR DESCRIPTION
## Summary
The second retry run cleared 74 of 88 sections but **14 still failed at `max_tokens=4096`** with the new diagnostic info: `stop_reason=max_tokens, blocks=['thinking']`. That confirms `adaptive` thinking is **unbounded by design** — on complex sections the model can consume the entire `max_tokens` budget for thinking and produce no text block. Bumping `max_tokens` further would just push the problem; adaptive can balloon to whatever ceiling we set.

Math-correct fix: switch from `adaptive` to `enabled` mode with an explicit `budget_tokens`:

```python
params["thinking"] = {
    "type": "enabled",
    "budget_tokens": THINKING_BUDGET_TOKENS,  # 4096
}
# max_tokens=8192
```

Now thinking is hard-capped at 4096 tokens, so output room is always **≥ `max_tokens − budget_tokens` = 4096 tokens**, regardless of section complexity. Output starvation becomes impossible.

## Test plan
- [x] Module parses cleanly
- [ ] After merge: re-run `python manage.py summarize_smc_sections`. Expected: the 14 sections that previously failed under adaptive go through cleanly with explicit budget; no `stop_reason=max_tokens, blocks=['thinking']` errors should appear.

## Note
This change only affects the bulk-summarize command. The chat / legislation paths in `claude_service.py` still use `adaptive` since they're synchronous one-offs where output starvation surfaces as a noticeable empty response, not a 14-section silent failure across a batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)