### PR TITLE
a11y: strip Vite scaffold defaults from index.css (PR 1/7)

### DIFF
--- a/frontend/src/components/LegislationHero.css
+++ b/frontend/src/components/LegislationHero.css
@@ -42,19 +42,6 @@
   line-height: 1.6;
 }
 
-/* sr-only: visually hidden but accessible to screen readers */
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .home-hero-form {
   width: 100%;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,13 @@
+/* Global base styles. Strictly: typography defaults, body reset,
+   accessibility utilities. Component-level CSS owns its own colors,
+   sizing, button/anchor styles — keep this file minimal so unstyled
+   elements don't inherit surprises. */
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
   color-scheme: light;
   color: #1f2937;
   background-color: #f9fafb;
@@ -13,54 +18,40 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  background-color: #f9fafb;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+/* Visually hidden but available to screen readers. Used for skip-link
+   targets, off-screen labels, and any text we want announced but not
+   rendered. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #1a1a1a;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
+/* Respect user's reduced-motion preference — collapse all transitions
+   and animations to near-zero so motion-sensitive users get a static
+   experience. WCAG 2.3.3 (Animation from Interactions). The
+   `!important` is required to override per-component transition
+   declarations. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary

First of seven PRs from the audit findings (PR #104). Bundles three loosely-related foundation items: Vite scaffold cleanup (P1.1), global `.sr-only` utility (P3.1), and `prefers-reduced-motion` handling (P2.6).

### What was removed
- Default `<a>` color `#646cff` (Vite purple) — every link path is styled by component CSS already.
- Default `<button>` background `#1a1a1a` and `#646cff` hover border — component CSS owns button styling.
- `h1 { font-size: 3.2em }` — per-page heading sizes own their scale.
- **`@media (prefers-color-scheme: light) { :root { background-color: #1a1a1a } }`** — the inverse of correct (dark bg under "light" preference). Removed entirely.
- `button:focus, button:focus-visible { outline: 4px auto -webkit-focus-ring-color }` — component-level focus styles already replace it.

### What was added
- **`.sr-only`** utility class moved here from `LegislationHero.css` (where it was scoped to one file but applied globally because CSS isn't scoped). Available everywhere now.
- **`@media (prefers-reduced-motion: reduce)`** global rule that collapses animation/transition durations to ~0. Uses `!important` to override per-component `transition: ... 0.15s` declarations (necessary — specificity won't beat declared transition-duration on ~50 component rules).

### Why bundle these three
P1.1, P2.6, P3.1 all live in or right next to `index.css` and don't conflict with each other. Splitting them into three PRs would mean three rebases against this same file. Bundling avoids the churn while keeping the diff small enough to review.

## Test plan
- [ ] Hard-refresh the homepage and confirm no visual regressions (links still render in their component-specific colors, buttons still styled).
- [ ] DevTools → Rendering → Emulate `prefers-reduced-motion: reduce` and confirm hover/focus transitions are instant rather than 0.15s.
- [ ] Tab through to the search bar in `LegislationHero` — visually-hidden label should still be picked up by screen readers (no visible label, `<input>` accessibility shows correct accessible name).
- [ ] Confirm the "Active filters" pills on `MuniCodeIndex` and other UI elements still look identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)