### PR TITLE
frontend: indigo-tint legislation summary card, link sponsors to rep profiles

### DIFF
--- a/frontend/src/components/LegislationDetail.css
+++ b/frontend/src/components/LegislationDetail.css
@@ -154,20 +154,37 @@
 }
 
 .leg-summary-card {
-  /* Inherits .leg-detail-section card chrome (white bg, border,
-     rounded, padded) — no override needed beyond internal layout. */
+  /* Indigo tint to match the SMC plain-language summary panel
+     so the LLM-generated content reads consistently across the
+     two surfaces. Background and border override the default
+     .leg-detail-section card chrome (white / gray-200). */
+  background: #eef2ff;
+  border-color: #c7d2fe;
 }
 
-/* Small uppercase eyebrow above each prose chunk (Summary / Impact)
-   — internal section labels within the single "Plain-language
-   summary" card without adding more h-level chrome. */
+/* The card title ("Plain-language summary" / "Key changes") on
+   the indigo card picks up matching indigo for stronger visual
+   weight on the tinted background. The default card-title color
+   (#111827) reads fine on white but is slightly heavy here. */
+.leg-summary-card .leg-detail-section-title {
+  color: #3730a3;
+}
+
+/* Internal section labels (SUMMARY / IMPACT) inside the single
+   "Plain-language summary" card. Previously rendered in muted
+   gray (#6b7280) with the small eyebrow font — got lost between
+   the prose paragraphs above and below. Bumped to higher contrast
+   indigo + larger font + a thin bottom border so the boundary
+   between Summary and Impact reads at a glance. */
 .leg-summary-eyebrow {
-  margin: 1.25rem 0 0.5rem;
-  font-size: 0.75rem;
-  font-weight: 700;
+  margin: 1.5rem 0 0.625rem;
+  padding-bottom: 0.375rem;
+  border-bottom: 1px solid #c7d2fe;
+  font-size: 0.8125rem;
+  font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #6b7280;
+  color: #3730a3;
 }
 .leg-summary-eyebrow:first-of-type {
   margin-top: 0.25rem;
@@ -179,7 +196,10 @@
      can stretch wide on desktop. ~70 characters per line is the
      sweet spot for body text. */
   max-width: 70ch;
-  color: #1f2937;
+  /* Deep indigo body text on the indigo card — matches the SMC
+     summary panel for cross-surface visual consistency, and reads
+     warmer than pure dark gray on the tinted background. */
+  color: #1e1b4b;
   line-height: 1.65;
   font-size: 0.9375rem;
 }
@@ -356,6 +376,18 @@
   border-bottom: none;
   font-size: 0.875rem;
   line-height: 1.5;
