### PR TITLE
frontend: NavBar reorder — surface human-facing pages first

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -64,6 +64,10 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 
 ## Done
 
+### Frontend — NavBar reorder — committed 2026-05-02
+
+Tiny ergonomic reorder. New order: `Home · City Council · Legislation · Events · Municode · About`. Surfaces the human-facing pages (council members, bills, meetings) before the reference/utility ones (municipal code, about). About moves to the tail since it's a one-time read, not a recurring destination. No behavior changes; `NAV_ITEMS` array reorder in `NavBar.jsx` only.
+
 ### LLM — render legislation summaries in API + frontend (Stage 3 of bills pipeline) — committed 2026-04-30
 Final stage of the bills LLM pipeline — surfaces the summaries to users.
 

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -5,11 +5,11 @@ import './NavBar.css';
 
 const NAV_ITEMS = [
   { label: 'Home',         to: '/' },
-  { label: 'About',        to: '/about' },
-  { label: 'Events',       to: '/events' },
-  { label: 'Legislation',  to: '/legislation' },
-  { label: 'Municode',     to: '/municode' },
   { label: 'City Council', to: '/reps' },
+  { label: 'Legislation',  to: '/legislation' },
+  { label: 'Events',       to: '/events' },
+  { label: 'Municode',     to: '/municode' },
+  { label: 'About',        to: '/about' },
 ];
 
 function isActive(pathname, item) {


### PR DESCRIPTION
## Summary

- Reorder NavBar to: **Home · City Council · Legislation · Events · Municode · About**
- Puts the human-facing pages (council members, bills, meetings) ahead of reference/utility (municipal code, about)
- About moves to the tail — one-time read, not a recurring destination
- Pure `NAV_ITEMS` array reorder in `NavBar.jsx`; no behavior changes

## Test plan

- [ ] Desktop: confirm new order renders left-to-right
- [ ] Mobile (<768px): hamburger panel renders top-to-bottom in same order
- [ ] Active highlighting still works on each route

🤖 Generated with [Claude Code](https://claude.com/claude-code)