### PR TITLE
frontend: bump key-changes bullet contrast against the indigo card

### DIFF
--- a/frontend/src/components/LegislationDetail.css
+++ b/frontend/src/components/LegislationDetail.css
@@ -242,8 +242,14 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: #ede9fe;
-  color: #5b21b6;
+  /* Filled indigo + white instead of pale-purple-on-pale-purple.
+     Against the indigo card background (#eef2ff) the previous
+     #ede9fe / #5b21b6 combination nearly disappeared. White on
+     #3730a3 hits ~10:1 contrast and matches the card heading +
+     SUMMARY/IMPACT eyebrow color so the page reads as one
+     coordinated indigo system. */
+  background: #3730a3;
+  color: #ffffff;
   font-size: 0.8125rem;
   font-weight: 700;
   border-radius: 9999px;


### PR DESCRIPTION
## Summary
The numbered bullets in the Key changes card were `#ede9fe` (very light purple) bg with `#5b21b6` text. On the indigo card background (`#eef2ff`) added by PR #88/#89, that pale-purple-on-pale-purple combination nearly disappears — bullets are visually flat against the card.

Bumped to filled indigo with white text:
- bg: `#3730a3` (matches the card heading + `SUMMARY`/`IMPACT` eyebrow color)
- color: `#ffffff`
- contrast ratio against the card: ~10:1, comfortably WCAG AAA

Fits the rest of the indigo system on the card so the page reads as one coordinated palette.

## Test plan
- [x] Compiled CSS shows `background:#3730a3;color:#fff` on `.leg-key-change:before`
- [ ] Visit `/legislation/cb-121173` after merge — numbered circles in Key changes are now filled indigo with white numerals; legible from a glance

🤖 Generated with [Claude Code](https://claude.com/claude-code)