### PR TITLE
reps: tighten default map zoom to fill viewport vertically

### DIFF
--- a/frontend/src/components/CouncilMap.jsx
+++ b/frontend/src/components/CouncilMap.jsx
@@ -22,6 +22,12 @@ export default function CouncilMap({ districts, activeDistrict, onDistrictActiva
       mapInstanceRef.current = L.map(mapRef.current, {
         center: [47.6062, -122.3321], // Seattle center
         zoom: 11,
+        // Default zoomSnap of 1 means each "+/-" click doubles or
+        // halves the scale — too coarse for our default fit. With
+        // 0.5 the +/- buttons step in half-zooms and fitBounds can
+        // pick a fractional level, so the districts fill the
+        // viewport tightly without needing a click-in to feel right.
+        zoomSnap: 0.5,
         zoomControl: true,
         scrollWheelZoom: false,
         // Leaflet's built-in attribution control renders the
@@ -79,7 +85,12 @@ export default function CouncilMap({ districts, activeDistrict, onDistrictActiva
     }
 
     if (allBounds.isValid()) {
-      mapInstanceRef.current.fitBounds(allBounds, { padding: [16, 16] })
+      // Padding is `[paddingX, paddingY]` in Leaflet's Point form.
+      // Tighter vertical padding nudges fitBounds to pick a slightly
+      // closer zoom so the city polygons fill most of the 480px-tall
+      // map area; keeping horizontal padding at 16 leaves breathing
+      // room around West Seattle and the eastern edge.
+      mapInstanceRef.current.fitBounds(allBounds, { padding: [16, 4] })
     }
 
     return () => {


### PR DESCRIPTION
## Summary

The /reps map's default fit looked slightly under-zoomed, but a single "+" click overshot — Leaflet's default `zoomSnap: 1` makes each step double or halve the scale, so anything between the current zoom and current+1 was unreachable.

Two small knobs in `CouncilMap.jsx`:

- **`zoomSnap: 0.5`** on the map options. Lets `fitBounds` settle on half-zoom levels (e.g. 11.5 instead of jumping to 12), and lets the user's +/- clicks step in halves too.
- **`fitBounds` padding** changed from `[16, 16]` to `[16, 4]` (Leaflet `Point` form is `[paddingX, paddingY]`). Tighter vertical padding nudges fitBounds to pick a slightly closer zoom so the polygons fill most of the 480px-tall map area; horizontal stays at 16 so West Seattle and the eastern edge keep breathing room.

## Test plan
- [ ] Visit `/reps`. Map should default to a noticeably tighter fit than before — districts taking up most of the vertical space.
- [ ] Click the "+" button. Should step a half-zoom (less aggressive jump than before).
- [ ] Click "-" twice. Should step out smoothly. No layout shift.
- [ ] Resize the browser; on narrower viewports the responsive `fitBounds` should still work and pick an appropriate zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)