### PR TITLE
frontend: use favicon.png as the header brand mark

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -50,22 +50,13 @@
     outline-offset: 2px;
   }
   
-  .logo-icon {
+  .logo-icon-img {
     width: 2rem;
     height: 2rem;
-    background-color: #2E3D5B;
-    border-radius: 0.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    flex-shrink: 0;
+    object-fit: contain;
   }
-  
-  .icon {
-    width: 1rem;
-    height: 1rem;
-    color: white;
-  }
-  
+
   .title {
     font-size: 1rem;
     font-weight: 800;
@@ -114,17 +105,11 @@
       gap: 1rem;
     }
     
-    .logo-icon {
+    .logo-icon-img {
       width: 2.5rem;
       height: 2.5rem;
-      border-radius: 0.75rem;
     }
-    
-    .icon {
-      width: 1.25rem;
-      height: 1.25rem;
-    }
-    
+
     .title {
       font-size: 1.25rem;
     }

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,5 +1,4 @@
 import { Link } from 'react-router-dom';
-import { Landmark } from 'lucide-react';
 import NavBar from './NavBar';
 
 export default function Header() {
@@ -8,15 +7,13 @@ export default function Header() {
       <div className="header-container">
         <div className="header-content">
 
-          {/* Logo + title — clickable, returns to homepage from any page */}
+          {/* Logo + title — clickable, returns to homepage from any page.
+              The favicon image is decorative (alt=""); the parent
+              <Link>'s aria-label carries the link's purpose. */}
           <Link to="/" className="logo-section" aria-label="Seattle Councilmatic — Home">
 
-            {/* logo icon */}
-            <div className="logo-icon">
-              <Landmark className="icon" strokeWidth={2.5} />
-            </div>
+            <img src="/favicon.png" alt="" className="logo-icon-img" />
 
-            {/* title and subtitle */}
             <div>
               <h1 className="title">Seattle Councilmatic</h1>
               <p className="subtitle">


### PR DESCRIPTION
## Summary

Brings the in-page brand mark in line with the browser-tab icon. The header `<Link to="/">` now renders `frontend/public/favicon.png` (the book icon shipped in PR #100) instead of the navy-square + lucide `Landmark` icon combo it was using.

### Changes
- `Header.jsx`: replaced the `<div className="logo-icon"><Landmark .../></div>` wrapper with `<img src="/favicon.png" alt="" className="logo-icon-img" />`. The img is decorative (`alt=""`); the parent `<Link>`'s existing `aria-label="Seattle Councilmatic — Home"` still announces the link's purpose to screen readers.
- `App.css`: dropped the unused `.logo-icon` (navy box) and `.icon` (white inner) styles, replaced with a single `.logo-icon-img` rule that preserves the same 2rem (mobile) / 2.5rem (≥640px) footprint.
- Dropped the now-unused `Landmark` import from `lucide-react`.

## Test plan
- [ ] Hard-refresh the homepage; confirm the header shows the book icon (matching the browser tab) at the same size as before, with the title + subtitle to its right.
- [ ] Resize the browser through the 640px breakpoint and confirm the icon scales up to 2.5rem on desktop.
- [ ] Tab to the home link and confirm the focus ring still appears around the whole logo+title area (`.logo-section:focus-visible`).
- [ ] Visit any inner page; confirm the header icon still renders and clicking it returns to `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)