### PR TITLE
llm: extract pre-enactment "Full Text" attachments

### DIFF
--- a/seattle_app/services/bill_text_extractor.py
+++ b/seattle_app/services/bill_text_extractor.py
@@ -50,6 +50,14 @@ SUMMARY_NOTE_RE = re.compile(r"^summary\s+and\s+fiscal\s+note\b", re.IGNORECASE)
 # stray "Signed [Something Else]" doc is small in practice — Legistar's
 # document templates are predictable.
 SIGNED_NOTE_RE = re.compile(r"^signed\s+", re.IGNORECASE)
+# Pre-enactment canonical text. Legistar attaches the ordinance body as
+# "Full Text: CB 121173 v1" (or vN for revised drafts) BEFORE the bill
+# is signed; once signed, it gets renamed and re-attached as "Signed
+# Ordinance NNNNN". Both are canonical bill body for our summarization
+# purposes — categorizing separately just so the audit trail can tell
+# them apart and so future code can prefer signed over draft if both
+# are present.
+FULL_TEXT_NOTE_RE = re.compile(r"^full\s+text\b", re.IGNORECASE)
 AFFIDAVIT_NOTE_RE = re.compile(r"\baffidavit\b", re.IGNORECASE)
 
 
@@ -80,6 +88,8 @@ def categorize_note(note: str) -> str:
         return "summary"
     if SIGNED_NOTE_RE.match(note or ""):
         return "signed"
+    if FULL_TEXT_NOTE_RE.match(note or ""):
+        return "full_text"
     if AFFIDAVIT_NOTE_RE.search(note or ""):
         return "affidavit"
     return "other"
@@ -180,10 +190,17 @@ def combine_bill_documents(
         ))
 
     parts: list[str] = []
-    # Summary first, then signed, so the LLM reads framing before
-    # canonical text. Multiple matches in a category get all included.
-    for category, header_word in (("summary", "STAFF SUMMARY AND FISCAL NOTE"),
-                                  ("signed", "SIGNED CANONICAL TEXT")):
+    # Summary first (staff framing), then canonical text (signed if
+    # available, else the pre-enactment "Full Text" draft). Multiple
+    # matches in a category get all included; for an enacted bill that
+    # also still has a draft attached, the LLM sees both — small cost
+    # in tokens, robust to versions diverging.
+    sections = (
+        ("summary",   "STAFF SUMMARY AND FISCAL NOTE"),
+        ("signed",    "SIGNED CANONICAL TEXT"),
+        ("full_text", "FULL TEXT (PRE-ENACTMENT DRAFT)"),
+    )
+    for category, header_word in sections:
         for doc in extracted:
             if doc.category == category and doc.text:
                 parts.append(f"[{header_word} — {doc.note}]\n{doc.text}")


### PR DESCRIPTION
## Summary
Smoke run from PR #75 surfaced a gap: `CB 121173` had a doc named **`"Full Text: CB 121173 v1"`** (.docx, 7,571 chars) — the actual canonical bill body — being skipped as `category: "other"` because the existing `SIGNED_NOTE_RE` only matches the post-enactment `^Signed Ordinance NNN` naming.

Pre-enactment drafts use `Full Text:` instead. Once a bill is signed, the canonical text gets re-attached as `Signed Ordinance NNN`. Recent CBs (`CB 1212xx`) are mostly unenacted — so without this fix, most of the 381 bills would be summarized from staff framing alone.

### Changes
- New `FULL_TEXT_NOTE_RE = ^full\s+text\b`
- New `full_text` category in `categorize_note`
- New section marker `[FULL TEXT (PRE-ENACTMENT DRAFT) — ...]` in `combine_bill_documents` output, concatenated after summary + signed so the LLM can tell draft from signed canonical text
- Audit trail (`source_documents` JSON) now records `category: "full_text"` so we can query "which bills only had a draft vs which had a signed version"

For enacted bills that retain both `Full Text` and `Signed Ordinance` attachments, the LLM sees both — small token cost, robust to draft/final versions diverging during the legislative process.

## Test plan
- [x] Updated regex smoke-tested across 10 cases including the actual notes from `CB 121173`'s audit trail
- [ ] After merge: `docker compose exec <web-service> python manage.py extract_bill_text --force --bill "CB 121173"` re-extracts; expect `source_documents` to show `category: "full_text"` with non-zero `char_count` for the "Full Text: CB 121173 v1" entry, and the BillText `text` to grow accordingly
- [ ] Then run unbounded for the full 381

🤖 Generated with [Claude Code](https://claude.com/claude-code)