### PR TITLE
infra: add wagtail to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,13 @@ dj-database-url>=2.1.0
 # Councilmatic core
 django-councilmatic @ https://github.com/datamade/django-councilmatic/archive/refs/heads/5.x.zip
 
+# Wagtail CMS (used by INSTALLED_APPS for the /cms/ admin). Pinned to
+# the 6.x line for Django 4.2 compatibility — Wagtail 7+ requires
+# Django 5+. Was previously satisfied transitively by an older
+# django-councilmatic; making it explicit so fresh image builds don't
+# fail with ModuleNotFoundError: No module named 'wagtail'.
+wagtail>=6.0,<7
+
 # Legislative data scraping
 pupa>=0.11.0
 scraper-legistar>=0.0.2


### PR DESCRIPTION
## Summary
`INSTALLED_APPS` in `seattle_app/settings.py` references **`wagtail`** plus 11 of its sub-apps (`wagtail.admin`, `wagtail.documents`, `wagtail.images`, `wagtail.snippets`, `wagtail.contrib.forms`, etc. — used for the `/cms/` admin per WORK_LOG conventions). But `wagtail` has never been in `requirements.txt`. The running container picked it up either via a one-off manual install or transitively from an older `django-councilmatic` version. A fresh image build without that cache fails:

```
ModuleNotFoundError: No module named 'wagtail'
```

at the `collectstatic` step (which runs `django.setup()` and chokes on the `INSTALLED_APPS` import).

Pin to the **6.x line** — Django 4.2-compatible (Wagtail 7+ requires Django 5+, and we're on `Django>=4.2,<5`).

## Test plan
- [x] `requirements.txt` parses cleanly
- [ ] After merge: `docker compose up -d --build` succeeds through the `collectstatic` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)