### PR TITLE
llm: bill text extractor (Stage 1 of bills pipeline)

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -22,7 +22,11 @@ Prioritized to-do. Quick wins flagged with *(quick)*.
   1. ~~**Bootstrap command** to generate gold-standard summaries for the curated 5 archetypes via Opus, output to JSON for human review and curation.~~ *(shipped PR #60.)*
   2. ~~**Curate** Opus output → final 5 few-shot examples in `data/few_shot_section_summaries.json` (no timestamp; checked in).~~ *(shipped this PR. Three Opus iterations: v1 had unwanted markdown + 2-3x length, v2 fixed both but admin rule produced a 1-sentence dead-end, v3 relaxed admin rule but prompt didn't match the categorize-and-map output we wanted, v4 aligned the prompt to the categorized shape. Final 5: 8.37.020, 22.170.170, 23.50.012, 23.76.012, 25.05.675.)*
   3. ~~**Bulk command** `summarize_smc_sections` — reads `data/few_shot_section_summaries.json` to build cached few-shot system prompt; submits Batch API jobs over sections without `plain_summary`; resumable via persisted batch IDs; idempotent on re-run.~~ *(shipped this PR.)*
-  4. **Bills command** `summarize_legislation` — Opus on each bill, structured JSON via existing `output_config`. Smaller volume; streaming or batched is fine.
+  4. **Bills text extraction → summarization → API → frontend**, staged because the scraper only stores attachment URLs (not text):
+     - 4a. ~~**Bill text extractor** — `seattle_app/services/bill_text_extractor.py` + `BillText` model + `extract_bill_text` management command. Downloads each bill's "Summary and Fiscal Note" (.docx) and "Signed Ordinance/Resolution" (.pdf) attachments, concatenates with section markers, persists to `BillText`. Audit trail in `source_documents` JSON.~~ *(shipped this PR.)*
+     - 4b. **Bills summarizer** `summarize_legislation` — reads `BillText.text`, submits to Anthropic Batch API with Opus, persists to `LegislationSummary` (already exists). Adds `summary_batch_id` for parity with the SMC pattern. `affected_sections` discovered via `extract_ordinance_refs` over the extracted text.
+     - 4c. **API**: extend `/api/legislation/<slug>/` to include `llm_summary` block.
+     - 4d. **Frontend**: render summary in `LegislationDetail` with the same plain-prose paragraph treatment as `MuniCodeSection`.
   5. **API**: ~~add section summary to `/api/smc/sections/<n>/` — already exposed `plain_summary` / `summary_model` / `summary_generated_at` (this PR uses them).~~ Still pending: extend `/api/legislation/<slug>/` to include `llm_summary` once the bills command runs.
   6. ~~**Frontend (SMC)**: render summary in `MuniCodeSection` alongside the full text in a 2-column layout at desktop widths.~~ *(shipped this PR.)* Still pending: render summary in `LegislationDetail` once bills are summarized.
 
@@ -53,6 +57,17 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### LLM — bill text extractor (Stage 1 of bills pipeline) — committed 2026-04-29
+First piece of the bills LLM pipeline. The OCD/pupa scraper only stores attachment URLs (not text), so this stage adds the download + extract layer that the bills summarizer (Stage 2) will read from.
+
+**`seattle_app/services/bill_text_extractor.py`** — pure helper. `extract_text(url, media_type)` downloads and returns plain text; PDF via `pdfplumber.extract_text()`, .docx via `python-docx` (paragraphs + tables in document order). Legacy `.doc` binary is logged + skipped. `combine_bill_documents(documents)` is the picker: categorizes each attachment by its note (`summary` / `signed` / `affidavit` / `other`), extracts the staff summary and signed canonical text, concatenates with `[STAFF SUMMARY AND FISCAL NOTE — …]` and `[SIGNED CANONICAL TEXT — …]` section markers so the LLM can tell staff framing apart from canonical text.
+
+**`seattle_app.BillText` model** — 1:1 with `councilmatic_core.Bill`. Fields: `text` (concatenated extraction), `source_documents` (per-document audit JSON: note/url/media_type/category/char_count/error), `extracted_at` / `last_regenerated`. Migration `0018_billtext`.
+
+**`extract_bill_text` management command** — iterates bills missing `BillText`, prefetches `documents__links`, hands them to the extractor, persists. Idempotent on `BillText` existence; `--force` to re-extract; `--bill <identifier>` for one-off; `--limit N` for smoke runs; `--include-other` to opt non-summary/non-signed docs into the extraction (off by default to keep noise out).
+
+Why staged separately from the summarizer: extractor quality is the riskier unknown. Iterating on the extractor (table-aware, header-aware, OCR fallback if needed) shouldn't force re-running summaries; iterating on prompts shouldn't force re-downloading PDFs. `BillText` is the cache between them.
 
 ### Frontend — render SMC section summaries in a wide 2-column layout — committed 2026-04-29
 First user-visible piece of the LLM-summaries feature. `MuniCodeSection.jsx` now displays the `plain_summary` (already exposed by the API) alongside the full text. At ≥1024px viewports the page splits into a 2-column grid (`minmax(20rem, 1fr)` summary / `minmax(0, 1.4fr)` body); below that, the summary stacks above the body. Sections that don't yet have a summary fall back to the body filling the row — no phantom empty column.

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,8 @@ anthropic>=0.40.0
 # Seattle Municipal Code PDF parsing
 pdfplumber>=0.11.0
 
+# Bill attachment text extraction (Word .docx)
+python-docx>=1.1.0
+
 # Municode HTML scraping (zoning maps, historic landmarks, ordinance table)
 beautifulsoup4>=4.12.0

--- a/seattle_app/management/commands/extract_bill_text.py
+++ b/seattle_app/management/commands/extract_bill_text.py
@@ -1,0 +1,167 @@
+"""Download bill attachment files and extract their plain text into BillText.
+
+Iterates the OCD/pupa Bill rows, finds the substantive attachments
+(staff summary + signed canonical text), downloads them, and persists
+the concatenated text + an audit trail to ``seattle_app.BillText``.
+Idempotent: skips bills that already have a BillText row unless
+``--force`` is set.
+
+Why a backfill command instead of doing this inside the summarizer:
+keeps the LLM pipeline decoupled from extraction quality. If we improve
+the extractor later (table-aware, header-aware, OCR fallback) we can
+re-run this command without re-running summaries; if we improve
+prompts, we re-run summaries without re-downloading every bill's PDFs.
+
+Usage:
+    python manage.py extract_bill_text                # all bills missing BillText
+    python manage.py extract_bill_text --limit 5      # smoke run
+    python manage.py extract_bill_text --force        # re-extract even rows that exist
+    python manage.py extract_bill_text --bill CB-120909  # single bill
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from councilmatic_core.models import Bill
+
+from seattle_app.models import BillText
+from seattle_app.services.bill_text_extractor import combine_bill_documents
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Download bill attachments and cache their extracted text in BillText."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Max number of bills to process (testing).",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Re-extract even bills that already have BillText rows.",
+        )
+        parser.add_argument(
+            "--bill",
+            default=None,
+            help="Bill identifier to process (e.g. 'CB 120909'). Skips all others.",
+        )
+        parser.add_argument(
+            "--include-other",
+            action="store_true",
+            help=(
+                "Also extract documents whose note doesn't match the staff-summary "
+                "or signed-canonical patterns. Off by default to keep noise out."
+            ),
+        )
+
+    def handle(self, *args, **opts):
+        bills = self._target_bills(
+            force=opts["force"],
+            limit=opts["limit"],
+            bill_identifier=opts["bill"],
+        )
+
+        total = len(bills)
+        self.stdout.write(f"Extracting text for {total} bill(s)…")
+
+        wrote = 0
+        skipped_no_docs = 0
+        skipped_no_match = 0
+        for i, bill in enumerate(bills, start=1):
+            self.stdout.write(self.style.NOTICE(
+                f"[{i}/{total}] {bill.identifier} — {len(bill.documents.all())} doc(s)"
+            ))
+            documents = self._serialize_documents(bill)
+            if not documents:
+                self.stdout.write("  ! no documents on this bill, skipping")
+                skipped_no_docs += 1
+                continue
+
+            text, extracted = combine_bill_documents(
+                documents,
+                include_other=opts["include_other"],
+            )
+            if not text:
+                self.stdout.write(self.style.WARNING(
+                    "  ! no usable text extracted (all documents are affidavits/other), skipping"
+                ))
+                skipped_no_match += 1
+                # Still record the audit trail so re-runs don't silently skip again.
+                self._save(bill, text="", extracted=extracted)
+                continue
+
+            self.stdout.write(self.style.SUCCESS(
+                f"  → {len(text):,} chars from "
+                f"{sum(1 for d in extracted if d.text)}/{len(extracted)} documents"
+            ))
+            self._save(bill, text=text, extracted=extracted)
+            wrote += 1
+
+        self.stdout.write(self.style.SUCCESS(
+            f"\nDone. Wrote {wrote} BillText row(s); "
+            f"skipped {skipped_no_docs} (no docs), {skipped_no_match} (no match)."
+        ))
+
+    def _target_bills(
+        self,
+        *,
+        force: bool,
+        limit: Optional[int],
+        bill_identifier: Optional[str],
+    ) -> list[Bill]:
+        qs = Bill.objects.all().order_by("-created_at")
+        if bill_identifier:
+            qs = qs.filter(identifier=bill_identifier)
+        elif not force:
+            # Skip bills whose extracted_text row already exists.
+            qs = qs.filter(extracted_text__isnull=True)
+        qs = qs.prefetch_related("documents__links")
+        if limit is not None:
+            qs = qs[:limit]
+        return list(qs)
+
+    @staticmethod
+    def _serialize_documents(bill: Bill) -> list[dict]:
+        """Flatten BillDocument + BillDocumentLink into the dict shape the
+        extractor expects. Each (document, link) pair becomes one entry —
+        a single document occasionally has multiple format variants."""
+        out: list[dict] = []
+        for doc in bill.documents.all():
+            for link in doc.links.all():
+                out.append({
+                    "note": doc.note,
+                    "url": link.url,
+                    "media_type": link.media_type,
+                })
+        return out
+
+    @staticmethod
+    @transaction.atomic
+    def _save(bill: Bill, *, text: str, extracted) -> None:
+        audit = [
+            {
+                "note": d.note,
+                "url": d.url,
+                "media_type": d.media_type,
+                "category": d.category,
+                "char_count": len(d.text),
+                "error": d.error,
+            }
+            for d in extracted
+        ]
+        BillText.objects.update_or_create(
+            bill=bill,
+            defaults={
+                "text": text,
+                "source_documents": audit,
+            },
+        )

--- a/seattle_app/migrations/0018_billtext.py
+++ b/seattle_app/migrations/0018_billtext.py
@@ -1,0 +1,49 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('councilmatic_core', '0001_initial'),
+        ('seattle_app', '0017_municipalcodesection_summary_batch_id'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BillText',
+            fields=[
+                ('id', models.BigAutoField(
+                    auto_created=True, primary_key=True, serialize=False, verbose_name='ID',
+                )),
+                ('text', models.TextField(
+                    blank=True,
+                    help_text=(
+                        'Concatenated plain text of all chosen attachments, with '
+                        'section markers between sources (staff summary first, then '
+                        'signed canonical text).'
+                    ),
+                )),
+                ('source_documents', models.JSONField(
+                    blank=True,
+                    default=list,
+                    help_text=(
+                        'Per-document audit trail: list of '
+                        '{note, url, media_type, category, char_count, error}.'
+                    ),
+                )),
+                ('extracted_at', models.DateTimeField(auto_now_add=True)),
+                ('last_regenerated', models.DateTimeField(auto_now=True)),
+                ('bill', models.OneToOneField(
+                    help_text='The legislation whose attachments produced this text.',
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='extracted_text',
+                    to='councilmatic_core.bill',
+                )),
+            ],
+            options={
+                'verbose_name': 'Bill Text',
+                'verbose_name_plural': 'Bill Texts',
+            },
+        ),
+    ]

--- a/seattle_app/models.py
+++ b/seattle_app/models.py
@@ -255,6 +255,54 @@ class LegislationSummary(models.Model):
         return f"Summary: {self.bill.identifier}"
 
 
+class BillText(models.Model):
+    """Extracted plain text of a Bill's substantive attachments.
+
+    Seattle bills carry their content in Legistar document attachments
+    — typically a "Summary and Fiscal Note" (.docx) plus, after
+    enactment, a "Signed Ordinance NNNNN" (.pdf). The OCD/pupa Bill row
+    only stores attachment URLs, so this model is the cache of their
+    extracted plain text, keyed 1:1 by Bill. The bill summarizer
+    reads from `text` instead of re-downloading on every LLM call.
+
+    `source_documents` is the audit trail: which attachments were
+    extracted, what category they fell into, what their byte sizes were,
+    and any per-document error message. Re-running extraction overwrites
+    `text` and refreshes the audit trail.
+    """
+    bill = models.OneToOneField(
+        Bill,
+        on_delete=models.CASCADE,
+        related_name="extracted_text",
+        help_text="The legislation whose attachments produced this text.",
+    )
+    text = models.TextField(
+        blank=True,
+        help_text=(
+            "Concatenated plain text of all chosen attachments, with "
+            "section markers between sources (staff summary first, then "
+            "signed canonical text)."
+        ),
+    )
+    source_documents = models.JSONField(
+        default=list,
+        blank=True,
+        help_text=(
+            "Per-document audit trail: list of "
+            "{note, url, media_type, category, char_count, error}."
+        ),
+    )
+    extracted_at = models.DateTimeField(auto_now_add=True)
+    last_regenerated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "Bill Text"
+        verbose_name_plural = "Bill Texts"
+
+    def __str__(self):
+        return f"Text: {self.bill.identifier} ({len(self.text):,} chars)"
+
+
 class SeattleBill(Bill):
     """
     Extend the base Bill model for city-specific functionality.

--- a/seattle_app/services/bill_text_extractor.py
+++ b/seattle_app/services/bill_text_extractor.py
@@ -1,0 +1,252 @@
+"""Download and extract plain text from bill attachments.
+
+Seattle bills carry their substantive content in Legistar document
+attachments (PDF or .docx). The :mod:`Bill` row from the OCD/pupa scrape
+only stores their URLs, not their content; this module downloads them
+on demand and turns them into plain text suitable for LLM
+summarization.
+
+Two well-known attachment kinds — see the ``extract_bill_text``
+management command for the picker that decides which to use:
+
+* "Summary and Fiscal Note" (.docx) — staff plain-language summary plus
+  fiscal analysis. Available from introduction onward.
+* "Signed Ordinance NNNNN" / "Signed Resolution NNNNN" (PDF) — canonical
+  body text. Only present after enactment.
+
+We skip the "Affidavit of Publication" (PDF, legal notice, no bill
+content). Other attachment types fall to ``other`` and are ignored by
+default; callers can opt in with ``include_other=True`` if they want a
+broader sweep.
+"""
+from __future__ import annotations
+
+import io
+import logging
+import re
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import pdfplumber
+import requests
+from docx import Document
+
+logger = logging.getLogger(__name__)
+
+# Conservative HTTP timeout — Legistar's CDN is fast under normal load,
+# but a stuck request shouldn't block a whole batch run.
+_HTTP_TIMEOUT_SECONDS = 30
+
+# How long an extracted blob can grow before we treat it as suspicious
+# and bail out. Bill texts in the wild run 5k–80k chars; anything past
+# this is almost certainly a scan/OCR artifact or wrong document.
+_MAX_TEXT_CHARS = 500_000
+
+# Document categories. Matched against BillDocument.note (case-insensitive,
+# anchored). Order here mirrors the LLM-input concatenation order.
+SUMMARY_NOTE_RE = re.compile(r"^summary\s+and\s+fiscal\s+note\b", re.IGNORECASE)
+# Permissive prefix match: "Signed Ordinance 127119", "Signed Resolution
+# 32168", "Signed Council Bill 12345" all qualify. Risk of catching a
+# stray "Signed [Something Else]" doc is small in practice — Legistar's
+# document templates are predictable.
+SIGNED_NOTE_RE = re.compile(r"^signed\s+", re.IGNORECASE)
+AFFIDAVIT_NOTE_RE = re.compile(r"\baffidavit\b", re.IGNORECASE)
+
+
+# Media-type strings, kept verbose for legibility.
+_PDF_MEDIA = "application/pdf"
+_DOCX_MEDIA = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
+_DOC_MEDIA = "application/msword"  # legacy binary; we don't extract from these
+
+
+@dataclass
+class ExtractedDocument:
+    """Result of extracting one document, including everything we want
+    to record on the BillText row's ``source_documents`` JSON."""
+
+    note: str
+    url: str
+    media_type: str
+    category: str          # 'summary' | 'signed' | 'affidavit' | 'other' | 'unsupported'
+    text: str              # may be empty for skipped/failed docs
+    error: Optional[str] = None
+
+
+def categorize_note(note: str) -> str:
+    """Classify a BillDocument note into our document buckets."""
+    if SUMMARY_NOTE_RE.match(note or ""):
+        return "summary"
+    if SIGNED_NOTE_RE.match(note or ""):
+        return "signed"
+    if AFFIDAVIT_NOTE_RE.search(note or ""):
+        return "affidavit"
+    return "other"
+
+
+def extract_text(url: str, media_type: str) -> str:
+    """Download `url` and return its plain text.
+
+    Returns "" on download failure, unsupported media type (legacy .doc),
+    or extraction failure. Errors are logged at WARNING; callers
+    decide whether to skip the document or surface the error.
+    """
+    try:
+        resp = requests.get(url, timeout=_HTTP_TIMEOUT_SECONDS)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        logger.warning("download failed: %s — %s", url, e)
+        return ""
+
+    blob = resp.content
+    if media_type == _PDF_MEDIA:
+        return _extract_pdf(blob, url)
+    if media_type == _DOCX_MEDIA:
+        return _extract_docx(blob, url)
+    if media_type == _DOC_MEDIA:
+        # Legacy binary .doc — not commonly used by Seattle but possible
+        # for older bills. Skip rather than introduce another dep.
+        logger.warning("skipping legacy .doc (not supported): %s", url)
+        return ""
+    logger.warning("unsupported media type %r for %s", media_type, url)
+    return ""
+
+
+def combine_bill_documents(
+    documents: Iterable[dict],
+    *,
+    include_other: bool = False,
+) -> tuple[str, list[ExtractedDocument]]:
+    """Pick the right documents for a bill, extract each, and return a
+    single concatenated text block plus a per-document audit trail.
+
+    Each document in `documents` is a dict with ``note``, ``url``, and
+    ``media_type`` keys (matching the shape we already serialize in the
+    bill detail API).
+
+    The returned text is structured for LLM consumption:
+
+        [STAFF SUMMARY AND FISCAL NOTE — note text]
+        <body>
+
+        [SIGNED ORDINANCE NNNNN — note text]
+        <body>
+
+    Section markers help the LLM tell staff framing apart from the
+    canonical text. If a category yields no text, its block is omitted.
+    """
+    extracted: list[ExtractedDocument] = []
+    for doc in documents:
+        note = (doc.get("note") or "").strip()
+        url = (doc.get("url") or "").strip()
+        media_type = (doc.get("media_type") or "").strip()
+        category = categorize_note(note)
+
+        if category == "affidavit":
+            # Legal notice; never has bill content. Record it for the
+            # audit trail but don't download.
+            extracted.append(ExtractedDocument(
+                note=note, url=url, media_type=media_type,
+                category=category, text="",
+            ))
+            continue
+        if category == "other" and not include_other:
+            extracted.append(ExtractedDocument(
+                note=note, url=url, media_type=media_type,
+                category=category, text="",
+            ))
+            continue
+        if not url:
+            extracted.append(ExtractedDocument(
+                note=note, url=url, media_type=media_type,
+                category=category, text="",
+                error="missing url",
+            ))
+            continue
+
+        text = extract_text(url, media_type)
+        if len(text) > _MAX_TEXT_CHARS:
+            err = f"extracted text too large ({len(text)} chars), suspicious"
+            logger.warning("%s: %s", url, err)
+            extracted.append(ExtractedDocument(
+                note=note, url=url, media_type=media_type,
+                category=category, text="", error=err,
+            ))
+            continue
+        extracted.append(ExtractedDocument(
+            note=note, url=url, media_type=media_type,
+            category=category, text=text,
+        ))
+
+    parts: list[str] = []
+    # Summary first, then signed, so the LLM reads framing before
+    # canonical text. Multiple matches in a category get all included.
+    for category, header_word in (("summary", "STAFF SUMMARY AND FISCAL NOTE"),
+                                  ("signed", "SIGNED CANONICAL TEXT")):
+        for doc in extracted:
+            if doc.category == category and doc.text:
+                parts.append(f"[{header_word} — {doc.note}]\n{doc.text}")
+    return "\n\n".join(parts), extracted
+
+
+# ---------------------------------------------------------------------------
+# Format-specific extraction
+# ---------------------------------------------------------------------------
+
+def _extract_pdf(blob: bytes, url: str) -> str:
+    """Plain-text extraction from a PDF blob via pdfplumber.
+
+    pdfplumber's ``extract_text()`` is single-column-friendly and
+    suitable for the well-formatted ordinance PDFs Legistar produces.
+    Page-by-page join with single newlines so paragraph reflow is
+    tractable downstream.
+    """
+    try:
+        with pdfplumber.open(io.BytesIO(blob)) as pdf:
+            pages: list[str] = []
+            for page in pdf.pages:
+                text = page.extract_text() or ""
+                if text.strip():
+                    pages.append(text)
+        return "\n".join(pages).strip()
+    except Exception as e:
+        logger.warning("pdfplumber failed on %s: %s", url, e)
+        return ""
+
+
+def _extract_docx(blob: bytes, url: str) -> str:
+    """Plain-text extraction from a .docx blob via python-docx.
+
+    Walks paragraphs in document order and tables row-by-row.
+    Headers/footers are ignored — Seattle's "Summary and Fiscal Note"
+    template puts the actual content in the body, with template
+    cruft in headers/footers we don't want polluting the LLM input.
+    """
+    try:
+        doc = Document(io.BytesIO(blob))
+    except Exception as e:
+        logger.warning("python-docx failed on %s: %s", url, e)
+        return ""
+
+    parts: list[str] = []
+    # Walk the document body. Element order matters because a "Summary
+    # and Fiscal Note" template intersperses headings, paragraphs, and
+    # tables; reading them in document order preserves intent.
+    seen_table_ids: set[int] = set()
+    for para in doc.paragraphs:
+        text = para.text.strip()
+        if text:
+            parts.append(text)
+    for table in doc.tables:
+        # Avoid double-counting tables that appear inside body
+        # paragraphs; python-docx returns top-level tables here.
+        if id(table) in seen_table_ids:
+            continue
+        seen_table_ids.add(id(table))
+        for row in table.rows:
+            cells = [c.text.strip() for c in row.cells]
+            cells = [c for c in cells if c]
+            if cells:
+                parts.append(" | ".join(cells))
+    return "\n".join(parts).strip()


### PR DESCRIPTION
## Summary
First stage of the bills LLM pipeline. The OCD/pupa scraper only stores attachment URLs (not text) — this PR adds the download + extract layer that the bills summarizer (Stage 2) will read from.

### Pieces

**`seattle_app/services/bill_text_extractor.py`** — pure helper.
- `extract_text(url, media_type)`: PDF via `pdfplumber.extract_text()`; `.docx` via `python-docx` (paragraphs + tables in document order; headers/footers ignored — the "Summary and Fiscal Note" template puts content in the body and template cruft in headers/footers). Legacy `.doc` binary is logged + skipped (rare, and avoids another dep).
- `combine_bill_documents(documents)`: the picker. Categorizes each attachment by its `note` field:
  - `summary` — `^Summary and Fiscal Note` (staff plain-language framing)
  - `signed` — `^Signed ` (canonical body text after enactment)
  - `affidavit` — recorded in audit but never downloaded (legal notice, no bill content)
  - `other` — skipped by default; `include_other=True` opts in
- Concatenates extracted text with `[STAFF SUMMARY AND FISCAL NOTE — …]` and `[SIGNED CANONICAL TEXT — …]` markers so the LLM can distinguish framing from canonical text.

**`seattle_app.BillText`** model — 1:1 with `councilmatic_core.Bill`. `text` (concatenated extraction), `source_documents` JSON (per-document audit: note/url/media_type/category/char_count/error), `extracted_at` / `last_regenerated`. Migration `0018_billtext`.

**`extract_bill_text`** management command — iterates bills missing `BillText`, prefetches `documents__links`, hands them to the extractor, persists. Idempotent + flags:
- `--force` re-extract even existing rows
- `--bill <identifier>` one-off
- `--limit N` smoke run
- `--include-other` opt in non-summary/non-signed docs

### Why staged
Extractor quality is the riskier unknown. Iterating on extraction (table-aware, header-aware, OCR fallback) shouldn't force re-running summaries. Iterating on prompts shouldn't force re-downloading PDFs. `BillText` is the cache between them.

## Test plan
- [x] All 4 modules + migration parse cleanly
- [x] `categorize_note` smoke-tested across 8 cases (summary / signed / affidavit / other)
- [ ] After merge: `python manage.py migrate`
- [ ] Smoke-run on 5 bills: `python manage.py extract_bill_text --limit 5` → spot-check `BillText` rows have non-empty `text` and reasonable `source_documents` audit
- [ ] Quality check: `select substring(text, 1, 500) from seattle_app_billtext order by random() limit 1` — eyeball for clean prose vs noise (table cells, headers/footers, etc.)
- [ ] If quality is good, run unbounded for the full 381

🤖 Generated with [Claude Code](https://claude.com/claude-code)