### PR TITLE
frontend: Landmark favicon to match the header brand mark

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="alternate icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#2E3D5B"/>
+  <g transform="translate(4 4)" fill="none" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M10 18v-7"/>
+    <path d="M11.12 2.198a2 2 0 0 1 1.76.006l7.866 3.847c.476.233.31.949-.22.949H3.474c-.53 0-.695-.716-.22-.949z"/>
+    <path d="M14 18v-7"/>
+    <path d="M18 18v-7"/>
+    <path d="M3 22h18"/>
+    <path d="M6 18v-7"/>
+  </g>
+</svg>

--- a/seattle_app/urls.py
+++ b/seattle_app/urls.py
@@ -16,11 +16,14 @@ urlpatterns = [
     # the root regardless of the <link rel="icon"> in the SPA shell.
     # Without these explicit routes the requests hit the SPA catch-all
     # and return index.html, which Chrome can cache as "no valid icon"
-    # and then ignore the <link> tag on subsequent loads. Redirecting to
-    # the real /static/favicon.png lets browsers cache a working icon
-    # for the origin.
-    path("favicon.ico", RedirectView.as_view(url="/static/favicon.png", permanent=True)),
-    path("favicon.png", RedirectView.as_view(url="/static/favicon.png", permanent=True)),
+    # and then ignore the <link> tag on subsequent loads. We redirect
+    # to /static/favicon.svg (Landmark glyph on navy, matches the
+    # header brand mark); .png stays as a fallback for older browsers
+    # that don't support SVG favicons. 302 (temporary) so a future
+    # icon swap doesn't get stuck in browser caches the way a 301
+    # would.
+    path("favicon.ico", RedirectView.as_view(url="/static/favicon.svg", permanent=False)),
+    path("favicon.png", RedirectView.as_view(url="/static/favicon.png", permanent=False)),
     path("admin/", admin.site.urls),
     path("api/reps/", include("reps.urls")),
     path("api/legislation/recent/", api_views.recent_legislation, name="api_legislation_recent"),


### PR DESCRIPTION
## Summary

Browser tab now shows the same Landmark glyph (white on navy `#2E3D5B`) used in the header logo. Built `favicon.svg` by hand using the lucide Landmark path data extracted from `node_modules/lucide-react/dist/esm/icons/landmark.js`, wrapped in a navy rounded square (rx=8, matching the header's `0.5rem` radius on a 32px footprint, with `stroke-width="2.5"` matching the header icon).

### Changes
- **`frontend/public/favicon.svg`** *(new)* — Landmark glyph on navy
- **`frontend/index.html`** — primary `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />` plus `<link rel="alternate icon" type="image/png" href="/favicon.png" />` as a fallback for the rare browsers that don't support SVG favicons
- **`seattle_app/urls.py`** — `/favicon.ico` now redirects to `/static/favicon.svg`; `/favicon.png` still redirects to the book PNG so anything caching the old PNG location keeps resolving. Switched both redirects from 301 (permanent) to 302 (temporary) so future icon swaps don't get stuck in browser caches the way the previous 301 might have.

### Untouched
- `seattle_app/static/favicon.png` (the book) stays for Django admin / Wagtail's `base.html` which references it via `{% static 'favicon.png' %}`.

## Test plan
- [ ] Pull, rebuild the container.
- [ ] Close+reopen the tab pointing at localhost:8000 (don't just refresh — Chrome's favicon cache survives reload). The tab should show the white Landmark on navy.
- [ ] If it still doesn't update, DevTools → Application → Storage → "Clear site data" for localhost. Reload.
- [ ] Verify directly: `curl -I http://localhost:8000/static/favicon.svg` returns `Content-Type: image/svg+xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)