### PR TITLE
frontend: force indigo summary-card override past .leg-detail-section

### DIFF
--- a/frontend/src/components/LegislationDetail.css
+++ b/frontend/src/components/LegislationDetail.css
@@ -153,19 +153,22 @@
   min-width: 0;
 }
 
-.leg-summary-card {
-  /* Indigo tint to match the SMC plain-language summary panel
-     so the LLM-generated content reads consistently across the
-     two surfaces. Background and border override the default
-     .leg-detail-section card chrome (white / gray-200). */
+/* Indigo tint to match the SMC plain-language summary panel so the
+   LLM-generated content reads consistently across both surfaces.
+   The double-class selector .leg-detail-section.leg-summary-card
+   is intentional: .leg-detail-section is declared later in the
+   file with `background: #ffffff` and an opaque gray border, so
+   a single-class .leg-summary-card rule loses the source-order
+   tiebreak. The double-class form (specificity 0,2,0) wins
+   regardless of where either block lives. */
+.leg-detail-section.leg-summary-card {
   background: #eef2ff;
   border-color: #c7d2fe;
 }
 
 /* The card title ("Plain-language summary" / "Key changes") on
    the indigo card picks up matching indigo for stronger visual
-   weight on the tinted background. The default card-title color
-   (#111827) reads fine on white but is slightly heavy here. */
+   weight on the tinted background. */
 .leg-summary-card .leg-detail-section-title {
   color: #3730a3;
 }


### PR DESCRIPTION
## Summary
PR #88 added `.leg-summary-card { background: #eef2ff }` intending to tint the legislation summary card to match the SMC summary panel. It didn't take — `.leg-detail-section` is declared later in the same stylesheet with `background: #ffffff` and the same single-class specificity (0,1,0), so the later rule wins the tiebreak and re-paints the card white.

Fix: use the **double-class selector** `.leg-detail-section.leg-summary-card` (specificity 0,2,0) so the tint wins regardless of source order. Same fix would apply to the title-color override but that one already uses a descendant combinator (`.leg-summary-card .leg-detail-section-title`) which has higher specificity, so it wasn't affected.

## Test plan
- [x] Compiled CSS shows `.leg-detail-section.leg-summary-card{background:#eef2ff;border-color:#c7d2fe}` — the double-class form makes it past minification
- [ ] Visit `/legislation/cb-121173` after merge — summary card now has the same indigo tint as the SMC `MuniCodeSection` summary panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)