### PR TITLE
llm: bills summarization end-to-end (Stages 2 + 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ data/few_shot_section_summaries_*.json
 
 # Bulk-summarizer state (Anthropic batch IDs are per-environment).
 data/summarize_smc_state.json
+data/summarize_legislation_state.json
 
 # JavaScript
 frontend/node_modules/

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -24,7 +24,7 @@ Prioritized to-do. Quick wins flagged with *(quick)*.
   3. ~~**Bulk command** `summarize_smc_sections` — reads `data/few_shot_section_summaries.json` to build cached few-shot system prompt; submits Batch API jobs over sections without `plain_summary`; resumable via persisted batch IDs; idempotent on re-run.~~ *(shipped this PR.)*
   4. **Bills text extraction → summarization → API → frontend**, staged because the scraper only stores attachment URLs (not text):
      - 4a. ~~**Bill text extractor** — `seattle_app/services/bill_text_extractor.py` + `BillText` model + `extract_bill_text` management command. Downloads each bill's "Summary and Fiscal Note" (.docx) and "Signed Ordinance/Resolution" (.pdf) attachments, concatenates with section markers, persists to `BillText`. Audit trail in `source_documents` JSON.~~ *(shipped this PR.)*
-     - 4b. **Bills summarizer** `summarize_legislation` — reads `BillText.text`, submits to Anthropic Batch API with Opus, persists to `LegislationSummary` (already exists). Adds `summary_batch_id` for parity with the SMC pattern. `affected_sections` discovered via `extract_ordinance_refs` over the extracted text.
+     - 4b. ~~**Bills summarizer** `summarize_legislation` — reads `BillText.text`, submits to Anthropic Batch API with Opus, persists to `LegislationSummary` (already exists). Adds `summary_batch_id` for parity with the SMC pattern. `affected_sections` discovered from the LLM's `key_changes[].affected_section` strings (resolved to `MunicipalCodeSection` rows post-response).~~ *(shipped this PR.)*
      - 4c. **API**: extend `/api/legislation/<slug>/` to include `llm_summary` block.
      - 4d. **Frontend**: render summary in `LegislationDetail` with the same plain-prose paragraph treatment as `MuniCodeSection`.
   5. **API**: ~~add section summary to `/api/smc/sections/<n>/` — already exposed `plain_summary` / `summary_model` / `summary_generated_at` (this PR uses them).~~ Still pending: extend `/api/legislation/<slug>/` to include `llm_summary` once the bills command runs.
@@ -57,6 +57,23 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### LLM — `summarize_legislation` command (Stage 2 of bills pipeline) — committed 2026-04-30
+Reads `BillText.text` (populated by Stage 1's `extract_bill_text`), submits each bill to Sonnet 4.6 via the Anthropic Message Batches API, and persists structured results to the existing `LegislationSummary` model. Two-phase like `summarize_smc_sections`: first invocation submits, subsequent invocations poll + process. State at `data/summarize_legislation_state.json` (gitignored).
+
+**Schema**: new `LegislationSummary.summary_batch_id` (CharField max 64) — parity with `MunicipalCodeSection.summary_batch_id` from PR #73. Migration `0019_legislationsummary_summary_batch_id`.
+
+**Per-bill request**: cached `LEGISLATION_SYSTEM_PROMPT` (`cache_control: ephemeral`) + structured JSON output via `output_config.format.json_schema` against the existing `LEGISLATION_OUTPUT_SCHEMA` (summary, impact_analysis, key_changes[]). Explicit thinking budget `{"type": "enabled", "budget_tokens": 8192}` with `max_tokens=16384` — same lesson learned in PR #70 about adaptive thinking starving output. Bill identifiers go through space↔underscore encoding for the `custom_id` field (Anthropic's `^[a-zA-Z0-9_-]{1,64}$` doesn't allow spaces in `"CB 121177"` style identifiers).
+
+**Input cap**: 600k chars per bill, tail-truncated. Opus's 200k-token context fits ~800k chars but we need room for system prompt + thinking + output. p95 of `BillText.text` is 192k chars, so the cap only bites on the very largest bills (e.g., CB 120993 at 871k chars) — and `BillText` concatenates the staff Summary first, so truncating the tail keeps the most useful content.
+
+**Idempotency + affected_sections**: bills with an existing `LegislationSummary` row are skipped unless `--force`. After parsing the LLM's structured response, `key_changes[].affected_section` strings are resolved to `MunicipalCodeSection` rows via `section_number` lookup and saved to the M2M; unmatched section numbers (typos, deprecated sections) are silently dropped from the M2M but remain in the JSON for the audit trail.
+
+**Model selection**: `CLAUDE_LEGISLATION_MODEL` default flipped from `claude-opus-4-7` → `claude-sonnet-4-6`. The original "Opus for legislation" decision was made before we'd tested anything; with the structured JSON output config enforcing format and the input being mostly staff-prepared plain-language summaries, Sonnet is sufficient and ~5x cheaper. New `--model` CLI flag for ad-hoc A/B testing (e.g. `--model claude-opus-4-7 --limit 5` to compare on a smoke batch).
+
+**CLI**: `--limit N`, `--force`, `--dry-run`, `--bill <identifier>`, `--model`, `--state-file`.
+
+**Cost estimate** (with current size distribution: avg 40k chars, p95 192k chars, max 871k chars per bill): **~$17 total** via Sonnet 4.6 + Batch API + cached system prompt for the full 381 bills (~$85 if escalated to Opus).
 
 ### LLM — bill text extractor (Stage 1 of bills pipeline) — committed 2026-04-29
 First piece of the bills LLM pipeline. The OCD/pupa scraper only stores attachment URLs (not text), so this stage adds the download + extract layer that the bills summarizer (Stage 2) will read from.

--- a/seattle_app/management/commands/summarize_legislation.py
+++ b/seattle_app/management/commands/summarize_legislation.py
@@ -1,0 +1,415 @@
+"""Bulk-summarize bills via the Anthropic Message Batches API.
+
+Reads from ``BillText`` (populated by the ``extract_bill_text`` command),
+submits each bill's text to Opus 4.7 with the structured-JSON output
+config from ``claude_service.py``, and persists results to
+``LegislationSummary``. Two-phase like ``summarize_smc_sections``: first
+invocation submits, subsequent invocations poll + process.
+
+Bills without ``BillText`` (extraction failed entirely) are skipped —
+the audit trail in ``BillText.source_documents`` already explains why
+each one was. Bills with empty ``BillText.text`` are also skipped (every
+candidate document was over-cap or malformed).
+
+State lives in ``data/summarize_legislation_state.json`` (gitignored —
+batch IDs are per-environment). Idempotent: bills that already have a
+``LegislationSummary`` are excluded unless ``--force``. The
+``LegislationSummary.summary_batch_id`` field records which batch each
+row came from so future ops can filter by batch.
+
+Usage:
+    python manage.py summarize_legislation
+    python manage.py summarize_legislation --limit 5      # smoke run
+    python manage.py summarize_legislation --force        # re-summarize all
+    python manage.py summarize_legislation --dry-run      # no API calls
+    python manage.py summarize_legislation --bill "CB 121177"
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone as dt_timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+import anthropic
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone
+
+from councilmatic_core.models import Bill
+
+from seattle_app.models import BillText, LegislationSummary, MunicipalCodeSection
+from seattle_app.services.claude_service import (
+    LEGISLATION_OUTPUT_SCHEMA,
+    LEGISLATION_SYSTEM_PROMPT,
+    _supports_adaptive_thinking,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STATE_PATH = "data/summarize_legislation_state.json"
+
+# Per-request token + thinking ceilings. Mirrors the explicit-budget
+# pattern that worked for the SMC bulk summarizer (PR #70): max_tokens
+# accommodates THINKING_BUDGET tokens of thinking plus generous output
+# room. The structured JSON output for legislation is more verbose
+# than a section summary because it has summary + impact_analysis +
+# multi-item key_changes — give it more output room.
+MAX_TOKENS_PER_REQUEST = 16384
+THINKING_BUDGET_TOKENS = 8192
+
+# Hard cap on input chars per bill. Opus 4.7 has a 200k-token context;
+# at ~4 chars/token that's ~800k chars, but we need room for the system
+# prompt (~500 tokens), thinking (8192), and output (~8k). Truncate the
+# tail of BillText.text past 600k chars — the staff Summary is
+# concatenated first, so any oversized bill keeps the most useful part.
+MAX_INPUT_CHARS = 600_000
+
+
+def _encode_custom_id(identifier: str) -> str:
+    """Encode a bill identifier for Anthropic's custom_id pattern.
+
+    Bill identifiers are like "CB 121177" / "Res 32168" / "Ord 12345".
+    Anthropic requires custom_id to match `^[a-zA-Z0-9_-]{1,64}$`, so
+    spaces aren't allowed. Bill identifiers don't contain underscores
+    in practice, so the swap is bidirectional.
+    """
+    return identifier.replace(" ", "_")
+
+
+def _decode_custom_id(custom_id: str) -> str:
+    """Reverse of `_encode_custom_id`."""
+    return custom_id.replace("_", " ")
+
+
+class Command(BaseCommand):
+    help = "Bulk-summarize bills via the Anthropic Message Batches API."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Max number of bills to include in this batch (testing).",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Re-summarize bills that already have a LegislationSummary.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be submitted without calling the API.",
+        )
+        parser.add_argument(
+            "--bill",
+            default=None,
+            help="Single bill identifier to process (e.g. 'CB 121177').",
+        )
+        parser.add_argument(
+            "--model",
+            default=None,
+            help=(
+                "Override settings.CLAUDE_LEGISLATION_MODEL for this run "
+                "(useful for A/B-ing Sonnet vs Opus on a small batch)."
+            ),
+        )
+        parser.add_argument(
+            "--state-file",
+            default=DEFAULT_STATE_PATH,
+            help=f"Path to the persisted batch state (default: {DEFAULT_STATE_PATH}).",
+        )
+
+    def handle(self, *args, **opts):
+        state_path = Path(opts["state_file"])
+        state = self._load_state(state_path)
+
+        if not settings.ANTHROPIC_API_KEY:
+            raise CommandError(
+                "ANTHROPIC_API_KEY is not configured. Set it in your environment "
+                "or Django settings before running."
+            )
+        client = anthropic.Anthropic(api_key=settings.ANTHROPIC_API_KEY)
+
+        # Phase 1: poll any in-flight batch.
+        if state.get("batch_id") and not state.get("processed"):
+            self._poll_and_maybe_process(client, state, state_path)
+            return
+
+        # Phase 2: gather candidates and submit.
+        bills = self._target_bills(
+            force=opts["force"],
+            limit=opts["limit"],
+            bill_identifier=opts["bill"],
+        )
+        if not bills:
+            self.stdout.write(self.style.SUCCESS(
+                "No bills need summaries. Done."
+            ))
+            return
+
+        model = opts["model"] or settings.CLAUDE_LEGISLATION_MODEL
+
+        if opts["dry_run"]:
+            total_chars = sum(len(b.extracted_text.text) for b in bills)
+            self.stdout.write(
+                f"[dry-run] Would submit {len(bills)} bill(s) with model {model}.\n"
+                f"          Total input: {total_chars:,} chars "
+                f"(~{total_chars // 4:,} tokens)\n"
+                f"          First 5: {[b.identifier for b in bills[:5]]}"
+            )
+            return
+
+        self.stdout.write(
+            f"Submitting batch: {len(bills)} bill(s), model {model}."
+        )
+        batch = self._submit_batch(client, bills, model)
+        state.update({
+            "batch_id": batch.id,
+            "submitted_at": datetime.now(dt_timezone.utc).isoformat(),
+            "bill_count": len(bills),
+            "model": model,
+            "processed": False,
+        })
+        for k in ("processed_at", "success_count", "error_count", "errors"):
+            state.pop(k, None)
+        self._save_state(state, state_path)
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Submitted batch {batch.id} with {len(bills)} bill(s).\n"
+            f"Re-run this command to poll status and write results to the DB."
+        ))
+
+    # ------------------------------------------------------------------ #
+    #  Phase 1 — poll + process                                           #
+    # ------------------------------------------------------------------ #
+
+    def _poll_and_maybe_process(self, client, state: dict, state_path: Path):
+        batch_id = state["batch_id"]
+        self.stdout.write(f"Polling batch {batch_id}…")
+        batch = client.messages.batches.retrieve(batch_id)
+        status = getattr(batch, "processing_status", None)
+        self.stdout.write(f"  processing_status: {status}")
+
+        counts = getattr(batch, "request_counts", None)
+        if counts is not None:
+            self.stdout.write(
+                f"  counts: processing={getattr(counts, 'processing', '?')} "
+                f"succeeded={getattr(counts, 'succeeded', '?')} "
+                f"errored={getattr(counts, 'errored', '?')} "
+                f"canceled={getattr(counts, 'canceled', '?')} "
+                f"expired={getattr(counts, 'expired', '?')}"
+            )
+
+        if status != "ended":
+            self.stdout.write(self.style.NOTICE(
+                "Batch not yet ended. Re-run later to retry polling."
+            ))
+            return
+
+        self._process_results(client, batch_id, state, state_path)
+
+    def _process_results(
+        self, client, batch_id: str, state: dict, state_path: Path
+    ):
+        success = 0
+        errors: list[tuple[str, str]] = []
+
+        results = list(client.messages.batches.results(batch_id))
+        identifiers = [_decode_custom_id(r.custom_id) for r in results]
+        bills_by_id = {
+            b.identifier: b
+            for b in Bill.objects.filter(identifier__in=identifiers)
+        }
+
+        for result in results:
+            identifier = _decode_custom_id(result.custom_id)
+            kind = result.result.type
+            if kind != "succeeded":
+                errors.append((identifier, kind))
+                continue
+
+            message = result.result.message
+            text = self._extract_text(message)
+            if not text:
+                block_types = sorted({getattr(b, "type", "?") for b in message.content})
+                stop_reason = getattr(message, "stop_reason", "?")
+                errors.append((
+                    identifier,
+                    f"empty text (stop_reason={stop_reason} blocks={block_types})",
+                ))
+                continue
+
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError as e:
+                errors.append((identifier, f"non-JSON output: {e}"))
+                continue
+
+            bill = bills_by_id.get(identifier)
+            if bill is None:
+                errors.append((identifier, "bill not in DB"))
+                continue
+
+            try:
+                self._upsert_summary(
+                    bill=bill,
+                    data=data,
+                    model_version=message.model,
+                    batch_id=batch_id,
+                )
+                success += 1
+            except Exception as e:
+                logger.exception("upsert failed for %s", identifier)
+                errors.append((identifier, f"upsert failed: {e}"))
+
+        state["processed"] = True
+        state["processed_at"] = datetime.now(dt_timezone.utc).isoformat()
+        state["success_count"] = success
+        state["error_count"] = len(errors)
+        if errors:
+            state["errors"] = errors[:50]
+        self._save_state(state, state_path)
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Processed batch {batch_id}: {success} succeeded, "
+            f"{len(errors)} errored."
+        ))
+        if errors:
+            self.stdout.write(self.style.WARNING(
+                f"First errors: {errors[:5]}"
+            ))
+
+    @staticmethod
+    @transaction.atomic
+    def _upsert_summary(*, bill: Bill, data: dict, model_version: str, batch_id: str) -> None:
+        """Create or update the LegislationSummary row and resolve
+        affected_sections from the LLM-reported section numbers in
+        each key_change.
+        """
+        summary, _ = LegislationSummary.objects.update_or_create(
+            bill=bill,
+            defaults={
+                "summary": data.get("summary", "") or "",
+                "impact_analysis": data.get("impact_analysis", "") or "",
+                "key_changes": data.get("key_changes", []) or [],
+                "model_version": model_version,
+                "summary_batch_id": batch_id,
+            },
+        )
+        # Resolve `key_changes[].affected_section` to MunicipalCodeSection
+        # rows. The LLM output has section numbers as strings; some may
+        # not match any row in our SMC table (typo, deprecated section,
+        # or referencing a non-SMC code), in which case we silently drop
+        # them — the JSON still records what the LLM thought.
+        section_numbers = {
+            (kc.get("affected_section") or "").strip()
+            for kc in (data.get("key_changes") or [])
+        }
+        section_numbers.discard("")
+        if section_numbers:
+            sections = MunicipalCodeSection.objects.filter(
+                section_number__in=section_numbers
+            )
+            summary.affected_sections.set(sections)
+        else:
+            summary.affected_sections.clear()
+
+    # ------------------------------------------------------------------ #
+    #  Phase 2 — submit                                                   #
+    # ------------------------------------------------------------------ #
+
+    def _target_bills(
+        self,
+        *,
+        force: bool,
+        limit: Optional[int],
+        bill_identifier: Optional[str],
+    ) -> list[Bill]:
+        # Only bills with a non-empty BillText are candidates.
+        qs = (
+            Bill.objects
+            .filter(extracted_text__isnull=False)
+            .exclude(extracted_text__text="")
+            .select_related("extracted_text")
+            .order_by("-created_at")
+        )
+        if bill_identifier:
+            qs = qs.filter(identifier=bill_identifier)
+        elif not force:
+            qs = qs.filter(llm_summary__isnull=True)
+        if limit is not None:
+            qs = qs[:limit]
+        return list(qs)
+
+    def _submit_batch(self, client, bills: Iterable[Bill], model: str):
+        requests = []
+        for bill in bills:
+            text = bill.extracted_text.text
+            if len(text) > MAX_INPUT_CHARS:
+                # Tail-truncate. BillText concatenates Summary first,
+                # so the most-useful content is at the head.
+                text = text[:MAX_INPUT_CHARS] + "\n\n[…truncated]"
+
+            user_content = (
+                f"Legislation: {bill.identifier}\n"
+                f"Title: {getattr(bill, 'title', '') or ''}\n\n"
+                f"Full text of the legislation (extracted from attachments):\n{text}"
+            )
+            params = {
+                "model": model,
+                "max_tokens": MAX_TOKENS_PER_REQUEST,
+                "system": [{
+                    "type": "text",
+                    "text": LEGISLATION_SYSTEM_PROMPT,
+                    "cache_control": {"type": "ephemeral"},
+                }],
+                "messages": [{"role": "user", "content": user_content}],
+                "output_config": {
+                    "format": {
+                        "type": "json_schema",
+                        "schema": LEGISLATION_OUTPUT_SCHEMA,
+                    }
+                },
+            }
+            if _supports_adaptive_thinking(model):
+                params["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": THINKING_BUDGET_TOKENS,
+                }
+            requests.append({
+                "custom_id": _encode_custom_id(bill.identifier),
+                "params": params,
+            })
+        return client.messages.batches.create(requests=requests)
+
+    # ------------------------------------------------------------------ #
+    #  Helpers                                                            #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _extract_text(message) -> str:
+        for block in message.content:
+            if block.type == "text":
+                return block.text
+        return ""
+
+    @staticmethod
+    def _load_state(path: Path) -> dict:
+        if not path.exists():
+            return {}
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            raise CommandError(f"Could not parse state file {path}: {e}") from e
+
+    @staticmethod
+    def _save_state(state: dict, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(state, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )

--- a/seattle_app/migrations/0019_legislationsummary_summary_batch_id.py
+++ b/seattle_app/migrations/0019_legislationsummary_summary_batch_id.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('seattle_app', '0018_billtext'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='legislationsummary',
+            name='summary_batch_id',
+            field=models.CharField(
+                blank=True,
+                default='',
+                help_text=(
+                    "Anthropic Message Batches ID this summary came from "
+                    "(e.g., 'msgbatch_01PCxUY7AHperTdVueAxmYr7'). Empty for "
+                    "synchronous one-off generations."
+                ),
+                max_length=64,
+            ),
+        ),
+    ]

--- a/seattle_app/models.py
+++ b/seattle_app/models.py
@@ -240,6 +240,15 @@ class LegislationSummary(models.Model):
         max_length=50,
         help_text="Model used (e.g., 'claude-sonnet-4-20250514')"
     )
+    summary_batch_id = models.CharField(
+        max_length=64,
+        blank=True,
+        help_text=(
+            "Anthropic Message Batches ID this summary came from "
+            "(e.g., 'msgbatch_01PCxUY7AHperTdVueAxmYr7'). Empty for "
+            "synchronous one-off generations."
+        ),
+    )
     generated_at = models.DateTimeField(
         auto_now_add=True
     )

--- a/seattle_app/settings.py
+++ b/seattle_app/settings.py
@@ -192,8 +192,12 @@ ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
 # Cached few-shot system prompt + Anthropic Batch API keep cost reasonable;
 # Haiku 4.5 was tried and is too inconsistent for legal-summary work.
 CLAUDE_CODE_SECTION_MODEL = os.getenv("CLAUDE_CODE_SECTION_MODEL", "claude-sonnet-4-6")
-# Opus: top-tier analysis of new legislation with structured output.
-CLAUDE_LEGISLATION_MODEL = os.getenv("CLAUDE_LEGISLATION_MODEL", "claude-opus-4-7")
+# Sonnet: balanced cost/quality for legislation summarization. The
+# task is mostly reformatting the staff Summary and Fiscal Note into
+# the structured JSON schema (output_config enforces format), so
+# Sonnet is sufficient. Set CLAUDE_LEGISLATION_MODEL=claude-opus-4-7
+# in the environment for higher-quality runs (~5x cost).
+CLAUDE_LEGISLATION_MODEL = os.getenv("CLAUDE_LEGISLATION_MODEL", "claude-sonnet-4-6")
 # Opus: gold-standard summaries of a curated section set; the outputs become
 # few-shot examples for the bulk Sonnet run. Calibration only — not bulk.
 CLAUDE_BOOTSTRAP_MODEL = os.getenv("CLAUDE_BOOTSTRAP_MODEL", "claude-opus-4-7")


### PR DESCRIPTION
## Summary
Bundles **Stage 2** (`summarize_legislation` management command) and **Stage 3** (API + frontend rendering) of the bills LLM pipeline into one PR. After Stage 1 (PR #75 + #78 + #80 + #81) populated `BillText`, this PR closes the loop end-to-end so summaries land in the DB and surface to users.

### Stage 2 — `summarize_legislation` command
Reads `BillText.text`, submits each bill to Sonnet 4.6 via the Anthropic Message Batches API, and persists structured results to the existing `LegislationSummary` model. Two-phase like `summarize_smc_sections`: first invocation submits, subsequent invocations poll + process.

- **Schema**: new `LegislationSummary.summary_batch_id` (CharField max 64) for parity with PR #73's SMC-side field. Migration `0019`.
- **Per-bill request**: cached `LEGISLATION_SYSTEM_PROMPT` + structured JSON via `output_config.format.json_schema`. Explicit `thinking: enabled, budget_tokens: 8192` with `max_tokens=16384` — same lesson from PR #70 about adaptive thinking starving output.
- **Identifier encoding**: bill identifiers like `"CB 121177"` go through space↔underscore for `custom_id` (Anthropic's regex doesn't allow spaces).
- **Input cap**: 600k chars, tail-truncated. p95 of `BillText.text` is 192k chars so the cap only bites on outliers (CB 120993 at 871k); `BillText` concatenates the staff Summary first so truncation keeps the most useful content.
- **Idempotency + affected_sections**: skip bills with existing summary unless `--force`. After parsing the response, `key_changes[].affected_section` strings resolve to `MunicipalCodeSection` rows via `section_number` lookup.
- **Model selection**: `CLAUDE_LEGISLATION_MODEL` default flipped from `claude-opus-4-7` → `claude-sonnet-4-6`. With structured JSON enforcing format and input being mostly staff-prepared plain language, Sonnet is sufficient and ~5x cheaper. New `--model` CLI flag for ad-hoc A/B testing.
- **Smoke-tested**: 5/5 bills succeeded; CB 121173 (One Seattle Plan zoning amendment) produced a strong summary with 11 key_changes and 8 resolved `affected_sections`.

### Stage 3 — API + frontend rendering
- **API**: `/api/legislation/<slug>/` gets a new `llm_summary` block — `summary`, `impact_analysis`, `key_changes` (raw JSON), resolved `affected_sections` ([{section_number, title}, …]), `model_version`, `generated_at`, `summary_batch_id`. `null` when the bill hasn't been summarized yet.
- **Frontend two-card layout** above the existing sidebar/timeline grid in `LegislationDetail`:
  - **Card 1 "Plain-language summary"** — Summary + Impact prose, split on `\n\n` into `<p>` per chunk, distinguished by uppercase `SUMMARY` / `IMPACT` eyebrows.
  - **Card 2 "Key changes"** — numbered `<ol>` with CSS counter; each item has title + description + "Affected: SMC X.Y.Z →" footer. The footer is a real `<Link>` to `/municode/T/C/S` when the section number resolves (validated against the API's `affected_sections` list); unresolved refs (chapter mentions like `23.32`, deprecated sections, typos) fall back to muted monospace text.
- Container `max-width` bumped 1100px → 80rem to match the SMC pattern. Existing `.leg-detail-section` card chrome reused via `.leg-summary-card`.
- Bills without `llm_summary` (operational bills, or anything not yet processed by the batch) skip the cards entirely and render the original layout.

## Test plan
- [x] All Python modules + migration parse cleanly
- [x] Frontend bundle builds; new CSS classes (`leg-key-changes`, `leg-summary-eyebrow`, etc.) shipped
- [x] Smoke batch (5 bills) processed; spot-check on CB 121173 showed strong summary + 8 linked SMC sections
- [ ] After merge: `docker compose up -d --build` + `python manage.py migrate`
- [ ] Visit `/legislation/cb-121173` — should render two summary cards above the existing sidebar
- [ ] Visit a bill without summary (anything not in the smoke batch) — should render unchanged from before this PR
- [ ] Click an "Affected: SMC X.Y.Z →" link — should land on the corresponding municode section page
- [ ] If smoke checks pass, fire the unbounded run for the full 381

## Cost
~$17 for Sonnet 4.6 + Batch API + cached system prompt across 381 bills (~$85 if escalated to Opus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)