### PR TITLE
infra: drop dead Node stage from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,3 @@
-FROM node:20-slim AS node
-
-COPY ./package.json package.json
-RUN npm install
-
 FROM python:3.12 AS app
 LABEL maintainer "DataMade <info@datamade.us>"
 
@@ -17,13 +12,6 @@ WORKDIR /app
 
 COPY ./requirements.txt /app/requirements.txt
 RUN pip install -r requirements.txt
-
-# Get NodeJS & npm
-COPY --from=node /usr/local/bin /usr/local/bin
-COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
-
-# Get app dependencies
-COPY --from=node node_modules /app/node_modules
 
 COPY . /app
 ENV DJANGO_SECRET_KEY 'foobar'


### PR DESCRIPTION
## Summary
PR #14 retired the legacy webpack pipeline and deleted the top-level `package.json`. The frontend now builds in its own container via `build: ./frontend` in `docker-compose.yml`. But this Dockerfile's Node stage still references the deleted `package.json` and copies node binaries + modules into the Django container that doesn't need them at runtime.

Previous builds worked off cached layers. A fresh `--build` cycle (e.g. when picking up new requirements like `python-docx`) invalidates the cache and fails:

```
target app: failed to solve: failed to compute cache key: failed to calculate checksum
of ref ... "/package.json": not found
```

Remove the Node stage entirely. The Django image is slightly slimmer; nothing in the Django container actually needs Node at runtime.

## Test plan
- [x] Diff inspection: only deletions; no Python or Django logic touched
- [ ] After merge: `docker compose up -d --build` succeeds and the Django container comes up healthy
- [ ] `docker compose exec <web-service> python -c "import docx; print(docx.__version__)"` confirms the python-docx dep from PR #75 is in the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)