### PR TITLE
llm: raise PDF page cap 300 → 500

### DIFF
--- a/seattle_app/services/bill_text_extractor.py
+++ b/seattle_app/services/bill_text_extractor.py
@@ -63,7 +63,7 @@ _DOWNLOAD_CHUNK_BYTES = 64 * 1024
 # per-page cache flush releases memory, so we hard-skip past this
 # threshold rather than spending minutes (and gigabytes of RSS) on
 # what's almost never the canonical bill body anyway.
-_MAX_PDF_PAGES = 300
+_MAX_PDF_PAGES = 500
 
 # Wall-clock cap on a single PDF parse. SIGALRM-based, so it works
 # inside the Linux Docker container (manage.py runs in the main


### PR DESCRIPTION
## Summary
PR #80 introduced `_MAX_PDF_PAGES = 300` as a defensive bound. In production smoke-testing, bumping to 500 recovered canonical text for 7 of the 8 bills that were dropped at 300, with no memory regression. The remaining bill (CB 120993) is the comprehensive-plan amendment whose signed ordinance is 551 pages — still over the bumped cap, but its staff Summary is plenty for summarization.

500 is well short of pdfplumber's blow-up threshold on pathological PDFs; the 90s SIGALRM timeout from PR #80 is still the ultimate safety net.

## Test plan
- [x] One-line constant change
- [x] User-tested in production: 7 of 8 previously-dropped bills now extract canonical text successfully without memory regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)