### PR TITLE
a11y: explicit focus-visible on Municode scoped-search input

### DIFF
--- a/frontend/src/components/MuniCodeDetail.css
+++ b/frontend/src/components/MuniCodeDetail.css
@@ -138,12 +138,24 @@
 .smc-scoped-search-input {
   flex: 1;
   border: none;
-  outline: none;
   font-size: 0.9375rem;
   color: #1f2937;
   background: transparent;
   padding: 0.4rem 0;
   min-width: 0;
+}
+/* Focus indicator on the input itself — the wrapping
+   `.smc-scoped-search:focus-within` already paints the navy
+   border + ring on the whole search-bar, but Firefox's
+   Accessibility Inspector checks focus styling per element and
+   flags `outline: none` here without a replacement. The 2px
+   solid sits inside the wrapper's padding so it doesn't visually
+   compound with the wrapper ring; together they read as one
+   coherent focused-search-bar look. */
+.smc-scoped-search-input:focus-visible {
+  outline: 2px solid #2E3D5B;
+  outline-offset: 2px;
+  border-radius: 0.25rem;
 }
 .smc-scoped-search-input::placeholder {
   color: #6b7280;


### PR DESCRIPTION
## Summary

Firefox's Accessibility Inspector checks focus styling per element rather than via parent context. The `.smc-scoped-search-input` on the Municode title and chapter pages had `outline: none` with the focus indicator delegated to `.smc-scoped-search:focus-within` on the wrapper — that visually shows the focused state on the whole search-bar, but FF flags the input itself for having no focus style of its own.

Removed `outline: none` from the input and added an explicit `:focus-visible` rule with a navy outline + 2px offset. The wrapper's `:focus-within` ring still paints around the whole search-bar; the inner outline sits inside that padding so the two read as one coherent focused state, not as compounding double-rings.

Both `/municode/<title>` ("Search within Title …") and `/municode/<title>/<chapter>` ("Search within Chapter …") share the same class, so this single change covers both pages.

## Test plan
- [ ] Visit `/municode/23` (Title 23 page); Tab into the search input. Should see the navy outline ON the input plus the wrapper's existing ring.
- [ ] Same on `/municode/23/32` (Chapter page).
- [ ] Re-run Firefox Accessibility Inspector on both — focus-style finding should clear.
- [ ] Mouse-click the input (not Tab) — should NOT show the inner outline (`:focus-visible` only fires for keyboard focus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)