### PR TITLE
a11y: /reps page fixes — address label, map label, focusable attribution

### DIFF
--- a/frontend/src/components/CouncilMap.css
+++ b/frontend/src/components/CouncilMap.css
@@ -39,6 +39,23 @@
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
+/* OSM / CARTO attribution. We disable Leaflet's default
+   attribution control (which renders inside the map div and
+   trips Firefox's "clickable but not focusable" check) and
+   render the same content as plain HTML here, where the <a>
+   tags are natively focusable and tab-able like any other
+   link on the page. */
+.council-map-attribution {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #6b7280;
+  text-align: right;
+}
+.council-map-attribution a {
+  color: #4b5563;
+  text-decoration: underline;
+}
+
 @media (max-width: 600px) {
   .council-map { height: 360px; }
 }

--- a/frontend/src/components/CouncilMap.jsx
+++ b/frontend/src/components/CouncilMap.jsx
@@ -19,10 +19,16 @@ export default function CouncilMap({ districts, onDistrictHover }) {
         zoom: 11,
         zoomControl: true,
         scrollWheelZoom: false,
+        // Leaflet's built-in attribution control renders the
+        // OSM/CARTO links inside a div that Firefox's Inspector
+        // flags as "clickable but not focusable." We disable it
+        // here and render the same attribution as a plain HTML
+        // <a> below the map, where it's natively focusable and
+        // satisfies the OSM/CARTO license terms either way.
+        attributionControl: false,
       })
 
       L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
         subdomains: 'abcd',
         maxZoom: 20,
       }).addTo(mapInstanceRef.current)
@@ -94,7 +100,17 @@ export default function CouncilMap({ districts, onDistrictHover }) {
 
   return (
     <div className="council-map-wrapper">
-      <div ref={mapRef} className="council-map" />
+      {/* aria-label gives the interactive map an accessible name for
+          screen readers and audit tools. The map content itself is
+          conveyed through the labeled district legend below + the
+          district cards alongside, so SR users always have a
+          non-visual path to the same info. */}
+      <div
+        ref={mapRef}
+        className="council-map"
+        role="application"
+        aria-label="Seattle City Council district map. Click a district to view its representatives."
+      />
       <ul className="council-map-legend" aria-label="District legend">
         {Object.entries(DISTRICT_COLORS).map(([num, color]) => (
           <li key={num} className="council-map-legend-item">
@@ -103,6 +119,16 @@ export default function CouncilMap({ districts, onDistrictHover }) {
           </li>
         ))}
       </ul>
+      <p className="council-map-attribution">
+        Map &copy;{' '}
+        <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">
+          OpenStreetMap
+        </a>
+        {' '}contributors &copy;{' '}
+        <a href="https://carto.com/attributions" target="_blank" rel="noopener noreferrer">
+          CARTO
+        </a>
+      </p>
     </div>
   )
 }

--- a/frontend/src/components/RepsIndex.css
+++ b/frontend/src/components/RepsIndex.css
@@ -127,10 +127,26 @@
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+/* Visible-label field wrapping the address input. Same pattern as
+   the index-page filter fields. */
+.reps-lookup-field {
+  flex: 1 1 16rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.reps-lookup-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #374151;
 }
 
 .reps-lookup-input {
-  flex: 1 1 16rem;
+  width: 100%;
   padding: 0.625rem 0.875rem;
   font-size: 1rem;
   border: 2px solid #e5e7eb;

--- a/frontend/src/components/RepsIndex.jsx
+++ b/frontend/src/components/RepsIndex.jsx
@@ -169,15 +169,17 @@ function AddressLookup() {
   return (
     <div className="reps-lookup">
       <form onSubmit={submit} className="reps-lookup-form">
-        <input
-          type="text"
-          className="reps-lookup-input"
-          placeholder="123 Main St, Seattle"
-          value={address}
-          onChange={e => setAddress(e.target.value)}
-          aria-label="Address"
-          autoFocus
-        />
+        <label className="reps-lookup-field">
+          <span className="reps-lookup-label">Find your representative by address</span>
+          <input
+            type="text"
+            className="reps-lookup-input"
+            placeholder="123 Main St, Seattle"
+            value={address}
+            onChange={e => setAddress(e.target.value)}
+            autoFocus
+          />
+        </label>
         <button type="submit" className="reps-lookup-btn" disabled={loading}>
           {loading ? 'Looking up…' : 'Look up'}
         </button>


### PR DESCRIPTION
## Summary

Three findings from the Firefox audit on `/reps`.

### 1. Address-lookup input lacks visible label
Had `aria-label="Address"` only. Wrapped in a `<label>` with a visible "Find your representative by address" span — same pattern as PR #112's index-page filter relabeling. Removed the now-redundant `aria-label`. The "Look up" button sits on the same baseline as the input via `align-items: flex-end` on the form.

### 2. Map graphic lacks label
Added `role="application"` + a descriptive `aria-label` ("Seattle City Council district map. Click a district to view its representatives.") to the `.council-map` div. Screen-reader users still get the non-visual path through the labeled district legend below the map and the district cards alongside; the role + label just gives the map itself an accessible name so audit tools can identify it.

### 3. Leaflet attribution flagged as clickable-but-not-focusable
Leaflet's default `attributionControl` renders the OSM/CARTO links inside a div that Firefox's Inspector treats as "clickable but not focusable". Disabled the built-in control (`attributionControl: false`) and rendered the same OSM + CARTO attribution as a plain `<p>` with `<a>` tags below the map — natively focusable, tab-able, and still license-compliant.

```jsx
<p className="council-map-attribution">
  Map &copy; <a href="https://www.openstreetmap.org/copyright" ...>OpenStreetMap</a>
  contributors &copy; <a href="https://carto.com/attributions" ...>CARTO</a>
</p>
```

## Test plan
- [ ] Visit `/reps`. The address-lookup field should show a visible "Find your representative by address" label above the input.
- [ ] Tab through the page; the OSM and CARTO attribution links below the map should receive keyboard focus and show focus rings.
- [ ] Re-run Firefox Accessibility Inspector on `/reps`. All three findings (input label, map label, attribution focusability) should clear.
- [ ] Confirm visual layout is unchanged elsewhere — the map fills its slot the same way; the attribution sits below the legend in a small gray right-aligned line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)