### PR TITLE
fix: link multi-cite affected_section values in SmcSectionRef

### DIFF
--- a/frontend/src/components/LegislationDetail.jsx
+++ b/frontend/src/components/LegislationDetail.jsx
@@ -282,11 +282,27 @@ export default function LegislationDetail() {
                           {kc.description && (
                             <p className="leg-key-change-desc"><BillLinkify text={kc.description} refs={bill.bill_refs} /></p>
                           )}
-                          {kc.affected_section && (
-                            <p className="leg-key-change-section">
-                              Affected: <SmcSectionRef number={kc.affected_section} validSet={validSet} />
-                            </p>
-                          )}
+                          {(() => {
+                            // affected_section may be a single cite ("1.04.020"),
+                            // a comma-separated list ("1.04.020, 1.04.070"), or
+                            // a list with "and" connectors. Pull every 2- or
+                            // 3-part SMC cite via regex and render each one
+                            // separately, joined by ", ".
+                            const cites = (kc.affected_section || '')
+                              .match(/\d+[A-Z]?\.\d+[A-Z]?(?:\.\d+[A-Z]?)?/g) || []
+                            if (cites.length === 0) return null
+                            return (
+                              <p className="leg-key-change-section">
+                                Affected:{' '}
+                                {cites.map((n, j) => (
+                                  <span key={j}>
+                                    <SmcSectionRef number={n} validSet={validSet} />
+                                    {j < cites.length - 1 && ', '}
+                                  </span>
+                                ))}
+                              </p>
+                            )
+                          })()}
                         </li>
                       ))}
                     </ol>

--- a/seattle_app/management/commands/summarize_legislation.py
+++ b/seattle_app/management/commands/summarize_legislation.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import datetime, timezone as dt_timezone
 from pathlib import Path
 from typing import Iterable, Optional
@@ -66,6 +67,12 @@ THINKING_BUDGET_TOKENS = 8192
 # tail of BillText.text past 600k chars — the staff Summary is
 # concatenated first, so any oversized bill keeps the most useful part.
 MAX_INPUT_CHARS = 600_000
+
+# Pull every 2- or 3-part SMC-shaped section number out of a free-form
+# affected_section field. Used so multi-cite values like "1.04.020,
+# 1.04.070" or "23.32.040 and 23.32.060" each resolve to their own
+# MunicipalCodeSection row in the affected_sections M2M.
+_SMC_CITE_RE = re.compile(r"\d+[A-Z]?\.\d+[A-Z]?(?:\.\d+[A-Z]?)?")
 
 
 def _encode_custom_id(identifier: str) -> str:
@@ -301,15 +308,16 @@ class Command(BaseCommand):
             },
         )
         # Resolve `key_changes[].affected_section` to MunicipalCodeSection
