### PR TITLE
reps: quiet district-card borders + cap lookup search width

### DIFF
--- a/frontend/src/components/CouncilMap.jsx
+++ b/frontend/src/components/CouncilMap.jsx
@@ -5,9 +5,14 @@ import 'leaflet/dist/leaflet.css'
 import { DISTRICT_COLORS } from './districtColors'
 import './CouncilMap.css'
 
-export default function CouncilMap({ districts, onDistrictHover }) {
+export default function CouncilMap({ districts, activeDistrict, onDistrictActivate }) {
   const mapRef = useRef(null)
   const mapInstanceRef = useRef(null)
+  // Polygon layer refs keyed by district number — populated as
+  // each feature is added in the build effect, consumed by the
+  // activeDistrict effect to programmatically apply the hover
+  // styling + open tooltip when the active district changes.
+  const layersByDistrictRef = useRef(new Map())
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -40,6 +45,7 @@ export default function CouncilMap({ districts, onDistrictHover }) {
         mapInstanceRef.current.removeLayer(layer)
       }
     })
+    layersByDistrictRef.current.clear()
 
     const allBounds = L.latLngBounds([])
 
@@ -55,19 +61,14 @@ export default function CouncilMap({ districts, onDistrictHover }) {
           fillOpacity: 0.3,
         },
         onEachFeature: (_feature, lyr) => {
+          layersByDistrictRef.current.set(d.number, lyr)
           const repName = d.rep?.name ?? 'Vacant'
           lyr.bindTooltip(
             `<strong>${d.name}</strong><br/>${repName}`,
             { sticky: true, direction: 'top' }
           )
-          lyr.on('mouseover', () => {
-            lyr.setStyle({ weight: 3, fillOpacity: 0.5 })
-            onDistrictHover?.(d.number)
-          })
-          lyr.on('mouseout', () => {
-            lyr.setStyle({ weight: 2, fillOpacity: 0.3 })
-            onDistrictHover?.(null)
-          })
+          lyr.on('mouseover', () => onDistrictActivate?.(d.number))
+          lyr.on('mouseout', () => onDistrictActivate?.(null))
           // Click goes to the district page (rep + at-large), not straight
           // to the district rep — gives users the full picture of who
           // represents them before drilling into a single profile.
@@ -87,6 +88,26 @@ export default function CouncilMap({ districts, onDistrictHover }) {
       // whole map only when the component unmounts.
     }
   }, [districts, navigate])
