### PR TITLE
llm: store Anthropic batch_id alongside section summaries

### DIFF
--- a/seattle_app/api_views.py
+++ b/seattle_app/api_views.py
@@ -1138,6 +1138,7 @@ def smc_section_detail(request, section_number):
         'plain_summary':        s.plain_summary or None,
         'summary_model':        s.summary_model or None,
         'summary_generated_at': s.summary_generated_at.isoformat() if s.summary_generated_at else None,
+        'summary_batch_id':     s.summary_batch_id or None,
         'source_pdf_page':      s.source_pdf_page,
         'neighbors':            _section_neighbors_pair(s.section_number),
     })

--- a/seattle_app/management/commands/summarize_smc_sections.py
+++ b/seattle_app/management/commands/summarize_smc_sections.py
@@ -277,8 +277,12 @@ class Command(BaseCommand):
             section.plain_summary = summary_text
             section.summary_model = message.model
             section.summary_generated_at = timezone.now()
+            section.summary_batch_id = batch_id
             section.save(update_fields=[
-                "plain_summary", "summary_model", "summary_generated_at"
+                "plain_summary",
+                "summary_model",
+                "summary_generated_at",
+                "summary_batch_id",
             ])
             success += 1
 

--- a/seattle_app/migrations/0017_municipalcodesection_summary_batch_id.py
+++ b/seattle_app/migrations/0017_municipalcodesection_summary_batch_id.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seattle_app', '0016_codetitle_codechapter'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='municipalcodesection',
+            name='summary_batch_id',
+            field=models.CharField(
+                blank=True,
+                default='',
+                help_text=(
+                    "Anthropic Message Batches ID this summary came from "
+                    "(e.g., 'msgbatch_01PCxUY7AHperTdVueAxmYr7'). Empty for "
+                    "synchronous one-off generations or legacy rows."
+                ),
+                max_length=64,
+            ),
+        ),
+    ]

--- a/seattle_app/models.py
+++ b/seattle_app/models.py
@@ -60,6 +60,15 @@ class MunicipalCodeSection(models.Model):
         blank=True,
         help_text="When the summary was generated"
     )
+    summary_batch_id = models.CharField(
+        max_length=64,
+        blank=True,
+        help_text=(
+            "Anthropic Message Batches ID this summary came from "
+            "(e.g., 'msgbatch_01PCxUY7AHperTdVueAxmYr7'). Empty for "
+            "synchronous one-off generations or legacy rows."
+        ),
+    )
     source_pdf_page = models.IntegerField(
         null=True,
         blank=True,


### PR DESCRIPTION
## Summary
Adds `MunicipalCodeSection.summary_batch_id` (CharField max 64), populated by the bulk `summarize_smc_sections` command when persisting each result. Surfaces in the API on `/api/smc/sections/<n>/`. Empty for legacy rows and synchronous one-off generations.

Pays off whenever a batch goes sideways — "show me everything from `msgbatch_X`" becomes one query instead of triangulating via `summary_generated_at` timestamp clusters (which is what we just had to do for the 67 truncated rows).

### Files
- `models.py` — new `summary_batch_id` field
- `migrations/0017_*.py` — additive migration with `default=''`
- `summarize_smc_sections.py` — `_process_results` writes the field on each save
- `api_views.py` — `smc_section_detail` exposes `summary_batch_id` in the JSON response

## Test plan
- [x] All 4 modules + the migration parse cleanly
- [ ] After merge: `python manage.py migrate` → confirms migration runs without error
- [ ] Then proceed with the 67-row truncation cleanup; re-run picks them up and the new batch's results all get `summary_batch_id` populated
- [ ] `select section_number, summary_batch_id from seattle_app_municipalcodesection where summary_batch_id != '' limit 5` after the cleanup batch should show the new batch ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)