### PR TITLE
a11y: explicit disabled-button colors + self-sufficient date labels (FF audit pass 2)

### DIFF
--- a/frontend/src/components/EventsIndex.css
+++ b/frontend/src/components/EventsIndex.css
@@ -222,8 +222,12 @@
   color: #ffffff;
 }
 
+/* See LegislationIndex.css `.leg-index-page-btn:disabled` for the
+   rationale on explicit-color over opacity. */
 .evt-index-page-btn:disabled {
-  opacity: 0.6;
+  color: #6b7280;
+  border-color: #6b7280;
+  background: #ffffff;
   cursor: not-allowed;
 }
 

--- a/frontend/src/components/EventsIndex.jsx
+++ b/frontend/src/components/EventsIndex.jsx
@@ -202,17 +202,15 @@ export default function EventsIndex() {
               className="evt-index-date-input"
               value={dateAfter}
               onChange={handleDateChange('date_after')}
-              aria-label="Date from"
             />
           </label>
           <label className="evt-index-date-field">
-            <span className="evt-index-date-label">to</span>
+            <span className="evt-index-date-label">Date to</span>
             <input
               type="date"
               className="evt-index-date-input"
               value={dateBefore}
               onChange={handleDateChange('date_before')}
-              aria-label="Date to"
             />
           </label>
         </div>

--- a/frontend/src/components/LegislationIndex.css
+++ b/frontend/src/components/LegislationIndex.css
@@ -193,8 +193,16 @@
   color: #ffffff;
 }
 
+/* Explicit disabled colors instead of opacity. Opacity composites
+   the button against whatever's behind it, which dropped the
+   computed contrast on the page bg below 4.5:1 even at 0.6.
+   #6b7280 (gray-500) on #ffffff hits ~4.83:1 — passes WCAG 1.4.3
+   AA with margin and is still clearly distinct from the
+   active-state navy. */
 .leg-index-page-btn:disabled {
-  opacity: 0.6;
+  color: #6b7280;
+  border-color: #6b7280;
+  background: #ffffff;
   cursor: not-allowed;
 }
 

--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -236,17 +236,15 @@ export default function LegislationIndex() {
               className="leg-index-date-input"
               value={introducedAfter}
               onChange={handleDateChange('introduced_after')}
-              aria-label="Introduced from date"
             />
           </label>
           <label className="leg-index-date-field">
-            <span className="leg-index-date-label">to</span>
+            <span className="leg-index-date-label">Introduced to</span>
             <input
               type="date"
               className="leg-index-date-input"
               value={introducedBefore}
               onChange={handleDateChange('introduced_before')}
-              aria-label="Introduced to date"
             />
           </label>
         </div>

--- a/frontend/src/components/MuniCodeIndex.css
+++ b/frontend/src/components/MuniCodeIndex.css
@@ -252,8 +252,11 @@
   background: #2E3D5B;
   color: #ffffff;
 }
+/* See LegislationIndex.css `.leg-index-page-btn:disabled`. */
 .smc-page-btn:disabled {
-  opacity: 0.6;
+  color: #6b7280;
+  border-color: #6b7280;
+  background: #ffffff;
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
## Summary

Two follow-up findings on `/legislation` from the Firefox audit that PR #112 didn't fully resolve.

### Disabled button still failing WCAG 1.4.3 (3.38:1)
PR #112 bumped opacity from `0.4` → `0.6`, but axe still measured 3.38:1 — opacity composites the button against the page background (`#f9fafb`), and the math doesn't reach the 4.5:1 floor even at 60%.

Replaced opacity with explicit colors:
```css
.*-page-btn:disabled {
  color: #6b7280;
  border-color: #6b7280;
  background: #ffffff;
  cursor: not-allowed;
}
```
`#6b7280` on `#ffffff` is **4.83:1** — passes AA with margin and stays visually distinct from the active-state navy. Applied across `LegislationIndex.css`, `EventsIndex.css`, `MuniCodeIndex.css`.

### Date input labels too short
The second date input in each range had visible label "to" — wrapped in a `<label>`, so axe should be happy in theory, but a one-word label like "to" doesn't function as a self-sufficient accessible name (you need the previous label to know what "to" means). axe flagged it.

Renamed both date labels per page so each stands alone:
| Page | Before | After |
|---|---|---|
| `/legislation` | "Introduced from" / "to" | "Introduced from" / "Introduced to" |
| `/events` | "Date from" / "to" | "Date from" / "Date to" |

Also dropped the redundant `aria-label` on each date input — visible label is now the source of truth, matching the pattern used for the search + select fields in PR #112.

## Test plan
- [ ] Re-run axe on `/legislation` page 1 (no other filters, so pagination renders with disabled "← Previous"). The "color-contrast" finding on the disabled button should be gone (computed contrast 4.83:1).
- [ ] Re-run axe on `/legislation` and `/events` filter rows; the "Form elements should have a visible text label" finding on the second date input should be gone.
- [ ] Confirm the disabled "← Previous" button is more legible than before but clearly reads as disabled (gray-on-white instead of faded navy).
- [ ] Confirm the date range labels read naturally as "Introduced from … Introduced to …" / "Date from … Date to …".

🤖 Generated with [Claude Code](https://claude.com/claude-code)