+}
+
+/* Sponsor-name link — when the sponsor matched a councilmatic
+   Person we render a Link to /reps/<slug>/, otherwise plain
+   text. Uses the same Councilmatic blue as other detail-card
+   external links for consistency. */
+.leg-detail-sponsor-link {
+  color: #2E3D5B;
+  text-decoration: none;
+}
+.leg-detail-sponsor-link:hover {
+  text-decoration: underline;
 }
 
 .leg-detail-cosponsor-label {

--- a/frontend/src/components/LegislationDetail.jsx
+++ b/frontend/src/components/LegislationDetail.jsx
@@ -157,7 +157,9 @@ export default function LegislationDetail() {
                       <ul className="leg-detail-sponsor-list leg-detail-sponsor-list--inline">
                         {primarySponsors.map(s => (
                           <li key={s.name} className="leg-detail-sponsor leg-detail-sponsor--primary">
-                            {s.name}
+                            {s.slug
+                              ? <Link to={`/reps/${s.slug}`} className="leg-detail-sponsor-link">{s.name}</Link>
+                              : s.name}
                           </li>
                         ))}
                       </ul>
@@ -171,7 +173,9 @@ export default function LegislationDetail() {
                       <ul className="leg-detail-sponsor-list leg-detail-sponsor-list--inline">
                         {coSponsors.map(s => (
                           <li key={s.name} className="leg-detail-sponsor">
-                            {s.name}
+                            {s.slug
+                              ? <Link to={`/reps/${s.slug}`} className="leg-detail-sponsor-link">{s.name}</Link>
+                              : s.name}
                           </li>
                         ))}
                       </ul>

--- a/seattle_app/api_views.py
+++ b/seattle_app/api_views.py
@@ -618,11 +618,34 @@ def legislation_detail(request, slug):
     raw_status = bill.extras.get('MatterStatusName', '')
     status_label, status_variant = _normalise_status(raw_status)
 
-    # Sponsors ordered by primary first
+    # Resolve sponsor names to councilmatic_core_person.slug (where the
+    # name matches a real person in our DB) so the frontend can link
+    # each sponsor to their /reps/<slug>/ profile. Slug lives on the
+    # councilmatic_core_person table while the sponsorship's name comes
+    # from opencivicdata_person — raw SQL JOIN is the same pattern as
+    # the reps service. Names that don't match (typos, alternate
+    # spellings, no-longer-in-DB) get None and render as plain text.
+    sponsor_names = list({
+        (s.entity_name or '').strip()
+        for s in bill.sponsorships.all()
+        if s.entity_name
+    })
+    sponsor_slugs: dict[str, str] = {}
+    if sponsor_names:
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                SELECT p.name, cp.slug
+                FROM opencivicdata_person p
+                INNER JOIN councilmatic_core_person cp ON cp.person_id = p.id
+                WHERE p.name = ANY(%s)
+            """, [sponsor_names])
+            sponsor_slugs = dict(cursor.fetchall())
+
     sponsors = [
         {
             'name':    s.entity_name,
             'primary': s.primary,
+            'slug':    sponsor_slugs.get((s.entity_name or '').strip()),
         }
         for s in bill.sponsorships.order_by('-primary', 'name')
     ]


### PR DESCRIPTION
## Summary
Three small UI/interaction tweaks bundled — all three from this morning's TODO list (items #2, #3, plus the bonus sponsor-link request):

### 1. Indigo tint on the legislation summary card
Was the default white card chrome (`.leg-detail-section`) — visually disconnected from the SMC plain-language summary panel even though both are LLM-generated content. Apply matching colors:

- bg: `#eef2ff`
- border: `#c7d2fe`
- heading: `#3730a3`
- body prose: `#1e1b4b`

Same palette as the SMC `MuniCodeSection` summary panel, so the LLM content reads consistently across both surfaces.

### 2. `SUMMARY` / `IMPACT` eyebrows pop
Was muted gray (`#6b7280`) uppercase at `0.75rem` — blended into the prose paragraphs above and below, hard to see the boundary between Summary and Impact at a glance. Now:

- color: `#3730a3` (indigo, matches the card theme)
- font: `0.8125rem` / weight `800`
- thin `#c7d2fe` bottom-border separator

### 3. Sponsor names → `/reps/<slug>/` links
Bonus from the same conversation — bill detail's "Sponsor(s)" / "Co-sponsors" rows in the Details card now render names as `<Link>` to the rep profile when the sponsor matches a councilmatic Person.

- **Backend**: raw SQL JOIN on `opencivicdata_person` + `councilmatic_core_person` (slug lives on the latter), resolves all sponsor names in one query, attaches `slug` to each `sponsors[]` entry. Falls back to `None` when no match (typos, alternate spellings, no longer in DB).
- **Frontend**: `<Link>` when slug is non-null, plain text when null.
- New `.leg-detail-sponsor-link` class uses the same Councilmatic blue (`#2E3D5B`) as other detail-card external links for consistency.

## Test plan
- [x] All Python parses cleanly; bundle builds; new classes/colors shipped
- [ ] Visit `/legislation/cb-121173` — summary card has indigo tint, SUMMARY/IMPACT eyebrows are clearly visible with bottom-borders, sponsor names are clickable and lead to `/reps/<slug>/`
- [ ] Visit a bill where a sponsor name doesn't match a councilmatic Person — that name renders as plain text (not a broken link)
- [ ] Hover the sponsor link — underline appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)