### PR TITLE
a11y: explicit htmlFor association on date inputs (FF audit pass 3)

### DIFF
--- a/frontend/src/components/EventsIndex.jsx
+++ b/frontend/src/components/EventsIndex.jsx
@@ -195,24 +195,33 @@ export default function EventsIndex() {
         </div>
 
         <div className="evt-index-controls evt-index-date-controls">
-          <label className="evt-index-date-field">
-            <span className="evt-index-date-label">Date from</span>
+          {/* Explicit htmlFor/id association — see LegislationIndex
+              for why we don't use implicit <label>-wraps-<input>
+              on date inputs. */}
+          <div className="evt-index-date-field">
+            <label htmlFor="evt-index-date-from" className="evt-index-date-label">
+              Date from
+            </label>
             <input
+              id="evt-index-date-from"
               type="date"
               className="evt-index-date-input"
               value={dateAfter}
               onChange={handleDateChange('date_after')}
             />
-          </label>
-          <label className="evt-index-date-field">
-            <span className="evt-index-date-label">Date to</span>
+          </div>
+          <div className="evt-index-date-field">
+            <label htmlFor="evt-index-date-to" className="evt-index-date-label">
+              Date to
+            </label>
             <input
+              id="evt-index-date-to"
               type="date"
               className="evt-index-date-input"
               value={dateBefore}
               onChange={handleDateChange('date_before')}
             />
-          </label>
+          </div>
         </div>
 
         <div role="status" className="evt-index-summary">

--- a/frontend/src/components/LegislationIndex.jsx
+++ b/frontend/src/components/LegislationIndex.jsx
@@ -229,24 +229,33 @@ export default function LegislationIndex() {
         </div>
 
         <div className="leg-index-controls leg-index-date-controls">
-          <label className="leg-index-date-field">
-            <span className="leg-index-date-label">Introduced from</span>
+          {/* Explicit htmlFor/id association — Firefox's Accessibility
+              Inspector doesn't always detect implicit <label>-wraps-
+              <input> association on date inputs. */}
+          <div className="leg-index-date-field">
+            <label htmlFor="leg-index-date-from" className="leg-index-date-label">
+              Introduced from
+            </label>
             <input
+              id="leg-index-date-from"
               type="date"
               className="leg-index-date-input"
               value={introducedAfter}
               onChange={handleDateChange('introduced_after')}
             />
-          </label>
-          <label className="leg-index-date-field">
-            <span className="leg-index-date-label">Introduced to</span>
+          </div>
+          <div className="leg-index-date-field">
+            <label htmlFor="leg-index-date-to" className="leg-index-date-label">
+              Introduced to
+            </label>
             <input
+              id="leg-index-date-to"
               type="date"
               className="leg-index-date-input"
               value={introducedBefore}
               onChange={handleDateChange('introduced_before')}
             />
-          </label>
+          </div>
         </div>
 
         <div role="status" className="leg-index-summary">


### PR DESCRIPTION
## Summary

Firefox's Accessibility Inspector doesn't always detect implicit `<label>`-wraps-`<input>` association on date inputs — flags them as missing label even though the visible label text renders correctly. axe accepts the implicit form; Firefox is stricter.

Switched the four date inputs from:

```jsx
<label className="...-date-field">
  <span className="...-date-label">Introduced from</span>
  <input type="date" .../>
</label>
```

to explicit `htmlFor`/`id`:

```jsx
<div className="...-date-field">
  <label htmlFor="..." className="...-date-label">Introduced from</label>
  <input id="..." type="date" .../>
</div>
```

Both patterns are valid HTML, but the explicit form reads unambiguously to every accessibility tool. The visible layout and CSS class names are unchanged.

### Files
- `LegislationIndex.jsx` — `leg-index-date-from` / `leg-index-date-to`
- `EventsIndex.jsx` — `evt-index-date-from` / `evt-index-date-to`

Search and select fields on the same pages keep the implicit wrapping `<label>` structure since those weren't flagged. If FF surfaces them in a future pass, easy to extend the same pattern.

## Test plan
- [ ] Pull, rebuild, hard-refresh.
- [ ] Re-run Firefox Accessibility Inspector on `/legislation` and `/events`. The "Form elements should have a visible text label" finding on the date inputs should be gone.
- [ ] Click each date input's label — input should focus (tests the `htmlFor`/`id` link).
- [ ] Visually confirm "Introduced from" / "Introduced to" / "Date from" / "Date to" still render to the left of each input on the same row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)