+
+  // Sync the polygon highlight + tooltip to the active-district state.
+  // The state is shared with the district cards in RepsIndex, so this
+  // effect fires whether the user hovered a polygon (mouseover above
+  // dispatches onDistrictActivate → state update → effect) or hovered/
+  // focused a card (RepMiniCard dispatches onActivate → same path).
+  // Manually centering the tooltip on the polygon's bounds avoids the
+  // sticky-tooltip cursor-tracking falling back to a stale cursor
+  // position when the activation came from a keyboard focus.
+  useEffect(() => {
+    for (const [num, lyr] of layersByDistrictRef.current) {
+      if (num === activeDistrict) {
+        lyr.setStyle({ weight: 3, fillOpacity: 0.5 })
+        lyr.openTooltip(lyr.getBounds().getCenter())
+      } else {
+        lyr.setStyle({ weight: 2, fillOpacity: 0.3 })
+        lyr.closeTooltip()
+      }
+    }
+  }, [activeDistrict])
 
   // Full unmount cleanup
   useEffect(() => {

--- a/frontend/src/components/RepsIndex.css
+++ b/frontend/src/components/RepsIndex.css
@@ -81,6 +81,15 @@
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 .rep-mini-card--accented {
+  /* District cards: only the left accent bar should be visible at
+     rest. The other three borders go transparent (keeping their
+     1px width so the highlighted state can fade them in without
+     a layout shift). The inline `borderLeftColor: accent` from
+     RepMiniCard paints the actual district color on top of the
+     #2E3D5B placeholder; the inline `borderColor: accent` from
+     `highlightStyle` (set on hover/focus via activeDistrict)
+     expands to all four sides and reveals the full ring. */
+  border-color: transparent;
   border-left: 4px solid #2E3D5B;
 }
 .rep-mini-card:hover {
@@ -134,9 +143,13 @@
 }
 
 /* Visible-label field wrapping the address input. Same pattern as
-   the index-page filter fields. */
+   the index-page filter fields. Capped at 32rem so the search bar
+   doesn't stretch to the container edge on wide screens — at full
+   width the input's focus ring crowded the "Look up" button even
+   with the form gap bumped to 1rem. */
 .reps-lookup-field {
   flex: 1 1 16rem;
+  max-width: 32rem;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;

--- a/frontend/src/components/RepsIndex.css
+++ b/frontend/src/components/RepsIndex.css
@@ -125,7 +125,10 @@
 
 .reps-lookup-form {
   display: flex;
-  gap: 0.5rem;
+  /* Gap was 0.5rem (8px), but the input's :focus state adds a 3px
+     box-shadow ring that visually crowded the "Look up" button.
+     Bumped to 1rem so the ring + button-border have room. */
+  gap: 1rem;
   flex-wrap: wrap;
   align-items: flex-end;
 }

--- a/frontend/src/components/RepsIndex.jsx
+++ b/frontend/src/components/RepsIndex.jsx
@@ -10,10 +10,13 @@ export default function RepsIndex() {
   useDocumentTitle('City Council')
   const [data, setData] = useState(null)
   const [loadError, setLoadError] = useState(null)
-  // Hover sync between CouncilMap and the district cards: hovering a
-  // polygon highlights the matching card (and vice versa would be nice
-  // someday, but one direction is enough for the visual correlation).
-  const [hoveredDistrict, setHoveredDistrict] = useState(null)
+  // Bidirectional active-district sync between CouncilMap and the
+  // district cards. Hovering a polygon, hovering a card, or
+  // keyboard-focusing a card all set the same state; the map
+  // applies the polygon hover-styling + tooltip and the card
+  // shows its district-color border + ring. Keyboard users get
+  // the same affordance as mouse users.
+  const [activeDistrict, setActiveDistrict] = useState(null)
 
   useEffect(() => {
     fetch('/api/reps/')
@@ -52,7 +55,11 @@ export default function RepsIndex() {
         {data && (
           <>
             <section aria-label="Council map" className="reps-section">
-              <CouncilMap districts={data.districts} onDistrictHover={setHoveredDistrict} />
+              <CouncilMap
+                districts={data.districts}
+                activeDistrict={activeDistrict}
+                onDistrictActivate={setActiveDistrict}
+              />
             </section>
 
             <section aria-label="District representatives" className="reps-section">
@@ -65,7 +72,8 @@ export default function RepsIndex() {
                       districtName={d.name}
                       description={d.description}
                       districtNumber={d.number}
-                      highlighted={hoveredDistrict === d.number}
+                      highlighted={activeDistrict === d.number}
+                      onActivate={setActiveDistrict}
                     />
                   </li>
                 ))}
@@ -92,12 +100,16 @@ export default function RepsIndex() {
   )
 }
 
-function RepMiniCard({ rep, districtName, description, districtNumber, highlighted }) {
+function RepMiniCard({ rep, districtName, description, districtNumber, highlighted, onActivate }) {
   const accent = districtNumber ? DISTRICT_COLORS[districtNumber] : null
-  // Inline style applied only when the matching polygon is hovered, so
-  // the card visibly correlates with the map without a permanent paint.
+  // Inline style applied when the card is "active" — hovered or
+  // focused. Replaces the default gray border with the district
+  // accent color and adds a soft matching ring, AND suppresses the
+  // browser's :focus-visible outline (.rep-mini-card has one set
+  // for at-large cards) so we don't draw a navy ring on top of
+  // the district-color ring on focus.
   const highlightStyle = highlighted && accent
-    ? { borderColor: accent, boxShadow: `0 0 0 2px ${accent}33` }
+    ? { borderColor: accent, boxShadow: `0 0 0 2px ${accent}33`, outline: 'none' }
     : undefined
   const accentBar = accent ? { borderLeftColor: accent } : undefined
 
@@ -105,6 +117,17 @@ function RepMiniCard({ rep, districtName, description, districtNumber, highlight
   // page (rep + at-large). At-large cards have no districtNumber, so they
   // navigate straight to the rep's detail page.
   const target = districtNumber ? `/reps/district/${districtNumber}` : `/reps/${rep?.slug}`
+
+  // Sync card hover/focus to the shared activeDistrict state. Only
+  // fires for districted cards — at-large cards have no map polygon
+  // to highlight, and we don't want a stray onActivate(null) from an
+  // at-large blur to clear an active state set by a districted card.
+  const activateHandlers = districtNumber ? {
+    onMouseEnter: () => onActivate?.(districtNumber),
+    onMouseLeave: () => onActivate?.(null),
+    onFocus: () => onActivate?.(districtNumber),
+    onBlur: () => onActivate?.(null),
+  } : {}
 
   if (!rep) {
     // Vacant seat still wants to surface the district context, so keep
@@ -115,6 +138,7 @@ function RepMiniCard({ rep, districtName, description, districtNumber, highlight
         to={target}
         className={`rep-mini-card rep-mini-card--empty${accent ? ' rep-mini-card--accented' : ''}`}
         style={{ ...accentBar, ...highlightStyle }}
+        {...activateHandlers}
       >
         <div className="rep-mini-card-district">{districtName}</div>
         <div className="rep-mini-card-name">Vacant</div>
@@ -126,6 +150,7 @@ function RepMiniCard({ rep, districtName, description, districtNumber, highlight
       to={target}
       className={`rep-mini-card${accent ? ' rep-mini-card--accented' : ''}`}
       style={{ ...accentBar, ...highlightStyle }}
+      {...activateHandlers}
     >
       <div className="rep-mini-card-district">{districtName}</div>
       <div className="rep-mini-card-name">{rep.name}</div>


### PR DESCRIPTION
## Summary

Two follow-up tweaks to PR #118.

### Quiet borders on district cards
At rest a district card now shows only the left accent bar. The previous gray top/right/bottom borders read as visual noise around the brightly-colored left bar.

`border-color: transparent` on `.rep-mini-card--accented` makes the three other borders invisible while keeping their 1px width so the highlighted state (driven by `activeDistrict`) can fade the accent color in on top with no layout shift. The inline `borderColor: accent` from `highlightStyle` (set on hover/focus) expands to all four sides and reveals the full ring.

At-large cards (no `--accented` class) keep the existing gray border default — they have no district color to fall back to.

### Lookup search width
PR #118 bumped the form gap from `0.5rem` → `1rem`, but on wide screens the input still grew to fill the container and its focus ring visually crowded the "Look up" button. Capping `.reps-lookup-field` at `max-width: 32rem` keeps the input at a comfortable size on desktop and gives the button breathing room.

## Test plan
- [ ] Visit `/reps`. District cards (1-7) at rest should show only the colored left bar — no gray borders on the other three sides.
- [ ] Hover or Tab to a district card. All four borders should appear in that district's accent color, plus the soft matching ring.
- [ ] Tab away. Borders return to "left bar only" state cleanly.
- [ ] At-large cards (Position 8 / 9) at rest should still show their gray border (unchanged).
- [ ] Click in the address-lookup input. The focus ring should sit comfortably with visible empty space between the input and the "Look up" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)