### PR TITLE
a11y: visible filter labels + disabled-button contrast (FF audit pass 1)

### DIFF
--- a/frontend/src/components/EventsIndex.css
+++ b/frontend/src/components/EventsIndex.css
@@ -58,11 +58,29 @@
   gap: 0.75rem;
   margin-bottom: 1rem;
   flex-wrap: wrap;
-  align-items: stretch;
+  align-items: flex-end;
+}
+
+/* See LegislationIndex.css `.leg-index-field` for the rationale —
+   visible-label wrapper for each filter control. */
+.evt-index-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.evt-index-field--search {
+  flex: 1 1 16rem;
+}
+
+.evt-index-field-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #374151;
 }
 
 .evt-index-search {
-  flex: 1 1 16rem;
+  width: 100%;
   padding: 0.625rem 0.875rem;
   font-size: 1rem;
   border: 2px solid #e5e7eb;
@@ -205,7 +223,7 @@
 }
 
 .evt-index-page-btn:disabled {
-  opacity: 0.4;
+  opacity: 0.6;
   cursor: not-allowed;
 }
 

--- a/frontend/src/components/EventsIndex.jsx
+++ b/frontend/src/components/EventsIndex.jsx
@@ -142,37 +142,43 @@ export default function EventsIndex() {
         </header>
 
         <div className="evt-index-controls">
-          <input
-            type="search"
-            className="evt-index-search"
-            placeholder="Search by committee or event name…"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            aria-label="Search events"
-            autoFocus
-          />
-          <select
-            className="evt-index-type"
-            value={type}
-            onChange={handleTypeChange}
-            aria-label="Filter by event type"
-          >
-            <option value="">All types</option>
-            {typeValues.map(t => (
-              <option key={t} value={t}>{t}</option>
-            ))}
-          </select>
-          <select
-            className="evt-index-type"
-            value={committee}
-            onChange={handleCommitteeChange}
-            aria-label="Filter by committee"
-          >
-            <option value="">All committees</option>
-            {committeeValues.map(c => (
-              <option key={c} value={c}>{c}</option>
-            ))}
-          </select>
+          <label className="evt-index-field evt-index-field--search">
+            <span className="evt-index-field-label">Search</span>
+            <input
+              type="search"
+              className="evt-index-search"
+              placeholder="Search by committee or event name…"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              autoFocus
+            />
+          </label>
+          <label className="evt-index-field">
+            <span className="evt-index-field-label">Type</span>
+            <select
+              className="evt-index-type"
+              value={type}
+              onChange={handleTypeChange}
+            >
+              <option value="">All types</option>
+              {typeValues.map(t => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </label>
+          <label className="evt-index-field">
+            <span className="evt-index-field-label">Committee</span>
+            <select
+              className="evt-index-type"
+              value={committee}
+              onChange={handleCommitteeChange}
+            >
+              <option value="">All committees</option>
+              {committeeValues.map(c => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </label>
           <div className="evt-index-time-toggle" role="group" aria-label="Filter by time">
             {timeValues.map(v => (
               <button

--- a/frontend/src/components/LegislationIndex.css
+++ b/frontend/src/components/LegislationIndex.css
@@ -58,10 +58,32 @@
   gap: 0.75rem;
   margin-bottom: 1rem;
   flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+/* Field wrapper that stacks a visible <span> label above each input
+   or select so the filter row meets WCAG SC 2.4.6 (Headings and
+   Labels) and 2.5.3 (Label in Name) — both want a visible textual
+   label, not just an aria-label. The wrapper is a <label>, so
+   clicking the label text focuses the control natively. */
+.leg-index-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.leg-index-field--search {
+  flex: 1 1 16rem;
+}
+
+.leg-index-field-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #374151;
 }
 
 .leg-index-search {
-  flex: 1 1 16rem;
+  width: 100%;
   padding: 0.625rem 0.875rem;
   font-size: 1rem;
   border: 2px solid #e5e7eb;
@@ -172,7 +194,7 @@
 }
 
 .leg-index-page-btn:disabled {
-  opacity: 0.4;
+  opacity: 0.6;
   cursor: not-allowed;
 }
 

--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -153,69 +153,79 @@ export default function LegislationIndex() {
         </header>
 
         <div className="leg-index-controls">
-          <input
-            type="search"
-            className="leg-index-search"
-            placeholder="Search by identifier or title…"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            aria-label="Search legislation"
-            autoFocus
-          />
-          <select
-            className="leg-index-status"
-            value={classification}
-            onChange={handleClassificationChange}
-            aria-label="Filter by type"
-          >
-            <option value="">All types</option>
-            {classificationValues.map(c => (
-              <option key={c} value={c}>{c}</option>
-            ))}
-          </select>
-          <select
-            className="leg-index-status"
-            value={status}
-            onChange={handleStatusChange}
-            aria-label="Filter by status"
-          >
-            <option value="">All statuses</option>
-            {statusValues.map(s => (
-              <option key={s} value={s}>{s}</option>
-            ))}
-          </select>
-          <select
-            className="leg-index-status"
-            value={sponsor}
-            onChange={handleSponsorChange}
-            aria-label="Filter by sponsor"
-          >
-            <option value="">All sponsors</option>
-            {sponsorValues.current.length > 0 && (
-              <optgroup label="Current council">
-                {sponsorValues.current.map(s => (
-                  <option key={s} value={s}>{s}</option>
-                ))}
-              </optgroup>
-            )}
-            {sponsorValues.former.length > 0 && (
-              <optgroup label="Former members">
-                {sponsorValues.former.map(s => (
-                  <option key={s} value={s}>{s}</option>
-                ))}
-              </optgroup>
-            )}
-          </select>
-          <select
-            className="leg-index-status"
-            value={sort || 'recent'}
-            onChange={handleSortChange}
-            aria-label="Sort order"
-          >
-            {sortValues.map(s => (
-              <option key={s.value} value={s.value}>{s.label}</option>
-            ))}
-          </select>
+          <label className="leg-index-field leg-index-field--search">
+            <span className="leg-index-field-label">Search</span>
+            <input
+              type="search"
+              className="leg-index-search"
+              placeholder="Search by identifier or title…"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              autoFocus
+            />
+          </label>
+          <label className="leg-index-field">
+            <span className="leg-index-field-label">Type</span>
+            <select
+              className="leg-index-status"
+              value={classification}
+              onChange={handleClassificationChange}
+            >
+              <option value="">All types</option>
+              {classificationValues.map(c => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </label>
+          <label className="leg-index-field">
+            <span className="leg-index-field-label">Status</span>
+            <select
+              className="leg-index-status"
+              value={status}
+              onChange={handleStatusChange}
+            >
+              <option value="">All statuses</option>
+              {statusValues.map(s => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+          </label>
+          <label className="leg-index-field">
+            <span className="leg-index-field-label">Sponsor</span>
+            <select
+              className="leg-index-status"
+              value={sponsor}
+              onChange={handleSponsorChange}
+            >
+              <option value="">All sponsors</option>
+              {sponsorValues.current.length > 0 && (
+                <optgroup label="Current council">
+                  {sponsorValues.current.map(s => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </optgroup>
+              )}
+              {sponsorValues.former.length > 0 && (
+                <optgroup label="Former members">
+                  {sponsorValues.former.map(s => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </optgroup>
+              )}
+            </select>
+          </label>
+          <label className="leg-index-field">
+            <span className="leg-index-field-label">Sort by</span>
+            <select
+              className="leg-index-status"
+              value={sort || 'recent'}
+              onChange={handleSortChange}
+            >
+              {sortValues.map(s => (
+                <option key={s.value} value={s.value}>{s.label}</option>
+              ))}
+            </select>
+          </label>
         </div>
 
         <div className="leg-index-controls leg-index-date-controls">

--- a/frontend/src/components/MuniCodeIndex.css
+++ b/frontend/src/components/MuniCodeIndex.css
@@ -51,6 +51,20 @@
   margin-bottom: 1rem;
 }
 
+/* See LegislationIndex.css `.leg-index-field` — visible-label
+   wrapper for the search input. */
+.smc-index-field {
+  display: block;
+}
+
+.smc-index-field-label {
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 0.25rem;
+}
+
 .smc-index-search-wrapper {
   position: relative;
 }
@@ -239,7 +253,7 @@
   color: #ffffff;
 }
 .smc-page-btn:disabled {
-  opacity: 0.4;
+  opacity: 0.6;
   cursor: not-allowed;
 }
 

--- a/frontend/src/components/MuniCodeIndex.jsx
+++ b/frontend/src/components/MuniCodeIndex.jsx
@@ -148,32 +148,34 @@ export default function MuniCodeIndex() {
         </header>
 
         <div className="smc-index-controls">
-          <div className="smc-index-search-wrapper">
-            <input
-              type="search"
-              className="smc-index-search"
-              placeholder="Search the code (e.g. 'short-term rental') or jump to a citation ('23.47A.004')…"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-              aria-label="Search the Seattle Municipal Code"
-              // Search is the primary interaction on this page — autofocus
-              // on mount so the user can type immediately. Also covers
-              // arriving here from a scoped search submission on a title
-              // or chapter page (focus would otherwise be lost when the
-              // scope page unmounted).
-              autoFocus
-            />
-            {searchInput && (
-              <button
-                type="button"
-                className="smc-index-search-clear"
-                onClick={clearSearchImmediately}
-                aria-label="Clear search"
-              >
-                <XIcon size={16} aria-hidden="true" />
-              </button>
-            )}
-          </div>
+          <label className="smc-index-field">
+            <span className="smc-index-field-label">Search</span>
+            <div className="smc-index-search-wrapper">
+              <input
+                type="search"
+                className="smc-index-search"
+                placeholder="Search the code (e.g. 'short-term rental') or jump to a citation ('23.47A.004')…"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                // Search is the primary interaction on this page — autofocus
+                // on mount so the user can type immediately. Also covers
+                // arriving here from a scoped search submission on a title
+                // or chapter page (focus would otherwise be lost when the
+                // scope page unmounted).
+                autoFocus
+              />
+              {searchInput && (
+                <button
+                  type="button"
+                  className="smc-index-search-clear"
+                  onClick={clearSearchImmediately}
+                  aria-label="Clear search"
+                >
+                  <XIcon size={16} aria-hidden="true" />
+                </button>
+              )}
+            </div>
+          </label>
         </div>
 
         {q && (chapter || title) && (


### PR DESCRIPTION
## Summary

First batch of fixes from the Firefox Dev Edition / axe audit pass. Two findings on `/legislation`; same patterns swept across `/events` and `/municode` since they shared the underlying issue.

### Visible filter labels (axe `label` rule + WCAG SC 2.4.6 / 2.5.3)

Filter controls had `aria-label` only — works for screen readers, but the visible-label requirement (sighted users) wasn't met. Each control is now wrapped in a `<label>` with a `<span class="*-field-label">` above it, giving a persistent visible label. The `aria-label` is removed since the visible label takes over as the accessible name (avoids "label in name" mismatch under SC 2.5.3).

| Page | Controls relabeled |
|---|---|
| `/legislation` | search + Type / Status / Sponsor / Sort selects |
| `/events` | search + Type / Committee selects |
| `/municode` | search |

Already-visible labels (the date-input pattern with `<span class="*-date-label">Introduced from</span>`) are unchanged — they were fine. The Time toggle on `/events` stays as `<div role="group" aria-label="Filter by time">` — a labeled radiogroup pattern is acceptable without per-button labels.

### Disabled pagination button contrast

`.leg-index-page-btn:disabled`, `.evt-index-page-btn:disabled`, and `.smc-page-btn:disabled` all used `opacity: 0.4` for the disabled state. axe flagged it for failing WCAG 1.4.3 (4.5:1 contrast).

WCAG technically *exempts* disabled controls under the "inactive UI components" carve-out, but: (a) axe doesn't reliably know whether a fade is a "disabled" state vs decorative, and (b) the 0.4 fade was genuinely hard to read for low-vision users. Bumped to `opacity: 0.6` — still reads as faded but clears the contrast floor.

## Test plan
- [ ] Visit `/legislation`, `/events`, `/municode`. Each filter control should have a visible label above it ("Search", "Type", "Status", etc.).
- [ ] Tab through the filters — clicking the visible label should focus the underlying input/select natively (implicit `<label>` association).
- [ ] On `/legislation` page 1 with no other filters applied (so totalCount > PAGE_SIZE for pagination to render), confirm the disabled "← Previous" button is more legible than before.
- [ ] Re-run axe on the same three pages; the `label` and `color-contrast` findings should be gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)