### PR TITLE
frontend: fix broken Legistar bill link host

### DIFF
--- a/frontend/src/components/LegislationDetail.jsx
+++ b/frontend/src/components/LegislationDetail.jsx
@@ -120,7 +120,7 @@ export default function LegislationDetail() {
                     <dt>Legistar</dt>
                     <dd>
                       <a
-                        href={`https://legistar.council.seattle.gov/LegislationDetail.aspx?ID=${bill.legistar_id}`}
+                        href={`https://seattle.legistar.com/LegislationDetail.aspx?ID=${bill.legistar_id}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="leg-detail-external-link"


### PR DESCRIPTION
## Summary
One-line hotfix: `legistar.council.seattle.gov` doesn't resolve. Seattle's actual public Legistar is at `seattle.legistar.com` (which is what the events scraper already uses).

Robust follow-up (separate PR): capture `MatterInSiteURL` from the Legistar API during bill scraping like the events scraper does for `EventInSiteURL`, store via `bill.add_source()`, expose as `legistar_url` on the bill detail JSON. Then we link to the canonical URL with proper GUID rather than a constructed one. That'll need a re-scrape, so it can wait.

## Test plan
- [x] Bundle builds clean
- [ ] After merge, click "View on Legistar" on `/legislation/cb-120909` (or any bill) — should open the matter on `seattle.legistar.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)