### PR TITLE
frontend: SMC chapter refs in SmcSectionRef + persistent link underlines

### DIFF
--- a/frontend/src/components/About.css
+++ b/frontend/src/components/About.css
@@ -19,8 +19,7 @@
   margin-bottom: 1.5rem;
   color: #6b7280;
 }
-.about-breadcrumb a { color: #2E3D5B; text-decoration: none; }
-.about-breadcrumb a:hover { text-decoration: underline; }
+.about-breadcrumb a { color: #2E3D5B; text-decoration: underline; }
 .about-breadcrumb-sep { color: #9ca3af; font-weight: 400; }
 .about-breadcrumb-current { color: #6b7280; font-weight: 500; }
 

--- a/frontend/src/components/EventDetail.css
+++ b/frontend/src/components/EventDetail.css
@@ -25,10 +25,6 @@
 
 .evt-detail-breadcrumb a {
   color: #2E3D5B;
-  text-decoration: none;
-}
-
-.evt-detail-breadcrumb a:hover {
   text-decoration: underline;
 }
 
@@ -160,10 +156,6 @@
 .evt-detail-external-link {
   color: #2E3D5B;
   font-weight: 600;
-  text-decoration: none;
-}
-
-.evt-detail-external-link:hover {
   text-decoration: underline;
 }
 
@@ -315,12 +307,8 @@
 
 .evt-agenda-link {
   color: #2E3D5B;
-  text-decoration: none;
-  font-weight: 600;
-}
-
-.evt-agenda-link:hover {
   text-decoration: underline;
+  font-weight: 600;
 }
 
 .evt-agenda-meta {
@@ -430,9 +418,5 @@
   font-size: 0.8125rem;
   color: #2E3D5B;
   font-weight: 600;
-  text-decoration: none;
-}
-
-.evt-att-link:hover {
   text-decoration: underline;
 }

--- a/frontend/src/components/EventsIndex.css
+++ b/frontend/src/components/EventsIndex.css
@@ -21,10 +21,6 @@
 
 .evt-index-breadcrumb a {
   color: #2E3D5B;
-  text-decoration: none;
-}
-
-.evt-index-breadcrumb a:hover {
   text-decoration: underline;
 }
 

--- a/frontend/src/components/LegislationDetail.css
+++ b/frontend/src/components/LegislationDetail.css
@@ -28,10 +28,6 @@
 
 .leg-detail-breadcrumb a {
   color: #2E3D5B;
-  text-decoration: none;
-}
-
-.leg-detail-breadcrumb a:hover {
   text-decoration: underline;
 }
 
@@ -282,9 +278,6 @@
   font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
   color: #2E3D5B;
   font-weight: 600;
-  text-decoration: none;
-}
-.leg-key-change-section-link:hover {
   text-decoration: underline;
 }
 
@@ -340,10 +333,6 @@
 .leg-detail-external-link {
   color: #2E3D5B;
   font-weight: 600;
-  text-decoration: none;
-}
-
-.leg-detail-external-link:hover {
   text-decoration: underline;
 }
 
@@ -391,9 +380,6 @@
    external links for consistency. */
 .leg-detail-sponsor-link {
   color: #2E3D5B;
-  text-decoration: none;
-}
-.leg-detail-sponsor-link:hover {
   text-decoration: underline;
 }
 
@@ -451,12 +437,8 @@
   font-size: 0.875rem;
   color: #2E3D5B;
   font-weight: 600;
-  text-decoration: none;
-  line-height: 1.4;
-}
-
-.leg-detail-doc-link:hover {
   text-decoration: underline;
+  line-height: 1.4;
 }
 
 /* ── Action history timeline ──────────────────────────────────── */

--- a/frontend/src/components/LegislationDetail.jsx
+++ b/frontend/src/components/LegislationDetail.jsx
@@ -29,18 +29,33 @@ function MediaIcon({ mediaType }) {
   return <span className="doc-icon doc-icon--generic">FILE</span>
 }
 
-// Render a section reference as either a Link (if the LLM-emitted number
-// resolves to a real MunicipalCodeSection in the affected_sections list)
-// or plain text (e.g. when the LLM emits a chapter like "23.32" or a
-// section that doesn't exist in our DB).
+// Render a section reference as a Link when possible, plain text otherwise.
+//
+// 3-part numbers (title.chapter.section) link to /municode/<t>/<c>/<s>
+// only when the cite resolves to a real MunicipalCodeSection in the
+// affected_sections list — keeps us from emitting links to sections the
+// LLM hallucinated or that have been repealed.
+//
+// 2-part numbers (title.chapter) link to the chapter page unconditionally.
+// We don't have a "valid chapters" set exposed on the API, and the
+// chapter page renders NotFound gracefully for missing chapters, so the
+// risk of a bad link is minor.
 function SmcSectionRef({ number, validSet }) {
   const trimmed = (number || '').trim()
   if (!trimmed) return null
-  if (!validSet.has(trimmed)) {
-    return <span className="leg-key-change-section-text">SMC {trimmed}</span>
-  }
   const parts = trimmed.split('.')
-  if (parts.length !== 3) {
+  if (parts.length === 2) {
+    const [title, chapter] = parts
+    return (
+      <Link
+        to={`/municode/${title}/${chapter}`}
+        className="leg-key-change-section-link"
+      >
+        SMC {trimmed} →
+      </Link>
+    )
+  }
+  if (parts.length !== 3 || !validSet.has(trimmed)) {
     return <span className="leg-key-change-section-text">SMC {trimmed}</span>
   }
   const [title, chapter, section] = parts

--- a/frontend/src/components/LegislationIndex.css
+++ b/frontend/src/components/LegislationIndex.css
@@ -21,10 +21,6 @@
 
 .leg-index-breadcrumb a {
   color: #2E3D5B;
-  text-decoration: none;
-}
-
-.leg-index-breadcrumb a:hover {
   text-decoration: underline;
 }
 

--- a/frontend/src/components/MuniCodeIndex.css
+++ b/frontend/src/components/MuniCodeIndex.css
@@ -21,8 +21,7 @@
   margin-bottom: 1.5rem;
   color: #6b7280;
 }
-.smc-breadcrumb a { color: #2E3D5B; text-decoration: none; }
-.smc-breadcrumb a:hover { text-decoration: underline; }
+.smc-breadcrumb a { color: #2E3D5B; text-decoration: underline; }
 .smc-breadcrumb-sep { color: #9ca3af; font-weight: 400; }
 .smc-breadcrumb-current { color: #6b7280; font-weight: 500; }
 

--- a/frontend/src/components/RcwLinkify.css
+++ b/frontend/src/components/RcwLinkify.css
@@ -8,12 +8,8 @@
   font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
   color: #2E3D5B;
   font-weight: 600;
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.rcw-ref:hover {
   text-decoration: underline;
+  white-space: nowrap;
 }
 
 .rcw-ref-arrow {

--- a/frontend/src/components/RcwLinkify.jsx
+++ b/frontend/src/components/RcwLinkify.jsx
@@ -1,22 +1,47 @@
 import './RcwLinkify.css'
 
-// Matches RCW citations like "RCW 35.21.560", "RCW 36.70A.040",
-// "RCW 9A.36.041", or chapter-only "RCW 35.21" / "RCW 36.70A".
-// Letter suffixes appear on either the title segment (9A.36.041
-// — criminal code) or the chapter segment (36.70A.040 — Growth
-// Management Act); we allow them on any numeric segment to keep
-// the regex simple. Third segment optional → chapter-level link.
-const RCW_RE = /\bRCW\s+(\d+[A-Z]?\.\d+[A-Z]?(?:\.\d+[A-Z]?)?)\b/g
+// RCW citations appear in three shapes across SMC + bill text:
+//
+//   1. Prefix:  "RCW 35.21.560"  (canonical)
+//   2. Suffix:  "19.405 RCW"     (legal-drafting style — common in
+//               bill text where the chapter is named first)
+//   3. Verbose: "Chapter 35.79 of the Revised Code of Washington"
+//               (and "Section X.Y.Z of the Revised Code of Washington")
+//
+// The cite token allows an optional uppercase letter suffix on any
+// segment to cover both letter-suffix titles (9A.36.041 — criminal
+// code) and letter-suffix chapters (36.70A.040 — Growth Management
+// Act). The third segment is optional so chapter-level refs link to
+// the chapter page rather than a section.
+//
+// Branches are wrapped in a single regex with three capturing groups
+// (one per branch); only one fires per match, so we OR them together
+// when reading the cite below. Case-insensitive so verbose-form
+// connectors ("Chapter", "Section", "of the Revised Code of
+// Washington") match regardless of casing in the source text.
+const CITE = '\\d+[A-Z]?\\.\\d+[A-Z]?(?:\\.\\d+[A-Z]?)?'
+const RCW_RE = new RegExp(
+  '\\b(?:' +
+    'RCW\\s+(' + CITE + ')' +
+  '|' +
+    '(' + CITE + ')\\s+RCW' +
+  '|' +
+    '(?:Chapter|Section)\\s+(' + CITE + ')\\s+of\\s+the\\s+Revised\\s+Code\\s+of\\s+Washington' +
+  ')\\b',
+  'gi',
+)
 
 function rcwUrl(cite) {
   return `https://app.leg.wa.gov/RCW/default.aspx?cite=${cite}`
 }
 
-// Inline replacer: scans `text` for RCW cites and renders each
-// match as an external link, leaving surrounding text untouched.
-// Returns a Fragment so the caller can drop it directly inside
-// any block element (<p>, <li>, etc.) without changing the DOM
-// shape they already expect for plain strings.
+// Inline replacer: scans `text` for RCW cites in any of the three
+// supported shapes and renders each match as an external link,
+// preserving the original surface form as the link text. Surrounding
+// text passes through untouched. Returns a Fragment so the caller
+// can drop it directly inside any block element (<p>, <li>, etc.)
+// without changing the DOM shape they already expect for plain
+// strings.
 export default function RcwLinkify({ text }) {
   if (!text) return null
   const parts = []
@@ -24,7 +49,7 @@ export default function RcwLinkify({ text }) {
   let key = 0
   for (const m of text.matchAll(RCW_RE)) {
     if (m.index > last) parts.push(text.slice(last, m.index))
-    const cite = m[1]
+    const cite = m[1] || m[2] || m[3]
     parts.push(
       <a
         key={key++}
@@ -33,9 +58,9 @@ export default function RcwLinkify({ text }) {
         rel="noopener noreferrer"
         className="rcw-ref"
       >
-        RCW {cite}
+        {m[0]}
         <span className="rcw-ref-arrow" aria-hidden="true">↗</span>
-      </a>
+      </a>,
     )
     last = m.index + m[0].length
   }

--- a/frontend/src/components/RepDetail.css
+++ b/frontend/src/components/RepDetail.css
@@ -19,8 +19,7 @@
   margin-bottom: 1.5rem;
   color: #6b7280;
 }
-.rep-detail-breadcrumb a { color: #2E3D5B; text-decoration: none; }
-.rep-detail-breadcrumb a:hover { text-decoration: underline; }
+.rep-detail-breadcrumb a { color: #2E3D5B; text-decoration: underline; }
 .rep-detail-breadcrumb-sep { color: #9ca3af; font-weight: 400; }
 .rep-detail-breadcrumb-current { color: #6b7280; font-weight: 500; }
 
@@ -77,10 +76,10 @@
 
 .rep-detail-contact-value {
   color: #1f2937;
-  text-decoration: none;
+  text-decoration: underline;
   font-size: 0.95rem;
 }
-.rep-detail-contact-value:hover { text-decoration: underline; color: #2E3D5B; }
+.rep-detail-contact-value:hover { color: #2E3D5B; }
 
 .rep-detail-actions {
   display: flex;

--- a/frontend/src/components/RepDistrict.css
+++ b/frontend/src/components/RepDistrict.css
@@ -19,8 +19,7 @@
   margin-bottom: 1.5rem;
   color: #6b7280;
 }
-.rep-district-breadcrumb a { color: #2E3D5B; text-decoration: none; }
-.rep-district-breadcrumb a:hover { text-decoration: underline; }
+.rep-district-breadcrumb a { color: #2E3D5B; text-decoration: underline; }
 .rep-district-breadcrumb-sep { color: #9ca3af; font-weight: 400; }
 .rep-district-breadcrumb-current { color: #6b7280; font-weight: 500; }
 

--- a/frontend/src/components/RepsIndex.css
+++ b/frontend/src/components/RepsIndex.css
@@ -19,8 +19,7 @@
   margin-bottom: 1.5rem;
   color: #6b7280;
 }
-.reps-breadcrumb a { color: #2E3D5B; text-decoration: none; }
-.reps-breadcrumb a:hover { text-decoration: underline; }
+.reps-breadcrumb a { color: #2E3D5B; text-decoration: underline; }
 .reps-breadcrumb-sep { color: #9ca3af; font-weight: 400; }
 .reps-breadcrumb-current { color: #6b7280; font-weight: 500; }
 

--- a/frontend/src/components/Search.css
+++ b/frontend/src/components/Search.css
@@ -19,8 +19,7 @@
   margin-bottom: 1.5rem;
   color: #6b7280;
 }
-.search-breadcrumb a { color: #2E3D5B; text-decoration: none; }
-.search-breadcrumb a:hover { text-decoration: underline; }
+.search-breadcrumb a { color: #2E3D5B; text-decoration: underline; }
 .search-breadcrumb-sep { color: #9ca3af; font-weight: 400; }
 .search-breadcrumb-current { color: #6b7280; font-weight: 500; }
 
@@ -113,9 +112,8 @@
   font-size: 0.875rem;
   font-weight: 600;
   color: #2E3D5B;
-  text-decoration: none;
+  text-decoration: underline;
 }
-.search-section-view-all:hover { text-decoration: underline; }
 
 .search-section-status {
   color: #6b7280;


### PR DESCRIPTION
## Summary

Two user requests bundled together — both touch the legislation detail surface, and the underline change benefits from being visible alongside the new chapter links.

> **Stacked on PR #93.** This branch is rebased on top of `frontend/rcw-external-links`, so it carries both #93's RCW suffix/verbose forms AND this PR's changes. Merging #93 first will leave a clean diff here; if this is merged first you'll need to also merge #93 or rebase.

### 1. SmcSectionRef handles 2-part chapter refs

`SmcSectionRef` previously required exactly 3 parts (title.chapter.section) and fell through to plain text for anything else. The LLM regularly emits `affected_section` values like `"15.62"` (chapter-only) when a key change touches a whole chapter rather than a single section — these were rendering as plain `SMC 15.62` instead of links.

Now: 2-part refs link to `/municode/<title>/<chapter>` unconditionally (the chapter page renders `NotFound` for missing chapters, so the risk of a bad link is small and the upside of a working chapter link is large). 3-part refs still validate against the `affected_sections` list before linking.

### 2. Persistent underlines on text links

Replaces the `text-decoration: none` + `:hover { text-decoration: underline }` pattern with a single `text-decoration: underline` on text-style links so they read as obviously clickable without needing to hover.

**Applied to:**
- All page breadcrumbs (Legislation, Municode, Reps, Events, Search, About, Index pages)
- `RcwLinkify` (RCW external links)
- `LegislationDetail`: sponsor links, external Legistar link, document links, key-change SMC section links
- `EventDetail`: external link, agenda links, attachment links
- `Search`: "view all" section header
- `RepDetail`: contact value (email/phone)

**Skipped (already obviously clickable through chrome):**
- Card wrappers (`.evt-card-link`, `.leg-card-link`, `.search-result`, `.smc-detail-link`, etc.) — underlining the entire card including its heading would read as noise
- Button-styled links (`.evt-doc-btn`, NotFound CTA, NeighborNav prev/next, Municode "Browse all titles" CTA)
- Nav links (NavBar, Footer, logo wrapper) — these have their own visual treatment

## Test plan
- [ ] On a bill whose `key_changes` includes a chapter-only `affected_section` (e.g. `SMC 15.62`), confirm it now renders as a link to `/municode/15/62` rather than plain text.
- [ ] On a section-level cite that's in `affected_sections`, confirm 3-part link still works.
- [ ] On a section-level cite that's NOT in `affected_sections` (deprecated section, hallucinated cite), confirm it still falls through to plain text.
- [ ] Walk a few flagship paths (Home → Legislation → bill detail → SMC section → back) and confirm text links carry underlines and card links don't.
- [ ] Confirm no accidental underlines appear on `.evt-card-link`, `.leg-card-link`, `.smc-detail-link`, NavBar, Footer, NeighborNav, NotFound CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)