### PR TITLE
frontend: swap summary and body so body flows directly under header

### DIFF
--- a/frontend/src/components/MuniCodeDetail.css
+++ b/frontend/src/components/MuniCodeDetail.css
@@ -182,7 +182,10 @@
 
 @media (min-width: 1024px) {
   .smc-detail-content--with-summary {
-    grid-template-columns: minmax(20rem, 1fr) minmax(0, 1.4fr);
+    /* Body (the canonical legal text) is the wider, primary column on
+       the left so it flows directly under the section header; summary
+       lives in the narrower right-hand aside. */
+    grid-template-columns: minmax(0, 1.4fr) minmax(20rem, 1fr);
     align-items: start;
   }
 }

--- a/frontend/src/components/MuniCodeSection.jsx
+++ b/frontend/src/components/MuniCodeSection.jsx
@@ -60,6 +60,10 @@ export default function MuniCodeSection() {
         </header>
 
         <div className={`smc-detail-content${data.plain_summary ? ' smc-detail-content--with-summary' : ''}`}>
+          <section className="smc-section-body" aria-label="Section text">
+            <SectionText text={data.full_text} />
+          </section>
+
           {data.plain_summary && (
             <aside className="smc-summary-panel" aria-label="Plain-language summary">
               <h2 className="smc-summary-heading">Plain-language summary</h2>
@@ -71,10 +75,6 @@ export default function MuniCodeSection() {
               )}
             </aside>
           )}
-
-          <section className="smc-section-body" aria-label="Section text">
-            <SectionText text={data.full_text} />
-          </section>
         </div>
 
         {data.source_pdf_page && (


### PR DESCRIPTION
## Summary
Per feedback: full text now sits directly under the section header as the primary, wider left column; summary moves to the narrower right-hand aside. Stack order on mobile (≤1023px) becomes header → body → summary, matching the desktop reading flow.

Markup change: source order in the JSX is body before summary so the grid columns align with reading order, and assistive tech reads body before the supplementary summary.

CSS change: grid template `minmax(20rem, 1fr) minmax(0, 1.4fr)` → `minmax(0, 1.4fr) minmax(20rem, 1fr)` (body wider, summary narrower).

## Test plan
- [x] Bundle builds clean
- [ ] Visual: at ≥1024px, body on left and summary on right; at ≤768px, body stacks above summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)