### PR TITLE
reps: bidirectional district highlight + lookup form gap

### DIFF
--- a/frontend/src/components/CouncilMap.jsx
+++ b/frontend/src/components/CouncilMap.jsx
@@ -5,9 +5,14 @@ import 'leaflet/dist/leaflet.css'
 import { DISTRICT_COLORS } from './districtColors'
 import './CouncilMap.css'
 
-export default function CouncilMap({ districts, onDistrictHover }) {
+export default function CouncilMap({ districts, activeDistrict, onDistrictActivate }) {
   const mapRef = useRef(null)
   const mapInstanceRef = useRef(null)
+  // Polygon layer refs keyed by district number — populated as
+  // each feature is added in the build effect, consumed by the
+  // activeDistrict effect to programmatically apply the hover
+  // styling + open tooltip when the active district changes.
+  const layersByDistrictRef = useRef(new Map())
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -40,6 +45,7 @@ export default function CouncilMap({ districts, onDistrictHover }) {
         mapInstanceRef.current.removeLayer(layer)
       }
     })
+    layersByDistrictRef.current.clear()
 
     const allBounds = L.latLngBounds([])
 
@@ -55,19 +61,14 @@ export default function CouncilMap({ districts, onDistrictHover }) {
           fillOpacity: 0.3,
         },
         onEachFeature: (_feature, lyr) => {
+          layersByDistrictRef.current.set(d.number, lyr)
           const repName = d.rep?.name ?? 'Vacant'
           lyr.bindTooltip(
             `<strong>${d.name}</strong><br/>${repName}`,
             { sticky: true, direction: 'top' }
           )
-          lyr.on('mouseover', () => {
-            lyr.setStyle({ weight: 3, fillOpacity: 0.5 })
-            onDistrictHover?.(d.number)
-          })
-          lyr.on('mouseout', () => {
-            lyr.setStyle({ weight: 2, fillOpacity: 0.3 })
-            onDistrictHover?.(null)
-          })
+          lyr.on('mouseover', () => onDistrictActivate?.(d.number))
+          lyr.on('mouseout', () => onDistrictActivate?.(null))
           // Click goes to the district page (rep + at-large), not straight
           // to the district rep — gives users the full picture of who
           // represents them before drilling into a single profile.
@@ -87,6 +88,26 @@ export default function CouncilMap({ districts, onDistrictHover }) {
       // whole map only when the component unmounts.
     }
   }, [districts, navigate])