-        # rows. The LLM output has section numbers as strings; some may
-        # not match any row in our SMC table (typo, deprecated section,
-        # or referencing a non-SMC code), in which case we silently drop
-        # them — the JSON still records what the LLM thought.
-        section_numbers = {
-            (kc.get("affected_section") or "").strip()
-            for kc in (data.get("key_changes") or [])
-        }
-        section_numbers.discard("")
+        # rows. The LLM sometimes emits a single cite ("1.04.020"), a
+        # comma-separated list ("1.04.020, 1.04.070"), or a list with
+        # an "and" connector — pull every 2- or 3-part SMC-shaped cite
+        # via regex so each one is resolved individually. Section
+        # numbers that don't match any row (typos, deprecated, or
+        # non-SMC) are silently dropped; the JSON still records what
+        # the LLM thought.
+        section_numbers: set[str] = set()
+        for kc in (data.get("key_changes") or []):
+            section_numbers.update(_SMC_CITE_RE.findall(kc.get("affected_section") or ""))
         if section_numbers:
             sections = MunicipalCodeSection.objects.filter(
                 section_number__in=section_numbers

--- a/seattle_app/migrations/0020_repopulate_affected_sections.py
+++ b/seattle_app/migrations/0020_repopulate_affected_sections.py
@@ -1,0 +1,52 @@
+"""Re-resolve LegislationSummary.affected_sections M2M to handle
+multi-cite values.
+
+The original `_upsert_summary` (in `summarize_legislation.py`) treated
+each `key_changes[].affected_section` as one literal section number,
+so a value like `"1.04.020, 1.04.070"` failed the
+`section_number__in=[...]` lookup and contributed nothing to the M2M.
+The forward-fix in that command now extracts every 2- or 3-part SMC
+cite via regex; this migration applies the same extraction to all
+existing LegislationSummary rows so their affected_sections M2M is
+correct without re-running the LLM pipeline.
+
+Reverse is a no-op — the original (buggy) M2M state isn't worth
+preserving.
+"""
+
+from __future__ import annotations
+
+import re
+
+from django.db import migrations
+
+
+_SMC_CITE_RE = re.compile(r"\d+[A-Z]?\.\d+[A-Z]?(?:\.\d+[A-Z]?)?")
+
+
+def repopulate_affected_sections(apps, schema_editor):
+    LegislationSummary = apps.get_model("seattle_app", "LegislationSummary")
+    MunicipalCodeSection = apps.get_model("seattle_app", "MunicipalCodeSection")
+
+    for summary in LegislationSummary.objects.all():
+        cites: set[str] = set()
+        for kc in (summary.key_changes or []):
+            cites.update(_SMC_CITE_RE.findall(kc.get("affected_section") or ""))
+        if cites:
+            sections = MunicipalCodeSection.objects.filter(section_number__in=cites)
+            summary.affected_sections.set(sections)
+        else:
+            summary.affected_sections.clear()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("seattle_app", "0019_legislationsummary_summary_batch_id"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            repopulate_affected_sections,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]


### PR DESCRIPTION
## Summary

Follow-up to PR #95. On `cb-120907` the user reported that `Affected: SMC 1.04.020, 1.04.070` rendered as plain text instead of links. Three places had to be fixed because the LLM emits multi-cite affected_section values like `"1.04.020, 1.04.070"` or `"23.32.040 and 23.32.060"` rather than a single cite:

1. **`summarize_legislation._upsert_summary`** (forward-fix): treated each value as one literal section_number string, so `section_number__in=[...]` never matched and the affected_sections M2M stayed empty.
2. **`SmcSectionRef` call site in `LegislationDetail.jsx`**: split the raw string on `.` and rejected anything that wasn't exactly 3 parts → fell through to plain text.
3. **`validSet` derivation**: built from the (empty-due-to-#1) M2M, so even if #2 had handled splits there was nothing for individual cites to match against.

## Fix

Same regex (`\d+[A-Z]?\.\d+[A-Z]?(?:\.\d+[A-Z]?)?`) applied in three places:
- **Server**: `_upsert_summary` extracts every cite from each `affected_section` and looks them up individually before setting the M2M.
- **Frontend**: the `affected_section` call site in `LegislationDetail.jsx` extracts cites from the string and renders each through `SmcSectionRef` separately, joined by `, `.
- **Migration 0020 (data migration)**: re-runs the M2M resolution against every existing `LegislationSummary` row so older data doesn't need an LLM re-run to benefit. Reverse is a no-op.

After applying the migration, the user's reported case (`cb-120907` → "Affected: SMC 1.04.020, 1.04.070") links to `/municode/1/04/020` and `/municode/1/04/070` individually. Single-cite values are unaffected (the regex extracts one match).

## Test plan
- [ ] Run `python manage.py migrate seattle_app` after pulling.
- [ ] Visit `cb-120907` and confirm both `1.04.020` and `1.04.070` are clickable links pointing to the right SMC section pages.
- [ ] Visit a bill with single-cite `affected_section` and confirm it still links the same way.
- [ ] Visit a bill with no `affected_section` on its key changes and confirm the row is hidden (no empty "Affected:" line).
- [ ] Spot-check a bill whose `affected_section` cites a real but non-summarized section (LLM said it but section isn't in the M2M for some other reason) — it should now link unconditionally via the regex extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)