### PR TITLE
frontend: action history left of key changes when both are present

### DIFF
--- a/frontend/src/components/LegislationDetail.css
+++ b/frontend/src/components/LegislationDetail.css
@@ -126,6 +126,32 @@
   min-width: 0;
 }
 
+/* When the bill has BOTH a Plain-language summary AND Key changes,
+   switch the right column to a 2-column sub-grid at ≥1024px:
+   summary spans the top row, Action history sits bottom-left and
+   Key changes bottom-right. Falls back to the flex stack on narrower
+   viewports or when only one of the two cards is present (e.g.
+   operational bills with summary but no key_changes). */
+@media (min-width: 1024px) {
+  .leg-detail-main-column--has-summary.leg-detail-main-column--has-changes {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      "summary summary"
+      "history changes";
+    align-items: start;
+  }
+  .leg-detail-main-column--has-summary.leg-detail-main-column--has-changes .leg-card-summary {
+    grid-area: summary;
+  }
+  .leg-detail-main-column--has-summary.leg-detail-main-column--has-changes .leg-card-changes {
+    grid-area: changes;
+  }
+  .leg-detail-main-column--has-summary.leg-detail-main-column--has-changes .leg-detail-main {
+    grid-area: history;
+  }
+}
+
 /* Backwards-compat shim — earlier markup used .leg-summary-stack as
    the wrapper before the layout flip. Keep it as an alias so any
    stragglers still get the same flex stack. */

--- a/frontend/src/components/LegislationDetail.jsx
+++ b/frontend/src/components/LegislationDetail.jsx
@@ -95,6 +95,8 @@ export default function LegislationDetail() {
 
   const primarySponsors = bill.sponsors.filter(s => s.primary)
   const coSponsors      = bill.sponsors.filter(s => !s.primary)
+  const hasSummary = !!bill.llm_summary
+  const hasKeyChanges = (bill.llm_summary?.key_changes?.length || 0) > 0
 
   return (
     <main className="leg-detail-page">
@@ -207,11 +209,18 @@ export default function LegislationDetail() {
             )}
           </aside>
 
-          {/* Right column: LLM summary cards (when available), then action history */}
-          <div className="leg-detail-main-column">
+          {/* Right column: LLM summary spans the top, then Action history sits
+              to the LEFT of Key changes when both are present (sub-grid). When
+              only one of those exists, the column collapses back to a stacked
+              flex layout — see the matching CSS for the conditional grid. */}
+          <div className={`leg-detail-main-column${
+            hasSummary ? ' leg-detail-main-column--has-summary' : ''
+          }${
+            hasKeyChanges ? ' leg-detail-main-column--has-changes' : ''
+          }`}>
 
             {bill.llm_summary && (
-              <article className="leg-detail-section leg-summary-card">
+              <article className="leg-detail-section leg-summary-card leg-card-summary">
                 <h2 className="leg-detail-section-title">Plain-language summary</h2>
                 {bill.llm_summary.summary && (
                   <>
@@ -240,7 +249,7 @@ export default function LegislationDetail() {
                 (bill.llm_summary.affected_sections || []).map(s => s.section_number)
               )
               return (
-                <article className="leg-detail-section leg-summary-card">
+                <article className="leg-detail-section leg-summary-card leg-card-changes">
                   <h2 className="leg-detail-section-title">Key changes</h2>
                   <ol className="leg-key-changes">
                     {bill.llm_summary.key_changes.map((kc, i) => (


### PR DESCRIPTION
## Summary
Per feedback: bring Action history up to the left of Key changes in the right column.

In the right column of `/legislation/<slug>`:

- **Plain-language summary** spans the top row (full width of the right column)
- **Action history** sits bottom-left, **Key changes** bottom-right at ≥1024px

Implemented via a CSS sub-grid with `grid-template-areas` rather than DOM reordering, so source order stays clean for accessibility (summary → key_changes → action_history).

The 2-col sub-grid only activates when **both** a summary AND key changes are present (`.leg-detail-main-column--has-summary.leg-detail-main-column--has-changes`). Other cases fall back to the existing flex stack:

- Operational bills with summary but no key_changes → flex stack (summary, then action history full width)
- Bills not yet summarized → flex stack (just action history)
- Mobile/tablet (<1024px) → flex stack (sidebar above, then summary, action history, key changes stacked)

## Test plan
- [x] Bundle builds; new pieces shipped (`leg-detail-main-column--has-summary`, `leg-card-summary`, `leg-card-changes`, `grid-template-areas`)
- [ ] Visit `/legislation/cb-121173` at desktop (≥1024px): summary spans top of right column; action history bottom-left, key changes bottom-right
- [ ] Same page at <1024px: cards stack vertically (summary, action history, key changes)
- [ ] Visit a bill with summary but no key_changes (operational): summary spans top, action history full-width below
- [ ] Visit a non-summarized bill: action history fills the right column

🤖 Generated with [Claude Code](https://claude.com/claude-code)