### PR TITLE
a11y: aria-live announcements for loading + dynamic content (PR 5/7)

### DIFF
--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -150,9 +150,9 @@ export default function EventDetail() {
       .catch(e => { setError(e.message); setLoading(false) })
   }, [slug])
 
-  if (loading)  return <div className="evt-detail-loading">Loading…</div>
+  if (loading)  return <div role="status" className="evt-detail-loading">Loading…</div>
   if (notFound) return <NotFound kind="event" />
-  if (error)    return <div className="evt-detail-error">Could not load event: {error}</div>
+  if (error)    return <div role="alert" className="evt-detail-error">Could not load event: {error}</div>
 
   const legistarUrl = event.legistar_url || null
   // Filter out items that have no matter_file and no attachments (pure procedural notes)

--- a/frontend/src/components/EventsIndex.jsx
+++ b/frontend/src/components/EventsIndex.jsx
@@ -209,7 +209,7 @@ export default function EventsIndex() {
           </label>
         </div>
 
-        <div className="evt-index-summary">
+        <div role="status" className="evt-index-summary">
           {loading
             ? 'Loading…'
             : error

--- a/frontend/src/components/LegislationDetail.jsx
+++ b/frontend/src/components/LegislationDetail.jsx
@@ -105,9 +105,9 @@ export default function LegislationDetail() {
       .catch(e => { setError(e.message); setLoading(false) })
   }, [slug])
 
-  if (loading)  return <div className="leg-detail-loading">Loading…</div>
+  if (loading)  return <div role="status" className="leg-detail-loading">Loading…</div>
   if (notFound) return <NotFound kind="legislation" />
-  if (error)    return <div className="leg-detail-error">Could not load legislation: {error}</div>
+  if (error)    return <div role="alert" className="leg-detail-error">Could not load legislation: {error}</div>
 
   const primarySponsors = bill.sponsors.filter(s => s.primary)
   const coSponsors      = bill.sponsors.filter(s => !s.primary)

--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -239,7 +239,7 @@ export default function LegislationIndex() {
           </label>
         </div>
 
-        <div className="leg-index-summary">
+        <div role="status" className="leg-index-summary">
           {loading
             ? 'Loading…'
             : error

--- a/frontend/src/components/MuniCodeIndex.jsx
+++ b/frontend/src/components/MuniCodeIndex.jsx
@@ -233,7 +233,7 @@ function SearchResults({ loading, error, results, totalCount, mode, currentPage,
                         totalPages, hasPrev, hasNext, goToOffset, offset }) {
   return (
     <>
-      <div className="smc-index-summary">
+      <div role="status" className="smc-index-summary">
         {loading
           ? 'Loading…'
           : error
@@ -298,8 +298,8 @@ function SearchResults({ loading, error, results, totalCount, mode, currentPage,
 }
 
 function BrowseTree({ tree, error }) {
-  if (error) return <div className="smc-index-summary">Could not load: {error}</div>
-  if (!tree) return <div className="smc-index-summary">Loading titles…</div>
+  if (error) return <div role="alert" className="smc-index-summary">Could not load: {error}</div>
+  if (!tree) return <div role="status" className="smc-index-summary">Loading titles…</div>
 
   return (
     <section className="smc-browse" aria-label="Browse by title">

--- a/frontend/src/components/MuniCodeTitle.jsx
+++ b/frontend/src/components/MuniCodeTitle.jsx
@@ -177,9 +177,9 @@ function Breadcrumb({ crumbs }) {
 export { Breadcrumb }
 
 function LoadingView() {
-  return <div className="smc-detail-page"><div className="smc-detail-container">Loading…</div></div>
+  return <div className="smc-detail-page"><div role="status" className="smc-detail-container">Loading…</div></div>
 }
 function ErrorView({ msg }) {
-  return <div className="smc-detail-page"><div className="smc-detail-container">Could not load: {msg}</div></div>
+  return <div className="smc-detail-page"><div role="alert" className="smc-detail-container">Could not load: {msg}</div></div>
 }
 export { LoadingView, ErrorView }

--- a/frontend/src/components/RepDetail.jsx
+++ b/frontend/src/components/RepDetail.jsx
@@ -26,10 +26,10 @@ export default function RepDetail() {
 
   if (status === 404) return <NotFound />
   if (error) return (
-    <div className="rep-detail-page"><div className="rep-detail-container">Could not load: {error}</div></div>
+    <div className="rep-detail-page"><div role="alert" className="rep-detail-container">Could not load: {error}</div></div>
   )
   if (!data) return (
-    <div className="rep-detail-page"><div className="rep-detail-container">Loading…</div></div>
+    <div className="rep-detail-page"><div role="status" className="rep-detail-container">Loading…</div></div>
   )
 
   return (

--- a/frontend/src/components/RepDistrict.jsx
+++ b/frontend/src/components/RepDistrict.jsx
@@ -26,10 +26,10 @@ export default function RepDistrict() {
 
   if (status === 404) return <NotFound />
   if (error) return (
-    <div className="rep-district-page"><div className="rep-district-container">Could not load: {error}</div></div>
+    <div className="rep-district-page"><div role="alert" className="rep-district-container">Could not load: {error}</div></div>
   )
   if (!data) return (
-    <div className="rep-district-page"><div className="rep-district-container">Loading…</div></div>
+    <div className="rep-district-page"><div role="status" className="rep-district-container">Loading…</div></div>
   )
 
   const accent = DISTRICT_COLORS[data.district.number] || '#2E3D5B'

--- a/frontend/src/components/Search.jsx
+++ b/frontend/src/components/Search.jsx
@@ -92,7 +92,7 @@ export default function Search() {
           <p className="search-empty">Type a keyword or citation above to begin searching.</p>
         )}
 
-        {q && error && <div className="search-error">Could not load: {error}</div>}
+        {q && error && <div role="alert" className="search-error">Could not load: {error}</div>}
 
         {q && !error && (
           <>
@@ -173,10 +173,10 @@ function SearchSection({ title, total, loading, viewAllPath, empty, children }) 
         )}
       </div>
       {loading
-        ? <div className="search-section-status">Loading…</div>
+        ? <div role="status" className="search-section-status">Loading…</div>
         : hasResults
           ? children
-          : <div className="search-section-status">{empty}</div>}
+          : <div role="status" className="search-section-status">{empty}</div>}
     </section>
   )
 }

--- a/frontend/src/components/ThisWeek.jsx
+++ b/frontend/src/components/ThisWeek.jsx
@@ -27,14 +27,14 @@ function ViewAllLink({ href, label }) {
 
 function LoadingSpinner() {
   return (
-    <div className="tw-loading" aria-label="Loading">
+    <div role="status" className="tw-loading" aria-label="Loading">
       <Loader2 className="tw-spinner" size={28} />
     </div>
   );
 }
 
 function ErrorMessage({ message }) {
-  return <p className="tw-error">{message}</p>;
+  return <p role="alert" className="tw-error">{message}</p>;
 }
 
 export default function ThisWeek() {


### PR DESCRIPTION
## Summary

Annotates loading, error, and result-count regions with ARIA live-region roles so screen-reader users get notified of state transitions instead of staring at a frozen page.

### `role="status"` (polite — announces when SR user is idle)
- Detail-page loading divs: `LegislationDetail`, `EventDetail`, `RepDetail`, `RepDistrict`, `MuniCodeTitle`'s shared `LoadingView`
- Index-page combined summary divs (the same div that shows "Loading…" → "127 results" → "No matching results"): `LegislationIndex`, `EventsIndex`, `MuniCodeIndex` (search summary + tree-load loading)
- `Search` per-section loading + empty-state announcements
- `ThisWeek` homepage loading spinner

### `role="alert"` (assertive — interrupts SR user)
- Detail-page error divs across the same components
- `MuniCodeIndex` tree-load error
- `Search` load error
- `ThisWeek` error message

### Why combined divs got `status` rather than `alert`
On index pages, the same `<div className="...-summary">` element transitions through Loading → Results count → (rare) Error. Picking `role="alert"` would interrupt the user during a normal filter change — too aggressive. `role="status"` (polite) lets the SR announce the new count when the user pauses typing. Standalone error-only divs (`MuniCodeIndex` line 301, `Search` line 95) stay on `role="alert"` since there's no benign-transition case to compete with.

No visual changes — purely ARIA annotations. Bundle builds clean.

## Test plan
- [ ] Open Firefox Accessibility Inspector → Audit, run on `/legislation`. Expected: the summary div renders as a live region; no "missing aria-live" or similar audit findings.
- [ ] Type into the search filter on `/legislation`; SR (NVDA, VoiceOver, Orca) should announce the new result count after a brief pause.
- [ ] Navigate to a bill detail page on a slow connection (or DevTools network throttling): SR should announce "Loading" then the page heading once loaded.
- [ ] Force an error (block the API in DevTools): SR should announce the error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)