### PR TITLE
frontend: extend RcwLinkify to suffix + verbose citation forms

### DIFF
--- a/frontend/src/components/RcwLinkify.jsx
+++ b/frontend/src/components/RcwLinkify.jsx
@@ -1,22 +1,47 @@
 import './RcwLinkify.css'
 
-// Matches RCW citations like "RCW 35.21.560", "RCW 36.70A.040",
-// "RCW 9A.36.041", or chapter-only "RCW 35.21" / "RCW 36.70A".
-// Letter suffixes appear on either the title segment (9A.36.041
-// — criminal code) or the chapter segment (36.70A.040 — Growth
-// Management Act); we allow them on any numeric segment to keep
-// the regex simple. Third segment optional → chapter-level link.
-const RCW_RE = /\bRCW\s+(\d+[A-Z]?\.\d+[A-Z]?(?:\.\d+[A-Z]?)?)\b/g
+// RCW citations appear in three shapes across SMC + bill text:
+//
+//   1. Prefix:  "RCW 35.21.560"  (canonical)
+//   2. Suffix:  "19.405 RCW"     (legal-drafting style — common in
+//               bill text where the chapter is named first)
+//   3. Verbose: "Chapter 35.79 of the Revised Code of Washington"
+//               (and "Section X.Y.Z of the Revised Code of Washington")
+//
+// The cite token allows an optional uppercase letter suffix on any
+// segment to cover both letter-suffix titles (9A.36.041 — criminal
+// code) and letter-suffix chapters (36.70A.040 — Growth Management
+// Act). The third segment is optional so chapter-level refs link to
+// the chapter page rather than a section.
+//
+// Branches are wrapped in a single regex with three capturing groups
+// (one per branch); only one fires per match, so we OR them together
+// when reading the cite below. Case-insensitive so verbose-form
+// connectors ("Chapter", "Section", "of the Revised Code of
+// Washington") match regardless of casing in the source text.
+const CITE = '\\d+[A-Z]?\\.\\d+[A-Z]?(?:\\.\\d+[A-Z]?)?'
+const RCW_RE = new RegExp(
+  '\\b(?:' +
+    'RCW\\s+(' + CITE + ')' +
+  '|' +
+    '(' + CITE + ')\\s+RCW' +
+  '|' +
+    '(?:Chapter|Section)\\s+(' + CITE + ')\\s+of\\s+the\\s+Revised\\s+Code\\s+of\\s+Washington' +
+  ')\\b',
+  'gi',
+)
 
 function rcwUrl(cite) {
   return `https://app.leg.wa.gov/RCW/default.aspx?cite=${cite}`
 }
 
-// Inline replacer: scans `text` for RCW cites and renders each
-// match as an external link, leaving surrounding text untouched.
-// Returns a Fragment so the caller can drop it directly inside
-// any block element (<p>, <li>, etc.) without changing the DOM
-// shape they already expect for plain strings.
+// Inline replacer: scans `text` for RCW cites in any of the three
+// supported shapes and renders each match as an external link,
+// preserving the original surface form as the link text. Surrounding
+// text passes through untouched. Returns a Fragment so the caller
+// can drop it directly inside any block element (<p>, <li>, etc.)
+// without changing the DOM shape they already expect for plain
+// strings.
 export default function RcwLinkify({ text }) {
   if (!text) return null
   const parts = []
@@ -24,7 +49,7 @@ export default function RcwLinkify({ text }) {
   let key = 0
   for (const m of text.matchAll(RCW_RE)) {
     if (m.index > last) parts.push(text.slice(last, m.index))
-    const cite = m[1]
+    const cite = m[1] || m[2] || m[3]
     parts.push(
       <a
         key={key++}
@@ -33,9 +58,9 @@ export default function RcwLinkify({ text }) {
         rel="noopener noreferrer"
         className="rcw-ref"
       >
-        RCW {cite}
+        {m[0]}
         <span className="rcw-ref-arrow" aria-hidden="true">↗</span>
-      </a>
+      </a>,
     )
     last = m.index + m[0].length
   }


### PR DESCRIPTION
## Summary
Follow-up to PR #92. The first cut handled only the canonical prefix form (`RCW 35.21.560`); user spotted two other shapes in the wild that the regex missed:

- **Suffix form** — `19.405 RCW`, `35.21.560 RCW` (legal-drafting style; common in bill text where the chapter is named first)
- **Verbose form** — `Chapter 35.79 of the Revised Code of Washington` and `Section X.Y.Z of the Revised Code of Washington`

The three forms are now combined into one regex with three capturing groups (one per branch); the loop reads whichever group fired. Added the `i` flag so verbose-form connectors (`Chapter`, `Section`, `of the Revised Code of Washington`) match regardless of casing.

Also: link text is now `m[0]` (the original surface form) rather than a canonicalized "RCW <cite>". Reading "Chapter 35.79 of the Revised Code of Washington" as a hyperlinked phrase is more natural than dropping the lead-in and showing only the cite.

Verified against a covering set of citation shapes including: standard, letter-suffix on title (9A.36.041) vs chapter (36.70A.040), chapter-only refs, multi-cite parens, lowercase verbose form, and negatives like bare "RCW" / "TheCityRCW123".

## Test plan
- [ ] On a bill or SMC section that uses suffix form (`19.405 RCW`), confirm the cite renders as a link.
- [ ] On a bill or SMC section that uses the verbose form (`Chapter X.Y of the Revised Code of Washington`), confirm the entire phrase is linkified and clicking it opens `app.leg.wa.gov` at the right cite.
- [ ] Confirm prefix-form cites (PR #92's original scope) still work.
- [ ] Confirm a paragraph mixing all three forms produces three separate links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)