### PR TITLE
reps: drive accent via CSS var + stack lookup form

### DIFF
--- a/frontend/src/components/RepsIndex.css
+++ b/frontend/src/components/RepsIndex.css
@@ -86,20 +86,15 @@
      them is preserved so the highlighted state can fade them in
      without a layout shift. */
   border-color: transparent;
-  /* Left bar uses LONGHAND properties — earlier we used the
-     shorthand `border-left: 4px solid #2E3D5B`, which set both
-     width AND color in one declaration; that made it look (in
-     the browser's resolved style panel) like the inline
-     `borderLeftColor` was being overridden, since a shorthand
-     declaration appears after the inline-applied longhand in
-     the cascade visualization. Splitting the width/style here
-     and leaving border-left-color to the inline style only —
-     `accentBar = { borderLeftColor: DISTRICT_COLORS[num] }` in
-     RepMiniCard — makes the source of truth obvious and removes
-     the resolved-style ambiguity. */
-  border-left-width: 4px;
-  border-left-style: solid;
-  /* No border-left-color here — set per-card via inline style. */
+  /* Left bar reads its color from the `--card-accent` CSS variable
+     set per-card via inline style in RepMiniCard. Falls back to
+     the brand navy if the variable isn't set so the bar always
+     paints. Earlier attempts using inline `borderLeftColor`
+     longhand or the `border-left` shorthand both failed to win
+     the cascade against `border-color: transparent` reliably;
+     resolving via `var()` inside the CSS itself sidesteps any
+     longhand-vs-shorthand resolution ambiguity in DevTools. */
+  border-left: 4px solid var(--card-accent, #2E3D5B);
 }
 
 /* Hover/focus on at-large cards only — they have no district
@@ -151,25 +146,19 @@
 }
 
 .reps-lookup-form {
+  /* Stacked layout: input on its own row (full width), button
+     on the row below right-aligned. Earlier attempts (gap bumps,
+     fixed-width input) either kept the button cramped or pushed
+     it out into a wide-empty-gap layout that read as "broken."
+     Stacking puts the input at full width where it belongs and
+     gives the button a clean right-side anchor on its own row. */
   display: flex;