+
+  // Sync the polygon highlight + tooltip to the active-district state.
+  // The state is shared with the district cards in RepsIndex, so this
+  // effect fires whether the user hovered a polygon (mouseover above
+  // dispatches onDistrictActivate → state update → effect) or hovered/
+  // focused a card (RepMiniCard dispatches onActivate → same path).
+  // Manually centering the tooltip on the polygon's bounds avoids the
+  // sticky-tooltip cursor-tracking falling back to a stale cursor
+  // position when the activation came from a keyboard focus.
+  useEffect(() => {
+    for (const [num, lyr] of layersByDistrictRef.current) {
+      if (num === activeDistrict) {
+        lyr.setStyle({ weight: 3, fillOpacity: 0.5 })
+        lyr.openTooltip(lyr.getBounds().getCenter())
+      } else {
+        lyr.setStyle({ weight: 2, fillOpacity: 0.3 })
+        lyr.closeTooltip()
+      }
+    }
+  }, [activeDistrict])
 
   // Full unmount cleanup
   useEffect(() => {

--- a/frontend/src/components/RepsIndex.css
+++ b/frontend/src/components/RepsIndex.css
@@ -125,7 +125,10 @@
 
 .reps-lookup-form {
   display: flex;
-  gap: 0.5rem;
+  /* Gap was 0.5rem (8px), but the input's :focus state adds a 3px
+     box-shadow ring that visually crowded the "Look up" button.
+     Bumped to 1rem so the ring + button-border have room. */
+  gap: 1rem;
   flex-wrap: wrap;
   align-items: flex-end;
 }

--- a/frontend/src/components/RepsIndex.jsx
+++ b/frontend/src/components/RepsIndex.jsx
@@ -10,10 +10,13 @@ export default function RepsIndex() {
   useDocumentTitle('City Council')
   const [data, setData] = useState(null)
   const [loadError, setLoadError] = useState(null)
-  // Hover sync between CouncilMap and the district cards: hovering a
-  // polygon highlights the matching card (and vice versa would be nice
-  // someday, but one direction is enough for the visual correlation).
-  const [hoveredDistrict, setHoveredDistrict] = useState(null)
+  // Bidirectional active-district sync between CouncilMap and the
+  // district cards. Hovering a polygon, hovering a card, or
+  // keyboard-focusing a card all set the same state; the map
+  // applies the polygon hover-styling + tooltip and the card
+  // shows its district-color border + ring. Keyboard users get
+  // the same affordance as mouse users.
+  const [activeDistrict, setActiveDistrict] = useState(null)
 
   useEffect(() => {
     fetch('/api/reps/')
@@ -52,7 +55,11 @@ export default function RepsIndex() {
         {data && (
           <>
             <section aria-label="Council map" className="reps-section">
-              <CouncilMap districts={data.districts} onDistrictHover={setHoveredDistrict} />
+              <CouncilMap
+                districts={data.districts}
+                activeDistrict={activeDistrict}
+                onDistrictActivate={setActiveDistrict}
+              />
             </section>
 
             <section aria-label="District representatives" className="reps-section">
@@ -65,7 +72,8 @@ export default function RepsIndex() {
                       districtName={d.name}
                       description={d.description}
                       districtNumber={d.number}
-                      highlighted={hoveredDistrict === d.number}
+                      highlighted={activeDistrict === d.number}
+                      onActivate={setActiveDistrict}
                     />
                   </li>
                 ))}
@@ -92,12 +100,16 @@ export default function RepsIndex() {
   )
 }
 
-function RepMiniCard({ rep, districtName, description, districtNumber, highlighted }) {
+function RepMiniCard({ rep, districtName, description, districtNumber, highlighted, onActivate }) {
   const accent = districtNumber ? DISTRICT_COLORS[districtNumber] : null
-  // Inline style applied only when the matching polygon is hovered, so
-  // the card visibly correlates with the map without a permanent paint.
+  // Inline style applied when the card is "active" — hovered or
+  // focused. Replaces the default gray border with the district
+  // accent color and adds a soft matching ring, AND suppresses the
+  // browser's :focus-visible outline (.rep-mini-card has one set
+  // for at-large cards) so we don't draw a navy ring on top of
+  // the district-color ring on focus.
   const highlightStyle = highlighted && accent
-    ? { borderColor: accent, boxShadow: `0 0 0 2px ${accent}33` }
+    ? { borderColor: accent, boxShadow: `0 0 0 2px ${accent}33`, outline: 'none' }
     : undefined
   const accentBar = accent ? { borderLeftColor: accent } : undefined
 
@@ -105,6 +117,17 @@ function RepMiniCard({ rep, districtName, description, districtNumber, highlight
   // page (rep + at-large). At-large cards have no districtNumber, so they
   // navigate straight to the rep's detail page.
   const target = districtNumber ? `/reps/district/${districtNumber}` : `/reps/${rep?.slug}`
+
+  // Sync card hover/focus to the shared activeDistrict state. Only
+  // fires for districted cards — at-large cards have no map polygon
+  // to highlight, and we don't want a stray onActivate(null) from an
+  // at-large blur to clear an active state set by a districted card.
+  const activateHandlers = districtNumber ? {
+    onMouseEnter: () => onActivate?.(districtNumber),
+    onMouseLeave: () => onActivate?.(null),
+    onFocus: () => onActivate?.(districtNumber),
+    onBlur: () => onActivate?.(null),
+  } : {}
 
   if (!rep) {
     // Vacant seat still wants to surface the district context, so keep
@@ -115,6 +138,7 @@ function RepMiniCard({ rep, districtName, description, districtNumber, highlight
         to={target}
         className={`rep-mini-card rep-mini-card--empty${accent ? ' rep-mini-card--accented' : ''}`}
         style={{ ...accentBar, ...highlightStyle }}
+        {...activateHandlers}
       >
         <div className="rep-mini-card-district">{districtName}</div>
         <div className="rep-mini-card-name">Vacant</div>
@@ -126,6 +150,7 @@ function RepMiniCard({ rep, districtName, description, districtNumber, highlight
       to={target}
       className={`rep-mini-card${accent ? ' rep-mini-card--accented' : ''}`}
       style={{ ...accentBar, ...highlightStyle }}
+      {...activateHandlers}
     >
       <div className="rep-mini-card-district">{districtName}</div>
       <div className="rep-mini-card-name">{rep.name}</div>


### PR DESCRIPTION
## Summary

Two visual tweaks on `/reps`.

### 1. Bidirectional active-district sync
Previously: hovering a map polygon highlighted the matching card (one direction). Hovering or keyboard-focusing a card did NOT highlight the polygon.

Now: hovering a polygon, hovering a card, or **keyboard-focusing a card** all drive the same `activeDistrict` state. The map applies the polygon hover styling + opens the district's tooltip; the matching card shows its district-color border + ring. Mouse and keyboard users get the same affordance.

**RepsIndex** — renamed `hoveredDistrict` → `activeDistrict`; now passes `activeDistrict` + `onDistrictActivate` to CouncilMap and `onActivate` to RepMiniCard.

**RepMiniCard** — added `onMouseEnter` / `onMouseLeave` / `onFocus` / `onBlur` handlers (district cards only — at-large cards have no map polygon to sync, and we don't want a stray `onActivate(null)` from an at-large blur to clear an active state set by a districted card). `highlightStyle` gains `outline: none` so the district-color ring shown on focus doesn't double up with the `.rep-mini-card :focus-visible` navy outline (that outline still applies to at-large cards, which have no district color to fall back to).

**CouncilMap** — tracks polygon refs in a `layersByDistrictRef` Map keyed by district number. New `useEffect(activeDistrict)` applies hover styling + `openTooltip(getBounds().getCenter())` when activated from a card. Centering the tooltip on the polygon explicitly avoids Leaflet's sticky-mode falling back to a stale cursor position when activation came from a keyboard focus.

### 2. Lookup form gap
The address input's 3px focus ring (`box-shadow: 0 0 0 3px rgba(46, 61, 91, 0.4)`) visually crowded the "Look up" button at the previous gap of `0.5rem`. Bumped to `1rem` so the ring + button-border have room.

## Test plan
- [ ] Visit `/reps`. Tab to a District N card (1-7); the matching polygon on the map should highlight + show its tooltip with the rep's name. Tab to the next card; previous polygon resets, next one activates.
- [ ] Hover the same cards with the mouse — same behavior.
- [ ] Hover a polygon on the map — the matching card should highlight (the previously-existing direction).
- [ ] Tab to an at-large card (Position 8 / 9) — should show the navy `:focus-visible` outline (no district color to fall back to). No map polygon should activate.
- [ ] Click in the address-lookup input on `/reps`. The "Look up" button should sit comfortably to the right of the focus ring, not crowded against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)