### PR TITLE
legislation: capture MatterInSiteURL for the View-on-Legistar link

### DIFF
--- a/frontend/src/components/LegislationDetail.jsx
+++ b/frontend/src/components/LegislationDetail.jsx
@@ -178,12 +178,12 @@ export default function LegislationDetail() {
                     </dd>
                   </>
                 )}
-                {bill.legistar_id && (
+                {bill.legistar_url && (
                   <>
                     <dt>Legistar</dt>
                     <dd>
                       <a
-                        href={`https://seattle.legistar.com/LegislationDetail.aspx?ID=${bill.legistar_id}`}
+                        href={bill.legistar_url}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="leg-detail-external-link"

--- a/seattle/bills.py
+++ b/seattle/bills.py
@@ -134,6 +134,17 @@ class SeattleBillScraper(Scraper):
                 )
 
         bill.add_source(f"{BASE_URL}/{ENDPOINT}/{matter_id}")
+
+        # Public-facing Legistar URL (used by the frontend bill detail
+        # page for the "View on Legistar" link). The constructed URL
+        # `seattle.legistar.com/LegislationDetail.aspx?ID=<MatterId>` is
+        # unreliable — Legistar's Detail page expects both ID and a GUID
+        # param to render correctly. The API exposes the canonical URL
+        # as `MatterInSiteURL`; capture and store it as a second source.
+        in_site_url = matter.get("MatterInSiteURL")
+        if in_site_url:
+            bill.add_source(in_site_url)
+
         bill.extras = {
             "MatterId": matter_id,
             "MatterTypeName": matter.get("MatterTypeName"),

--- a/seattle_app/api_views.py
+++ b/seattle_app/api_views.py
@@ -609,6 +609,7 @@ def legislation_detail(request, slug):
             'actions',
             'sponsorships',
             'documents__links',
+            'sources',
             'llm_summary__affected_sections',
         ),
         slug=slug,
@@ -653,6 +654,21 @@ def legislation_detail(request, slug):
     earliest = bill.actions.order_by('date').first()
     date_introduced = earliest.date[:10] if earliest and earliest.date else None
 
+    # Public-facing Legistar URL — captured into bill.sources by the
+    # bill scraper as MatterInSiteURL alongside the API source. Filter
+    # out the API source (which lives on webapi.legistar.com) to find
+    # the public seattle.legistar.com URL. None until the bill has been
+    # re-scraped after the scraper update; the frontend hides the
+    # "View on Legistar" link in that case rather than serving the
+    # known-broken constructed URL.
+    legistar_url = next(
+        (
+            s.url for s in bill.sources.all()
+            if s.url and 'webapi.legistar.com' not in s.url
+        ),
+        None,
+    )
+
     # LLM summary block — null when the summarize_legislation pipeline hasn't
     # touched this bill yet (or when summarization failed for it). Frontend
     # renders the cards conditionally so a missing summary degrades to the
@@ -687,6 +703,7 @@ def legislation_detail(request, slug):
         'last_modified':   bill.extras.get('MatterLastModifiedUtc', ''),
         'date_introduced': date_introduced,
         'legistar_id':     bill.extras.get('MatterId'),
+        'legistar_url':    legistar_url,
         'sponsors':        sponsors,
         'actions':         actions,
         'documents':       documents,


### PR DESCRIPTION
## Summary
PR #74 corrected the Legistar host (`legistar.council.seattle.gov` → `seattle.legistar.com`), but the constructed URL — `seattle.legistar.com/LegislationDetail.aspx?ID=<MatterId>` — doesn't reliably resolve. Legistar's Detail page expects **both** `ID` and a `GUID` query param; with only `ID`, most bills land on a redirect or 404.

Robust fix: capture **`MatterInSiteURL`** from the Legistar API directly. Mirrors what [`seattle/events.py:171-173`](seattle/events.py#L171-L173) already does with `EventInSiteURL`.

### Changes
- **`seattle/bills.py`**: capture `MatterInSiteURL` from each matter and store via `bill.add_source()` alongside the existing API source.
- **`seattle_app/api_views.py:legislation_detail`**: filter `bill.sources` to find the public-facing URL (anything not on `webapi.legistar.com`) and expose it as `legistar_url`. Adds `sources` to the `prefetch_related`.
- **`LegislationDetail.jsx`**: uses `bill.legistar_url` directly. Hides the "View on Legistar" row entirely if the field is null — rather than serving the known-broken constructed URL.

### Re-scrape required
The new source only populates on bills scraped after this lands. Existing bills' details page will hide the Legistar row until the scrape re-runs.

## Test plan
- [x] Both Python modules parse cleanly; frontend bundle builds
- [ ] After merge: `docker compose up -d --build` + re-run the bill scraper (or wait for the next scheduled scrape)
- [ ] Visit `/legislation/cb-121173` (or any bill from after the rescrape) — "View on Legistar" link should resolve directly to the canonical Legistar matter page
- [ ] Visit a bill that hasn't been re-scraped yet — Legistar row hidden
- [ ] Verify in DB: `select url from opencivicdata_billsource where bill_id = (...)` should show two rows post-rescrape (API URL + InSiteURL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)