### PR TITLE
a11y: skip-link + single <main> landmark (PR 2/7)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4,7 +4,38 @@
     display: flex;
     flex-direction: column;
   }
-  
+
+  /* Skip-link: visually hidden until focused, then drops in from the
+     top of the viewport. Sits at the very top of the DOM (App.jsx,
+     before <Header>) so it's the first focusable element on every
+     page. Targets <main id="main-content"> wrapping <Routes>. */
+  .skip-link {
+    position: absolute;
+    top: 0.5rem;
+    left: 0.5rem;
+    z-index: 100;
+    padding: 0.5rem 1rem;
+    background: #2E3D5B;
+    color: #ffffff;
+    font-weight: 700;
+    text-decoration: none;
+    border-radius: 0.375rem;
+    transform: translateY(calc(-100% - 1rem));
+    transition: transform 0.15s;
+  }
+  .skip-link:focus {
+    transform: translateY(0);
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+  }
+
+  /* Strip the default focus ring on <main id="main-content">. The
+     tabIndex=-1 there is for programmatic focus from the skip-link;
+     we don't want a visual ring on the entire main region. */
+  main#main-content:focus {
+    outline: none;
+  }
+
   .header {
     position: sticky;
     top: 0;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,31 +32,40 @@ function HomePage() {
 function App() {
   return (
     <BrowserRouter>
+      {/* Skip-link for keyboard / screen-reader users — first
+          focusable element on every page, visible only when focused.
+          Lets users bypass the header + main nav to reach page content
+          without tabbing through every nav item. WCAG 2.4.1. */}
+      <a href="#main-content" className="skip-link">
+        Skip to main content
+      </a>
       <Header />
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/legislation" element={<LegislationIndex />} />
-        <Route path="/legislation/" element={<LegislationIndex />} />
-        <Route path="/legislation/:slug" element={<LegislationDetail />} />
-        <Route path="/events" element={<EventsIndex />} />
-        <Route path="/events/" element={<EventsIndex />} />
-        <Route path="/events/:slug" element={<EventDetail />} />
-        <Route path="/municode" element={<MuniCodeIndex />} />
-        <Route path="/municode/" element={<MuniCodeIndex />} />
-        <Route path="/municode/:title/appendix/:label" element={<MuniCodeAppendix />} />
-        <Route path="/municode/:title/:chapter/:section" element={<MuniCodeSection />} />
-        <Route path="/municode/:title/:chapter" element={<MuniCodeChapter />} />
-        <Route path="/municode/:slug" element={<MuniCodeTitle />} />
-        <Route path="/reps" element={<RepsIndex />} />
-        <Route path="/reps/" element={<RepsIndex />} />
-        <Route path="/reps/district/:number" element={<RepDistrict />} />
-        <Route path="/reps/:slug" element={<RepDetail />} />
-        <Route path="/search" element={<Search />} />
-        <Route path="/search/" element={<Search />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/about/" element={<About />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      <main id="main-content" tabIndex={-1}>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/legislation" element={<LegislationIndex />} />
+          <Route path="/legislation/" element={<LegislationIndex />} />
+          <Route path="/legislation/:slug" element={<LegislationDetail />} />
+          <Route path="/events" element={<EventsIndex />} />
+          <Route path="/events/" element={<EventsIndex />} />
+          <Route path="/events/:slug" element={<EventDetail />} />
+          <Route path="/municode" element={<MuniCodeIndex />} />
+          <Route path="/municode/" element={<MuniCodeIndex />} />
+          <Route path="/municode/:title/appendix/:label" element={<MuniCodeAppendix />} />
+          <Route path="/municode/:title/:chapter/:section" element={<MuniCodeSection />} />
+          <Route path="/municode/:title/:chapter" element={<MuniCodeChapter />} />
+          <Route path="/municode/:slug" element={<MuniCodeTitle />} />
+          <Route path="/reps" element={<RepsIndex />} />
+          <Route path="/reps/" element={<RepsIndex />} />
+          <Route path="/reps/district/:number" element={<RepDistrict />} />
+          <Route path="/reps/:slug" element={<RepDetail />} />
+          <Route path="/search" element={<Search />} />
+          <Route path="/search/" element={<Search />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/about/" element={<About />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </main>
       <Footer />
     </BrowserRouter>
   )

--- a/frontend/src/components/About.jsx
+++ b/frontend/src/components/About.jsx
@@ -6,7 +6,7 @@ const CONTACT_EMAIL = 'contact@seattlecouncilmatic.org'
 
 export default function About() {
   return (
-    <main className="about-page">
+    <div className="about-page">
       <div className="about-container">
         <nav className="about-breadcrumb" aria-label="Breadcrumb">
           <Link to="/">Home</Link>
@@ -203,6 +203,6 @@ export default function About() {
           </p>
         </section>
       </div>
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -161,7 +161,7 @@ export default function EventDetail() {
   )
 
   return (
-    <main className="evt-detail-page">
+    <div className="evt-detail-page">
       <div className="evt-detail-container">
 
         {/* Breadcrumb */}
@@ -258,6 +258,6 @@ export default function EventDetail() {
 
         </div>
       </div>
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/EventsIndex.jsx
+++ b/frontend/src/components/EventsIndex.jsx
@@ -125,7 +125,7 @@ export default function EventsIndex() {
   const hasNext = offset + PAGE_SIZE < totalCount
 
   return (
-    <main className="evt-index-page">
+    <div className="evt-index-page">
       <div className="evt-index-container">
         <nav className="evt-index-breadcrumb" aria-label="Breadcrumb">
           <Link to="/">Home</Link>
@@ -255,6 +255,6 @@ export default function EventsIndex() {
           </nav>
         )}
       </div>
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/LegislationDetail.jsx
+++ b/frontend/src/components/LegislationDetail.jsx
@@ -117,7 +117,7 @@ export default function LegislationDetail() {
   const showRightCol = hasKeyChanges || hasDocuments
 
   return (
-    <main className="leg-detail-page">
+    <div className="leg-detail-page">
       <div className="leg-detail-container">
 
         {/* Breadcrumb */}
@@ -336,6 +336,6 @@ export default function LegislationDetail() {
 
         </div>
       </div>
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -136,7 +136,7 @@ export default function LegislationIndex() {
   const hasNext = offset + PAGE_SIZE < totalCount
 
   return (
-    <main className="leg-index-page">
+    <div className="leg-index-page">
       <div className="leg-index-container">
         <nav className="leg-index-breadcrumb" aria-label="Breadcrumb">
           <Link to="/">Home</Link>
@@ -285,6 +285,6 @@ export default function LegislationIndex() {
           </nav>
         )}
       </div>
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/MuniCodeAppendix.jsx
+++ b/frontend/src/components/MuniCodeAppendix.jsx
@@ -30,7 +30,7 @@ export default function MuniCodeAppendix() {
   if (!data) return <LoadingView />
 
   return (
-    <main className="smc-detail-page">
+    <div className="smc-detail-page">
       <div className="smc-detail-container">
         <Breadcrumb crumbs={[
           { to: '/', label: 'Home' },
@@ -52,6 +52,6 @@ export default function MuniCodeAppendix() {
           </p>
         )}
       </div>
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/MuniCodeChapter.jsx
+++ b/frontend/src/components/MuniCodeChapter.jsx
@@ -68,7 +68,7 @@ export default function MuniCodeChapter() {
   if (!data) return <LoadingView />
 
   return (
-    <main className="smc-detail-page">
+    <div className="smc-detail-page">
       <div className="smc-detail-container">
         <Breadcrumb crumbs={[
           { to: '/', label: 'Home' },
@@ -143,6 +143,6 @@ export default function MuniCodeChapter() {
 
         <NeighborNav neighbors={data.neighbors} ariaLabel="Chapter navigation" />
       </div>
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/MuniCodeIndex.jsx
+++ b/frontend/src/components/MuniCodeIndex.jsx
@@ -131,7 +131,7 @@ export default function MuniCodeIndex() {
   const hasNext = offset + PAGE_SIZE < totalCount
 
   return (
-    <main className="smc-index-page">
+    <div className="smc-index-page">
       <div className="smc-index-container">
         <nav className="smc-breadcrumb" aria-label="Breadcrumb">
           <Link to="/">Home</Link>
@@ -219,7 +219,7 @@ export default function MuniCodeIndex() {
           <BrowseTree tree={tree} error={error} />
         )}
       </div>
-    </main>
+    </div>
   )
 }
 

--- a/frontend/src/components/MuniCodeSection.jsx
+++ b/frontend/src/components/MuniCodeSection.jsx
@@ -33,7 +33,7 @@ export default function MuniCodeSection() {
   if (!data) return <LoadingView />
 
   return (
-    <main className="smc-detail-page">
+    <div className="smc-detail-page">
       <div className="smc-detail-container">
         <Breadcrumb crumbs={[
           { to: '/', label: 'Home' },
@@ -86,6 +86,6 @@ export default function MuniCodeSection() {
 
         <NeighborNav neighbors={data.neighbors} ariaLabel="Section navigation" />
       </div>
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/MuniCodeTitle.jsx
+++ b/frontend/src/components/MuniCodeTitle.jsx
@@ -80,7 +80,7 @@ function TitlePage({ titleNumber }) {
   if (!data) return <LoadingView />
 
   return (
-    <main className="smc-detail-page">
+    <div className="smc-detail-page">
       <div className="smc-detail-container">
         <Breadcrumb crumbs={[
           { to: '/', label: 'Home' },
@@ -156,7 +156,7 @@ function TitlePage({ titleNumber }) {
 
         <NeighborNav neighbors={data.neighbors} ariaLabel="Title navigation" />
       </div>
-    </main>
+    </div>
   )
 }
 
@@ -177,9 +177,9 @@ function Breadcrumb({ crumbs }) {
 export { Breadcrumb }
 
 function LoadingView() {
-  return <main className="smc-detail-page"><div className="smc-detail-container">Loading…</div></main>
+  return <div className="smc-detail-page"><div className="smc-detail-container">Loading…</div></div>
 }
 function ErrorView({ msg }) {
-  return <main className="smc-detail-page"><div className="smc-detail-container">Could not load: {msg}</div></main>
+  return <div className="smc-detail-page"><div className="smc-detail-container">Could not load: {msg}</div></div>
 }
 export { LoadingView, ErrorView }

--- a/frontend/src/components/NotFound.jsx
+++ b/frontend/src/components/NotFound.jsx
@@ -26,13 +26,13 @@ const DEFAULT_VARIANT = {
 export default function NotFound({ kind }) {
   const v = VARIANTS[kind] ?? DEFAULT_VARIANT
   return (
-    <main className="notfound-page">
+    <div className="notfound-page">
       <div className="notfound-container">
         <p className="notfound-code">404</p>
         <h1 className="notfound-title">{v.title}</h1>
         <p className="notfound-message">{v.message}</p>
         <Link to={v.linkTo} className="notfound-home-link">{v.linkLabel}</Link>
       </div>
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/RepDetail.jsx
+++ b/frontend/src/components/RepDetail.jsx
@@ -26,14 +26,14 @@ export default function RepDetail() {
 
   if (status === 404) return <NotFound />
   if (error) return (
-    <main className="rep-detail-page"><div className="rep-detail-container">Could not load: {error}</div></main>
+    <div className="rep-detail-page"><div className="rep-detail-container">Could not load: {error}</div></div>
   )
   if (!data) return (
-    <main className="rep-detail-page"><div className="rep-detail-container">Loading…</div></main>
+    <div className="rep-detail-page"><div className="rep-detail-container">Loading…</div></div>
   )
 
   return (
-    <main className="rep-detail-page">
+    <div className="rep-detail-page">
       <div className="rep-detail-container">
         <nav className="rep-detail-breadcrumb" aria-label="Breadcrumb">
           <Link to="/">Home</Link>
@@ -113,6 +113,6 @@ export default function RepDetail() {
           </section>
         )}
       </div>
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/RepDistrict.jsx
+++ b/frontend/src/components/RepDistrict.jsx
@@ -26,16 +26,16 @@ export default function RepDistrict() {
 
   if (status === 404) return <NotFound />
   if (error) return (
-    <main className="rep-district-page"><div className="rep-district-container">Could not load: {error}</div></main>
+    <div className="rep-district-page"><div className="rep-district-container">Could not load: {error}</div></div>
   )
   if (!data) return (
-    <main className="rep-district-page"><div className="rep-district-container">Loading…</div></main>
+    <div className="rep-district-page"><div className="rep-district-container">Loading…</div></div>
   )
 
   const accent = DISTRICT_COLORS[data.district.number] || '#2E3D5B'
 
   return (
-    <main className="rep-district-page">
+    <div className="rep-district-page">
       <div className="rep-district-container">
         <nav className="rep-district-breadcrumb" aria-label="Breadcrumb">
           <Link to="/">Home</Link>
@@ -85,7 +85,7 @@ export default function RepDistrict() {
           </ul>
         </section>
       </div>
-    </main>
+    </div>
   )
 }
 

--- a/frontend/src/components/RepsIndex.jsx
+++ b/frontend/src/components/RepsIndex.jsx
@@ -21,7 +21,7 @@ export default function RepsIndex() {
   }, [])
 
   return (
-    <main className="reps-page">
+    <div className="reps-page">
       <div className="reps-container">
         <nav className="reps-breadcrumb" aria-label="Breadcrumb">
           <Link to="/">Home</Link>
@@ -86,7 +86,7 @@ export default function RepsIndex() {
           </>
         )}
       </div>
-    </main>
+    </div>
   )
 }
 

--- a/frontend/src/components/Search.jsx
+++ b/frontend/src/components/Search.jsx
@@ -58,7 +58,7 @@ export default function Search() {
   }, [q])
 
   return (
-    <main className="search-page">
+    <div className="search-page">
       <div className="search-container">
         <nav className="search-breadcrumb" aria-label="Breadcrumb">
           <Link to="/">Home</Link>
@@ -151,7 +151,7 @@ export default function Search() {
           </>
         )}
       </div>
-    </main>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

Adds a keyboard-accessible skip-link as the first focusable element on every page, and consolidates 15 per-page `<main>` landmarks into a single `<main id="main-content">` wrapping `<Routes>`.

### P1.2 — Skip-link (WCAG 2.4.1 Bypass Blocks)
Visually hidden until focused; on Tab from the URL bar, drops in from the top of the viewport with a navy pill that links to `#main-content`. Lets keyboard / screen-reader users skip the header + nav without tabbing through every nav item.

### P1.3 — Single `<main>`
Before this PR, each detail page rendered its own `<main className="...-page">` wrapper (15 of them across the SPA), and the homepage rendered as a `<>`-fragment of `LegislationHero + ThisWeek` with no `<main>` at all. Now `App.jsx` wraps `<Routes>` in a single `<main id="main-content" tabIndex={-1}>`, and each page's outer wrapper becomes `<div className="...-page">` — same CSS, same layout, just one canonical landmark per page.

`tabIndex={-1}` lets the skip-link move keyboard focus into `<main>` programmatically; the focus outline is suppressed via `main#main-content:focus { outline: none }` so it doesn't render a visual ring around the entire region.

### Mechanical change
Used `sed -i 's|<main className=|<div className=|g; s|</main>|</div>|g'` across the 15 component files. Verified no other `<main>`/`</main>` references remain in `frontend/src/` except the new one in `App.jsx`.

## Test plan
- [ ] Hard-refresh any page; press Tab once. The "Skip to main content" pill should slide in at the top-left.
- [ ] Press Enter on it. Focus should jump past the header into the page content; the next Tab should land on the first interactive element inside `<main>` (a breadcrumb link, search input, etc.) rather than back at the navbar.
- [ ] Visit `/` (homepage). DevTools → Accessibility tree should show one `<main>` landmark wrapping LegislationHero + ThisWeek.
- [ ] Visit any detail page. Same — exactly one `<main>` landmark.
- [ ] Confirm visual layout is unchanged on every page (the page-specific CSS class is still on the same div, just no longer a `<main>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)