-  /* Gap was 0.5rem (8px), but the input's :focus state adds a 3px
-     box-shadow ring that visually crowded the "Look up" button.
-     Bumped to 1rem so the ring + button-border have room. */
-  gap: 1rem;
-  flex-wrap: wrap;
-  align-items: flex-end;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-/* Visible-label field wrapping the address input. Sized at a
-   fixed 24rem (won't grow past it) so the input doesn't span
-   the full container width and crowd the "Look up" button. The
-   button picks up `margin-left: auto` below so it slides to the
-   right edge of the form, giving a clear visual gap between the
-   two on desktop. flex-shrink: 1 still applies, so on a narrow
-   mobile viewport the input shrinks down. */
+/* Visible-label field wrapping the address input. */
 .reps-lookup-field {
-  flex: 0 1 24rem;
-  max-width: 24rem;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -207,10 +196,9 @@
   border-radius: 0.5rem;
   cursor: pointer;
   transition: background 0.15s;
-  /* Push to the right edge of the form so a clear visual gap
-     opens up between the (now fixed-width) field and the button.
-     On mobile where the form wraps to two lines, this is a no-op. */
-  margin-left: auto;
+  /* Right-align the button on its own row inside the
+     flex-direction: column form. */
+  align-self: flex-end;
 }
 .reps-lookup-btn:hover:not(:disabled) { background: #1c2638; }
 .reps-lookup-btn:disabled { opacity: 0.6; cursor: not-allowed; }

--- a/frontend/src/components/RepsIndex.jsx
+++ b/frontend/src/components/RepsIndex.jsx
@@ -102,8 +102,15 @@ export default function RepsIndex() {
 
 function RepMiniCard({ rep, districtName, description, districtNumber, highlighted, onActivate }) {
   const accent = districtNumber ? DISTRICT_COLORS[districtNumber] : null
+  // The accent color rides into CSS as a `--card-accent` custom
+  // property, consumed by `.rep-mini-card--accented` for the left
+  // bar and (when highlighted) by the boxShadow/border ring.
+  // Earlier we tried setting `borderLeftColor` directly inline,
+  // but the CSS shorthand cascade quietly clobbered it for the
+  // resting state; CSS variables sidestep all of that.
+  const accentVar = accent ? { '--card-accent': accent } : undefined
   // Inline style applied when the card is "active" — hovered or
-  // focused. Replaces the default gray border with the district
+  // focused. Replaces the gray rest-state border with the district
   // accent color and adds a soft matching ring, AND suppresses the
   // browser's :focus-visible outline (.rep-mini-card has one set
   // for at-large cards) so we don't draw a navy ring on top of
@@ -111,7 +118,6 @@ function RepMiniCard({ rep, districtName, description, districtNumber, highlight
   const highlightStyle = highlighted && accent
     ? { borderColor: accent, boxShadow: `0 0 0 2px ${accent}33`, outline: 'none' }
     : undefined
-  const accentBar = accent ? { borderLeftColor: accent } : undefined
 
   // District cards mirror map polygon click — navigate to the district
   // page (rep + at-large). At-large cards have no districtNumber, so they
@@ -137,7 +143,7 @@ function RepMiniCard({ rep, districtName, description, districtNumber, highlight
       <Link
         to={target}
         className={`rep-mini-card rep-mini-card--empty${accent ? ' rep-mini-card--accented' : ''}`}
-        style={{ ...accentBar, ...highlightStyle }}
+        style={{ ...accentVar, ...highlightStyle }}
         {...activateHandlers}
       >
         <div className="rep-mini-card-district">{districtName}</div>

--- a/frontend/src/components/RepsIndex.jsx
+++ b/frontend/src/components/RepsIndex.jsx
@@ -155,7 +155,7 @@ function RepMiniCard({ rep, districtName, description, districtNumber, highlight
     <Link
       to={target}
       className={`rep-mini-card${accent ? ' rep-mini-card--accented' : ''}`}
-      style={{ ...accentBar, ...highlightStyle }}
+      style={{ ...accentVar, ...highlightStyle }}
       {...activateHandlers}
     >
       <div className="rep-mini-card-district">{districtName}</div>


### PR DESCRIPTION
## Summary

Two carryover fixes from the `/reps` polish thread.

### Accent color via CSS variable
PRs #119 and #120 both tried to paint the district color on the left card border via inline React style — first with `borderLeft` shorthand (PR #119), then with a longhand `borderLeftColor` after splitting the CSS shorthand (PR #120). Neither reliably won the cascade against the rule's `border-color: transparent`; cards rendered all-navy in PR #119 and with no left bar at all in PR #120.

Switched to a CSS custom property:
```jsx
const accentVar = accent ? { '--card-accent': accent } : undefined
```
```css
.rep-mini-card--accented {
  border-color: transparent;
  border-left: 4px solid var(--card-accent, #2E3D5B);
}
```
Resolving the color inside the CSS itself via `var()` removes the longhand-vs-shorthand cascade ambiguity. The `#2E3D5B` fallback in the `var()` second argument guarantees a visible bar even if the inline property somehow doesn't make it through, so we can never end up in the "no left bar at all" state again.

### Stacked lookup form
PR #119 bumped the form gap; PR #120 fixed the field at 24rem + auto-margin on the button. Neither worked: the first kept the button cramped against the input, the second left a comically large empty gap.

Per user direction, switched the form to `flex-direction: column` — input on its own row at full width, "Look up" button on the row below right-aligned via `align-self: flex-end`.

## Test plan
- [ ] Pull, rebuild Docker container, hard-refresh the browser tab.
- [ ] Visit `/reps`. Each district card 1-7 should now show its district color on the left bar — D1 blue, D2 orange, D3 green, D4 red, D5 purple, D6 brown, D7 navy. Matches the legend swatches.
- [ ] Hover or Tab to a district card. All four borders turn the district color (driven by inline highlightStyle); polygon on the map highlights and shows tooltip.
- [ ] Tab away. Card returns to "left bar only" state cleanly.
- [ ] At-large cards (Position 8 / 9) show their gray border at rest, navy on hover/focus (unchanged behavior).
- [ ] On `/reps`, the address input is full-width on its own row; the "Look up" button is below it on a new row, right-aligned. Looks like a proper stacked form, not the cramped or excessively-spaced variants from the previous attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)