### PR TITLE
a11y: per-page <title> via useDocumentTitle hook (PR 6/7)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,9 +18,11 @@ import RepDistrict from './components/RepDistrict'
 import Search from './components/Search'
 import About from './components/About'
 import NotFound from './components/NotFound'
+import useDocumentTitle from './hooks/useDocumentTitle'
 import './App.css'
 
 function HomePage() {
+  useDocumentTitle(null) // Just "Seattle Councilmatic" — site is the page subject.
   return (
     <>
       <LegislationHero />

--- a/frontend/src/components/About.jsx
+++ b/frontend/src/components/About.jsx
@@ -1,10 +1,12 @@
 import { Link } from 'react-router-dom'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './About.css'
 
 const REPO_URL = 'https://github.com/SeattleCouncilmatic/seattle-councilmatic'
 const CONTACT_EMAIL = 'contact@seattlecouncilmatic.org'
 
 export default function About() {
+  useDocumentTitle('About')
   return (
     <div className="about-page">
       <div className="about-container">

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useLocation, Link } from 'react-router-dom'
 import NotFound from './NotFound'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './EventDetail.css'
 
 function formatDateTime(isoString) {
@@ -129,6 +130,7 @@ export default function EventDetail() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [notFound, setNotFound] = useState(false)
+  useDocumentTitle(event?.name)
 
   useEffect(() => {
     setLoading(true)

--- a/frontend/src/components/EventsIndex.jsx
+++ b/frontend/src/components/EventsIndex.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from 'react'
 import { useSearchParams, Link } from 'react-router-dom'
 import EventCard from './EventCard'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './EventsIndex.css'
 
 const PAGE_SIZE = 20
@@ -13,6 +14,7 @@ const TIME_LABELS = {
 }
 
 export default function EventsIndex() {
+  useDocumentTitle('Events')
   const [searchParams, setSearchParams] = useSearchParams()
 
   const q = searchParams.get('q') ?? ''

--- a/frontend/src/components/LegislationDetail.jsx
+++ b/frontend/src/components/LegislationDetail.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams, useLocation, Link } from 'react-router-dom'
 import NotFound from './NotFound'
 import BillLinkify from './BillLinkify'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './LegislationDetail.css'
 
 const VARIANT_CLASSES = {
@@ -84,6 +85,7 @@ export default function LegislationDetail() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [notFound, setNotFound] = useState(false)
+  useDocumentTitle(bill?.identifier)
 
   useEffect(() => {
     setLoading(true)

--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -1,12 +1,14 @@
 import { useEffect, useState, useRef } from 'react'
 import { useSearchParams, Link } from 'react-router-dom'
 import LegislationCard from './LegislationCard'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './LegislationIndex.css'
 
 const PAGE_SIZE = 20
 const SEARCH_DEBOUNCE_MS = 300
 
 export default function LegislationIndex() {
+  useDocumentTitle('Legislation')
   const [searchParams, setSearchParams] = useSearchParams()
 
   const q = searchParams.get('q') ?? ''

--- a/frontend/src/components/MuniCodeAppendix.jsx
+++ b/frontend/src/components/MuniCodeAppendix.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import NotFound from './NotFound'
 import SectionText from './SectionText'
 import { Breadcrumb, LoadingView, ErrorView } from './MuniCodeTitle'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './MuniCodeDetail.css'
 
 export default function MuniCodeAppendix() {
@@ -11,6 +12,7 @@ export default function MuniCodeAppendix() {
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
   const [status, setStatus] = useState(null)
+  useDocumentTitle(data ? `Title ${data.title_number} Appendix ${data.label}` : null)
 
   useEffect(() => {
     setData(null); setError(null); setStatus(null)

--- a/frontend/src/components/MuniCodeChapter.jsx
+++ b/frontend/src/components/MuniCodeChapter.jsx
@@ -4,6 +4,7 @@ import { Search as SearchIcon, X as XIcon } from 'lucide-react'
 import NotFound from './NotFound'
 import NeighborNav from './NeighborNav'
 import { Breadcrumb, LoadingView, ErrorView } from './MuniCodeTitle'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './MuniCodeDetail.css'
 
 const SCOPED_SEARCH_DEBOUNCE_MS = 300
@@ -18,6 +19,7 @@ export default function MuniCodeChapter() {
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
   const [status, setStatus] = useState(null)
+  useDocumentTitle(data ? `Chapter ${data.chapter_number}` : null)
   const [chapterSearch, setChapterSearch] = useState('')
   const debounceTimer = useRef(null)
 

--- a/frontend/src/components/MuniCodeIndex.jsx
+++ b/frontend/src/components/MuniCodeIndex.jsx
@@ -1,12 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { X as XIcon } from 'lucide-react'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './MuniCodeIndex.css'
 
 const PAGE_SIZE = 20
 const SEARCH_DEBOUNCE_MS = 300
 
 export default function MuniCodeIndex() {
+  useDocumentTitle('Municipal Code')
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
 

--- a/frontend/src/components/MuniCodeSection.jsx
+++ b/frontend/src/components/MuniCodeSection.jsx
@@ -5,6 +5,7 @@ import NeighborNav from './NeighborNav'
 import SectionText from './SectionText'
 import BillLinkify from './BillLinkify'
 import { Breadcrumb, LoadingView, ErrorView } from './MuniCodeTitle'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './MuniCodeDetail.css'
 
 export default function MuniCodeSection() {
@@ -14,6 +15,7 @@ export default function MuniCodeSection() {
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
   const [status, setStatus] = useState(null)
+  useDocumentTitle(data ? `SMC ${data.section_number}` : null)
 
   useEffect(() => {
     setData(null); setError(null); setStatus(null)

--- a/frontend/src/components/MuniCodeTitle.jsx
+++ b/frontend/src/components/MuniCodeTitle.jsx
@@ -3,6 +3,7 @@ import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
 import { Search as SearchIcon, X as XIcon } from 'lucide-react'
 import NotFound from './NotFound'
 import NeighborNav from './NeighborNav'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './MuniCodeDetail.css'
 
 const SCOPED_SEARCH_DEBOUNCE_MS = 300
@@ -32,6 +33,7 @@ function TitlePage({ titleNumber }) {
   const [status, setStatus] = useState(null)
   const [titleSearch, setTitleSearch] = useState('')
   const debounceTimer = useRef(null)
+  useDocumentTitle(data ? `Title ${data.title_number}` : null)
 
   const navigateToScopedResults = (term) => {
     const trimmed = term.trim()

--- a/frontend/src/components/NotFound.jsx
+++ b/frontend/src/components/NotFound.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './NotFound.css'
 
 const VARIANTS = {
@@ -25,6 +26,7 @@ const DEFAULT_VARIANT = {
 
 export default function NotFound({ kind }) {
   const v = VARIANTS[kind] ?? DEFAULT_VARIANT
+  useDocumentTitle(v.title)
   return (
     <div className="notfound-page">
       <div className="notfound-container">

--- a/frontend/src/components/RepDetail.jsx
+++ b/frontend/src/components/RepDetail.jsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom'
 import { Phone, Mail, ExternalLink, Clock } from 'lucide-react'
 import NotFound from './NotFound'
 import LegislationCard from './LegislationCard'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './RepDetail.css'
 
 export default function RepDetail() {
@@ -10,6 +11,7 @@ export default function RepDetail() {
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
   const [status, setStatus] = useState(null)
+  useDocumentTitle(data?.name)
 
   useEffect(() => {
     setData(null); setError(null); setStatus(null)

--- a/frontend/src/components/RepDistrict.jsx
+++ b/frontend/src/components/RepDistrict.jsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom'
 import NotFound from './NotFound'
 import DistrictMiniMap from './DistrictMiniMap'
 import { DISTRICT_COLORS } from './districtColors'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './RepDistrict.css'
 
 export default function RepDistrict() {
@@ -10,6 +11,7 @@ export default function RepDistrict() {
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
   const [status, setStatus] = useState(null)
+  useDocumentTitle(data ? `District ${number}` : null)
 
   useEffect(() => {
     setData(null); setError(null); setStatus(null)

--- a/frontend/src/components/RepsIndex.jsx
+++ b/frontend/src/components/RepsIndex.jsx
@@ -3,9 +3,11 @@ import { Link, useNavigate } from 'react-router-dom'
 import { AlertCircle } from 'lucide-react'
 import CouncilMap from './CouncilMap'
 import { DISTRICT_COLORS } from './districtColors'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './RepsIndex.css'
 
 export default function RepsIndex() {
+  useDocumentTitle('City Council')
   const [data, setData] = useState(null)
   const [loadError, setLoadError] = useState(null)
   // Hover sync between CouncilMap and the district cards: hovering a

--- a/frontend/src/components/Search.jsx
+++ b/frontend/src/components/Search.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { Search as SearchIcon } from 'lucide-react'
 import LegislationCard from './LegislationCard'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 import './Search.css'
 
 const TOP_N = 5
@@ -16,6 +17,7 @@ const SEARCH_DEBOUNCE_MS = 300
 export default function Search() {
   const [searchParams, setSearchParams] = useSearchParams()
   const q = searchParams.get('q') ?? ''
+  useDocumentTitle(q ? `Search: ${q}` : 'Search')
 
   const [legResults, setLegResults] = useState(null)   // { results, total_count } | null
   const [smcResults, setSmcResults] = useState(null)

--- a/frontend/src/hooks/useDocumentTitle.js
+++ b/frontend/src/hooks/useDocumentTitle.js
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+
+const SITE_NAME = 'Seattle Councilmatic'
+
+// Sets <title> to "<pageTitle> — Seattle Councilmatic" on mount /
+// when pageTitle changes; falls back to just "Seattle Councilmatic"
+// when pageTitle is empty/undefined (so a detail page in its loading
+// state doesn't leak the previous page's title — pass `null` until
+// the data resolves).
+//
+// WCAG 2.4.2 (Page Titled). Pair with a single <h1> per page so the
+// browser tab, bookmark, and screen-reader page announcement all
+// align.
+export default function useDocumentTitle(pageTitle) {
+  useEffect(() => {
+    document.title = pageTitle
+      ? `${pageTitle} — ${SITE_NAME}`
+      : SITE_NAME
+  }, [pageTitle])
+}


### PR DESCRIPTION
## Summary

Tiny custom hook (`frontend/src/hooks/useDocumentTitle.js`) that sets `document.title` to `<page> — Seattle Councilmatic` (or just `Seattle Councilmatic` when `null` is passed), plumbed into every routed page component.

WCAG 2.4.2 (Page Titled). Pairs with PR #107's heading-hierarchy fix so the browser tab, bookmark, and screen-reader announcement all align with the page's `<h1>`.

### Title catalog

**Index pages** — static titles:
| Page | Title |
|---|---|
| HomePage | `Seattle Councilmatic` |
| LegislationIndex | `Legislation — Seattle Councilmatic` |
| EventsIndex | `Events — Seattle Councilmatic` |
| MuniCodeIndex | `Municipal Code — Seattle Councilmatic` |
| RepsIndex | `City Council — Seattle Councilmatic` |
| About | `About — Seattle Councilmatic` |
| Search (no query) | `Search — Seattle Councilmatic` |
| Search (with query) | `Search: <q> — Seattle Councilmatic` |
| NotFound | `<variant title> — Seattle Councilmatic` |

**Detail pages** — data-derived; pass `null` while loading so the previous page's title doesn't leak:
| Page | Title |
|---|---|
| LegislationDetail | `CB 121200 — Seattle Councilmatic` |
| EventDetail | `<event name> — Seattle Councilmatic` |
| MuniCodeTitle | `Title 23 — Seattle Councilmatic` |
| MuniCodeChapter | `Chapter 23.32 — Seattle Councilmatic` |
| MuniCodeSection | `SMC 23.32.040 — Seattle Councilmatic` |
| MuniCodeAppendix | `Title 15 Appendix I and II — Seattle Councilmatic` |
| RepDetail | `Dan Strauss — Seattle Councilmatic` |
| RepDistrict | `District 6 — Seattle Councilmatic` |

### Implementation note

Hook is `useEffect`-based and re-runs whenever the title arg changes. Each `useDocumentTitle(...)` call sits above any conditional returns to satisfy React's hooks-ordering rules. On detail pages, the hook is called with `data?.field`, which is `undefined` during loading → falls through to just `Seattle Councilmatic` until data resolves.

## Test plan
- [ ] Visit each index page; browser tab should show the right title.
- [ ] Visit a bill detail (`/legislation/cb-121200`); tab title should flip from `Seattle Councilmatic` → `CB 121200 — Seattle Councilmatic` after data loads.
- [ ] Visit `/search?q=parking`; tab should show `Search: parking — Seattle Councilmatic`.
- [ ] Bookmark a couple of pages and confirm the bookmark inherits the per-page title.
- [ ] Screen reader: navigate between pages and confirm the page-title announcement matches the `<h1>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)