### PR TITLE
a11y: contrast fixes — #9ca3af → #6b7280 on meaningful text (PR 4/7)

### DIFF
--- a/frontend/src/components/EventCard.css
+++ b/frontend/src/components/EventCard.css
@@ -87,7 +87,7 @@
 
 .evt-card--cancelled .evt-card-title,
 .evt-card--cancelled .evt-card-date {
-  color: #9ca3af;
+  color: #6b7280;
 }
 
 .evt-card--cancelled .evt-card-title {

--- a/frontend/src/components/EventDetail.css
+++ b/frontend/src/components/EventDetail.css
@@ -281,7 +281,7 @@
 .evt-agenda-seq {
   font-size: 0.875rem;
   font-weight: 700;
-  color: #9ca3af;
+  color: #6b7280;
   min-width: 1.5rem;
   padding-top: 0.125rem;
   flex-shrink: 0;
@@ -328,7 +328,7 @@
 
 .evt-agenda-status {
   font-size: 0.75rem;
-  color: #9ca3af;
+  color: #6b7280;
 }
 
 .evt-agenda-action {

--- a/frontend/src/components/LegislationDetail.css
+++ b/frontend/src/components/LegislationDetail.css
@@ -388,7 +388,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #9ca3af;
+  color: #6b7280;
   margin: 1rem 0 0.375rem;
 }
 

--- a/frontend/src/components/LegislationHero.css
+++ b/frontend/src/components/LegislationHero.css
@@ -80,7 +80,7 @@
 }
 
 .home-hero-search-input::placeholder {
-  color: #9ca3af;
+  color: #6b7280;
 }
 
 .home-hero-search-btn {

--- a/frontend/src/components/MuniCodeDetail.css
+++ b/frontend/src/components/MuniCodeDetail.css
@@ -101,7 +101,7 @@
 }
 
 .smc-empty {
-  color: #9ca3af;
+  color: #6b7280;
   font-style: italic;
   margin: 0.5rem 0;
 }
@@ -141,7 +141,7 @@
   min-width: 0;
 }
 .smc-scoped-search-input::placeholder {
-  color: #9ca3af;
+  color: #6b7280;
 }
 /* Clear-search X button — only rendered when the input has text.
    Submit/Enter still triggers immediate navigation via the form
@@ -238,6 +238,6 @@
 .smc-source-note {
   margin-top: 2rem;
   font-size: 0.8125rem;
-  color: #9ca3af;
+  color: #6b7280;
   font-style: italic;
 }

--- a/frontend/src/components/RepDistrict.css
+++ b/frontend/src/components/RepDistrict.css
@@ -118,6 +118,6 @@
 }
 
 .rep-district-empty {
-  color: #9ca3af;
+  color: #6b7280;
   font-style: italic;
 }


### PR DESCRIPTION
## Summary

P1.6 from `AUDIT_FINDINGS.md`. `#9ca3af` (Tailwind gray-400) on white = **2.85:1** contrast — fails WCAG 1.4.3 AA (4.5:1 required for normal text). `#6b7280` (Tailwind gray-500) = **4.83:1** — passes AA.

Surgically bumped 9 instances where gray-400 was rendering meaningful text:
- `EventCard` cancelled-state title/date
- `EventDetail` agenda sequence number, agenda status
- `LegislationDetail` cosponsor label
- `LegislationHero` / `MuniCodeDetail` search-input placeholder
- `MuniCodeDetail` empty-state, source note
- `RepDistrict` empty-state

### Kept `#9ca3af` on `*-breadcrumb-sep`
The 10 breadcrumb separator classes (e.g. `.about-breadcrumb-sep`, `.leg-detail-breadcrumb-sep`) all render decorative `/` glyphs via `<span aria-hidden="true">/</span>`. WCAG 1.4.3 has a carve-out for "decoration, formatting, invisible," and these qualify — they're presentational delimiters, not content. Bumping them to `#6b7280` would flatten the breadcrumb hierarchy by making the separator visually compete with the links.

If a future strict-mode tool flags them anyway, easy follow-up.

## Test plan
- [ ] Run axe DevTools or Firefox Accessibility Inspector contrast scan on the homepage and a bill detail. Should see no contrast failures on the items I bumped.
- [ ] Confirm the cancelled-event card on `/events` (any cancelled meeting) still reads as visually muted but the text is now legible.
- [ ] Confirm placeholder text in the homepage hero search and the SMC scoped search reads slightly darker but still feels like a placeholder.
- [ ] Confirm empty-state messages ("No body text available for this section.", etc.) remain readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)