### PR TITLE
django: serve favicon at root paths so browsers pick it up

### DIFF
--- a/seattle_app/urls.py
+++ b/seattle_app/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
 from django.conf.urls.static import static
+from django.views.generic import RedirectView
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
@@ -11,6 +12,15 @@ from . import api_views
 
 urlpatterns = [
     path("robots.txt", views.robots_txt, name="robots_txt"),
+    # Browsers auto-request /favicon.ico (and sometimes /favicon.png) at
+    # the root regardless of the <link rel="icon"> in the SPA shell.
+    # Without these explicit routes the requests hit the SPA catch-all
+    # and return index.html, which Chrome can cache as "no valid icon"
+    # and then ignore the <link> tag on subsequent loads. Redirecting to
+    # the real /static/favicon.png lets browsers cache a working icon
+    # for the origin.
+    path("favicon.ico", RedirectView.as_view(url="/static/favicon.png", permanent=True)),
+    path("favicon.png", RedirectView.as_view(url="/static/favicon.png", permanent=True)),
     path("admin/", admin.site.urls),
     path("api/reps/", include("reps.urls")),
     path("api/legislation/recent/", api_views.recent_legislation, name="api_legislation_recent"),


### PR DESCRIPTION
## Summary

PR #100 wired up `<link rel="icon" type="image/png" href="/static/favicon.png" />` in the SPA shell, but the browser tab was still showing no favicon.

### Root cause
Browsers (especially Chrome) auto-request `/favicon.ico` (and sometimes `/favicon.png`) at the **root** regardless of the `<link>` tag. Those root-level requests were hitting the SPA catch-all (`<path:path>` → `react_app`) and returning `index.html` with `Content-Type: text/html`. Chrome interprets that as "no valid icon at the standard location" and caches the determination — sometimes ignoring the `<link rel="icon">` tag on subsequent loads.

```
$ curl -I http://localhost:8000/favicon.ico   # before fix
HTTP/1.1 200 OK
Content-Type: text/html       # <-- this is why Chrome bails
```

### Fix

Add explicit routes for `/favicon.ico` and `/favicon.png` *before* the catch-all that 301-redirect to `/static/favicon.png`. The 301 lets browsers cache the redirect and update their favicon mapping for the origin.

```
$ curl -I http://localhost:8000/favicon.ico   # after fix
HTTP/1.1 301 Moved Permanently
Location: /static/favicon.png

$ curl -I http://localhost:8000/static/favicon.png
HTTP/1.1 200 OK
Content-Type: image/png
```

## Test plan
- [ ] Restart Django (urls.py loads at startup), then close+reopen the browser tab pointing at localhost:8000.
- [ ] Confirm the book favicon appears in the tab.
- [ ] If it doesn't appear, hit `chrome://settings/clearBrowserData` → "Cached images and files" → All time → Clear; then reload. (Chrome's favicon cache is more aggressive than the regular HTTP cache.)
- [ ] Visit `http://localhost:8000/favicon.ico` directly and confirm it 301-redirects to `/static/favicon.png` and serves the PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)