### PR TITLE
a11y: heading hierarchy (PR 3/7)

### DIFF
--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -81,7 +81,7 @@ export default function EventCard({ event, backToSearch }) {
         <div className="evt-card-title-row">
           <TypeChip type={type} />
           {cancelled && <span className="evt-card-cancelled-badge">Cancelled</span>}
-          <h4 className="evt-card-title">
+          <h3 className="evt-card-title">
             {slug ? (
               <Link to={`/events/${slug}`} state={linkState} className="evt-card-link">
                 {name}
@@ -89,7 +89,7 @@ export default function EventCard({ event, backToSearch }) {
             ) : (
               name
             )}
-          </h4>
+          </h3>
         </div>
         <p className="evt-card-date">{formatEventDate(start_date)}</p>
       </div>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -18,7 +18,10 @@ export default function Header() {
 
             {/* title and subtitle */}
             <div>
-              <h1 className="title">Seattle Councilmatic</h1>
+              {/* Branding wordmark, not a heading — using <p> so each
+                  page's actual <h1> (bill identifier, section number,
+                  rep name, etc.) is the only h1 in the document. */}
+              <p className="title">Seattle Councilmatic</p>
               <p className="subtitle">
                 An easy way to follow Seattle City Council activity and find local bills.
               </p>

--- a/frontend/src/components/LegislationCard.jsx
+++ b/frontend/src/components/LegislationCard.jsx
@@ -58,7 +58,7 @@ export default function LegislationCard({ bill, backToSearch }) {
         )}
       </div>
 
-      <h4 className="leg-card-title">
+      <h3 className="leg-card-title">
         {slug ? (
           <Link to={`/legislation/${slug}`} state={linkState} className="leg-card-link">
             {titleNode}
@@ -66,7 +66,7 @@ export default function LegislationCard({ bill, backToSearch }) {
         ) : (
           titleNode
         )}
-      </h4>
+      </h3>
 
       {sponsor && (
         <p className="leg-card-sponsor">Sponsor: {sponsor}</p>

--- a/frontend/src/components/LegislationHero.jsx
+++ b/frontend/src/components/LegislationHero.jsx
@@ -26,7 +26,7 @@ export default function LegislationHero() {
     <div className="home-hero">
       <div className="home-hero-overlay" />
       <div className="home-hero-content">
-        <h2 className="home-hero-title">Search Seattle Government</h2>
+        <h1 className="home-hero-title">Search Seattle Government</h1>
         <p className="home-hero-subtitle">
           Find bills, resolutions, and the Municipal Code in one search.
         </p>

--- a/frontend/src/components/ThisWeek.jsx
+++ b/frontend/src/components/ThisWeek.jsx
@@ -7,10 +7,10 @@ import './ThisWeek.css';
 function SectionHeader({ icon: Icon, title, subtitle }) {
   return (
     <div className="tw-section-header">
-      <h3 className="tw-section-title">
+      <h2 className="tw-section-title">
         <Icon className="tw-section-icon" size={36} aria-hidden="true" />
         {title}
-      </h3>
+      </h2>
       <p className="tw-section-subtitle">{subtitle}</p>
     </div>
   );
@@ -62,7 +62,7 @@ export default function ThisWeek() {
   }, []);
 
   return (
-    <section id="this-week" className="this-week" aria-labelledby="tw-heading">
+    <section id="this-week" className="this-week">
       <div className="tw-inner">
         <div className="tw-grid">
 


### PR DESCRIPTION
## Summary

Resolves the two heading-related findings from AUDIT_FINDINGS.md, plus a broken `aria-labelledby` reference noticed along the way.

### P1.4 — single h1 per page
`Header.jsx`'s branding wordmark "Seattle Councilmatic" was an `<h1>`. Since Header is rendered on every page, every page had two h1s — one for the brand, one for the page subject. The wordmark is now `<p className="title">`. `.title` already sets font-size/weight/margin explicitly, so visual output is unchanged.

### P1.5 — fix heading-level skips
- **`LegislationHero.jsx`**: `<h2>` "Search Seattle Government" → `<h1>`. The homepage was without an h1 once the Header brand was demoted; the hero search heading is the natural primary heading for the landing page.
- **`ThisWeek.jsx`**: SectionHeader's `<h3>` → `<h2>`. With the homepage h1 in LegislationHero, the section headings ("Recent Legislation", "Upcoming Events") should be h2 — no more h1→h3 skip.
- **`LegislationCard.jsx`**: `<h4>` → `<h3>`. Index pages have h1 (page title) → h2 (section) → cards, so card titles are h3.
- **`EventCard.jsx`**: same change as LegislationCard.

### Side fix — broken aria-labelledby
`ThisWeek.jsx`'s outer `<section>` had `aria-labelledby="tw-heading"` but no element with that id existed anywhere. Broken reference is an a11y bug in its own right. The two SectionHeaders inside already have their own labeled h2s, so the outer section doesn't need a label — dropped the attribute.

## Test plan
- [ ] DevTools → Accessibility tree on the homepage. Should show one `<h1>` ("Search Seattle Government") and two `<h2>`s ("Recent Legislation", "Upcoming Events"). No more "Seattle Councilmatic" `<h1>`.
- [ ] Same check on a bill detail (`/legislation/cb-121200`): one `<h1>` (bill title), `<h2>`s for Details / Action history / Plain-language summary / Key changes / Documents.
- [ ] Same on `/legislation`: one `<h1>` (Legislation), card titles render as `<h3>`.
- [ ] Confirm visual output is unchanged (the heading classes set explicit font sizes; tag changes are semantic-only).
- [ ] Run an a11y scanner (axe or Firefox Accessibility Inspector) on the homepage and any detail page. Heading-order checks should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)