### PR TITLE
reps: scrape phone, fax, office/mailing addresses from per-member pages

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -64,6 +64,16 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 
 ## Done
 
+### Reps — scrape phone, fax, addresses from per-member contact tile — committed 2026-05-02
+
+The per-member seattle.gov detail pages each carry a Contact Us tile with phone, fax, email, office address, and mailing address. The pupa scraper only emitted a guessed `firstname.lastname@seattle.gov` email before. Now it also fetches the per-member page during scrape and pulls the rest of the tile into `core.PersonContactDetail` rows. Two address rows per person (`note='Office'` / `note='Mailing'`), one phone (`type='voice'`), one fax (`type='fax'`), and the canonical-capitalization email (which matters for `Alexis Mercedes Rinck` since the real mailbox is `AlexisMercedes.Rinck@seattle.gov`, not the guessed `alexis.mercedes.rinck@seattle.gov`).
+
+`extract_contact_details(html_str)` is the shared parser, used both inside `SeattlePersonScraper.scrape()` and from the new `backfill_council_contacts` management command that idempotently populates the existing 11 Person rows without requiring a full pupa rerun. Addresses are stored multi-line with `\n` separators (line breaks at `<br/>` in the source), and the frontend renders them via `white-space: pre-line` on `.rep-detail-contact-address`.
+
+`reps/services.py:_rep_row_to_dict` extends the contact-details loop to expose `fax`, `office_address`, and `mailing_address`. `RepDetail.jsx` adds Phone (already wired but never populated), Fax (display-only), Office address, and Mailing address rows using lucide `Printer` and `MapPin` icons.
+
+Both scraper and backfill use `requests.get(..., allow_redirects=False)` and skip non-200 responses — seattle.gov 301s former-member URLs to their successor's page (`sara-nelson` → Dionne Foster, `mark-solomon` → Eddie Lin), which would otherwise attribute the successor's contact info to the former member's record. Sara Nelson and Mark Solomon keep the old guessed-email contact only.
+
 ### Reps — switch profile link to per-member detail page — committed 2026-05-02
 
 Was linking to `https://www.seattle.gov/council/members#DeboraJuarez` (anchor on the index page). Now links to `https://www.seattle.gov/council/members/debora-juarez` — the per-member detail page that carries about/committees/staff/blog content we'll pull from in follow-on work.

--- a/frontend/src/components/RepDetail.css
+++ b/frontend/src/components/RepDetail.css
@@ -81,6 +81,22 @@
 }
 .rep-detail-contact-value:hover { color: #2E3D5B; }
 
+/* Display-only contact values (fax, addresses) — no underline, no
+   hover color shift. The `<a>` styling above is the link variant. */
+.rep-detail-contact-static {
+  text-decoration: none;
+}
+.rep-detail-contact-static:hover { color: #1f2937; }
+
+/* Multi-line address values — server stores them with `\n` between
+   lines (Seattle City Hall / 600 Fourth Avenue / 2nd Floor / …);
+   `pre-line` honors those breaks while still collapsing inline runs
+   of whitespace. */
+.rep-detail-contact-address {
+  white-space: pre-line;
+  line-height: 1.4;
+}
+
 .rep-detail-actions {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/components/RepDetail.jsx
+++ b/frontend/src/components/RepDetail.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { Phone, Mail, ExternalLink, Clock } from 'lucide-react'
+import { Phone, Mail, Printer, MapPin, ExternalLink, Clock } from 'lucide-react'
 import NotFound from './NotFound'
 import LegislationCard from './LegislationCard'
 import useDocumentTitle from '../hooks/useDocumentTitle'
@@ -69,6 +69,37 @@ export default function RepDetail() {
               <div>
                 <div className="rep-detail-contact-label">Email</div>
                 <a href={`mailto:${data.email}`} className="rep-detail-contact-value">{data.email}</a>
+              </div>
+            </div>
+          )}
+          {data.fax && (
+            <div className="rep-detail-contact-row">
+              <Printer size={16} aria-hidden="true" />
+              <div>
+                <div className="rep-detail-contact-label">Fax</div>
+                <div className="rep-detail-contact-value rep-detail-contact-static">{data.fax}</div>
+              </div>
+            </div>
+          )}
+          {data.office_address && (
+            <div className="rep-detail-contact-row">
+              <MapPin size={16} aria-hidden="true" />
+              <div>
+                <div className="rep-detail-contact-label">Office address</div>
+                <div className="rep-detail-contact-value rep-detail-contact-static rep-detail-contact-address">
+                  {data.office_address}
+                </div>
+              </div>
+            </div>
+          )}
+          {data.mailing_address && (
+            <div className="rep-detail-contact-row">
+              <MapPin size={16} aria-hidden="true" />
+              <div>
+                <div className="rep-detail-contact-label">Mailing address</div>
+                <div className="rep-detail-contact-value rep-detail-contact-static rep-detail-contact-address">
+                  {data.mailing_address}
+                </div>
               </div>
             </div>
           )}

--- a/reps/services.py
+++ b/reps/services.py
@@ -357,6 +357,15 @@ def _rep_row_to_dict(name: str, slug: str, label: str, person_id: str) -> Dict[s
                 rep_data['email'] = contact.value
             elif contact.type == 'voice':
                 rep_data['phone'] = contact.value
+            elif contact.type == 'fax':
+                rep_data['fax'] = contact.value
+            elif contact.type == 'address':
+                # Two address rows per person (Office + Mailing) keyed by
+                # `note` — see seattle/people.py.
+                if contact.note == 'Office':
+                    rep_data['office_address'] = contact.value
+                elif contact.note == 'Mailing':
+                    rep_data['mailing_address'] = contact.value
         for link in person.links.all():
             if link.note == 'City Council profile':
                 rep_data['profile_url'] = link.url

--- a/seattle/people.py
+++ b/seattle/people.py
@@ -23,6 +23,83 @@ def profile_slug(name: str) -> str:
     return name.strip().lower().replace(" ", "-")
 
 
+def _clean_address(div) -> str:
+    """Pull the address out of a `.contactTilePhysicalAddress` /
+    `.contactTileMailingAddress` div, preserving the per-line structure
+    by treating each `<br/>` as a line break. Skips the `<strong>` label
+    ('Street Address:' / 'Mailing Address:') and the close `<button>`.
+    Inline whitespace within each line is collapsed; lines are joined
+    with `\\n` so the API can store them as a single string and the
+    frontend can render via `white-space: pre-line` (or `.split('\\n')`).
+    """
+    lines: list[str] = []
+    buf: list[str] = []
+
+    def flush():
+        line = " ".join(" ".join(buf).split())
+        if line:
+            lines.append(line)
+        buf.clear()
+
+    def walk(el):
+        if el.tag == "br":
+            flush()
+        elif el.tag in ("strong", "button"):
+            pass  # skip the label and the close-icon button entirely
+        else:
+            if el.text:
+                buf.append(el.text)
+            for child in el:
+                walk(child)
+        if el.tail:
+            buf.append(el.tail)
+
+    for child in div:
+        walk(child)
+    flush()
+    return "\n".join(lines)
+
+
+def extract_contact_details(html_str: str) -> dict:
+    """Parse the Contact Us tile on a per-member seattle.gov profile
+    page. Returns a dict with any of `phone`, `fax`, `email`,
+    `office_address`, `mailing_address`. Missing keys mean the field
+    wasn't found — caller decides whether that's a hard error.
+
+    The Contact Us block is rendered server-side as a div with class
+    `ContactComponent`; child tiles use stable class names
+    (`contactTilePhone`, `contactTileEmail`, `fax`,
+    `contactTilePhysicalAddress`, `contactTileMailingAddress`). The two
+    address divs' element IDs are misnamed on the live page (the office
+    address sits inside `tileMailing_*` and vice-versa) so we key off
+    the class name, not the ID."""
+    h = lxml_html.fromstring(html_str)
+    boxes = h.xpath('//div[contains(@class, "ContactComponent")]')
+    if not boxes:
+        return {}
+    box = boxes[0]
+    out: dict[str, str] = {}
+
+    phone = box.xpath('.//div[@class="contactTilePhone"]/a/text()')
+    if phone:
+        out["phone"] = phone[0].strip()
+    fax = box.xpath('.//div[@class="fax"]/a/text()')
+    if fax:
+        out["fax"] = fax[0].strip()
+    email = box.xpath('.//div[@class="contactTileEmail"]/a/text()')
+    if email:
+        out["email"] = email[0].strip()
+
+    office = box.xpath('.//div[contains(@class, "contactTilePhysicalAddress")]')
+    if office:
+        out["office_address"] = _clean_address(office[0])
+    mailing = box.xpath('.//div[contains(@class, "contactTileMailingAddress")]')
+    if mailing:
+        out["mailing_address"] = _clean_address(mailing[0])
+
+    return out
+
+
 class SeattlePersonScraper(Scraper):
 
 
@@ -31,20 +108,20 @@ class SeattlePersonScraper(Scraper):
         Scrape Seattle City Council members from official seattle.gov site
         """
         url = "https://www.seattle.gov/council/members"
-        
+
         response = requests.get(url)
         html = lxml_html.fromstring(response.content)
-        
+
         # Find all councilmember sections
         # The page has "District X:" or "Position X:" followed by name links
         member_items = html.xpath('//ul/li[contains(text(), "District") or contains(text(), "Position")]')
-        
+
         for item in member_items:
             text = item.text_content().strip()
 
             # Parse district/position and name
             match = re.match(r'(District|Position) (\d+):\s*(.+)', text)
-            
+
             if match:
                 district_type = match.group(1)
                 number = match.group(2)
@@ -68,15 +145,41 @@ class SeattlePersonScraper(Scraper):
                 )
 
                 person.add_source(url)
-                person.add_contact_detail(
-                    type="email",
-                    value=f"{name.replace(' ', '.').lower()}@seattle.gov",
-                    note="Official email"
-                )
-                
+
                 # Build profile link — per-member detail page on seattle.gov
                 profile_url = f"{url}/{profile_slug(name)}"
                 person.add_link(profile_url, note="City Council profile")
+
+                # Pull contact details from the per-member detail page.
+                # Falls back to a constructed `firstname.lastname@seattle.gov`
+                # email if the profile fetch or parse fails — not ideal for
+                # multi-name members like Alexis Mercedes Rinck (real
+                # canonical form is `AlexisMercedes.Rinck@seattle.gov`)
+                # but better than nothing.
+                # `allow_redirects=False`: seattle.gov 301s a former
+                # member's URL to their successor's page (e.g.
+                # `/sara-nelson` → `/dionne-foster`), and we don't want
+                # to attribute the successor's contact info to the
+                # former member's record. A 200 means this URL really
+                # belongs to this person.
+                contacts = {}
+                try:
+                    profile_resp = requests.get(profile_url, timeout=10, allow_redirects=False)
+                    if profile_resp.status_code == 200:
+                        contacts = extract_contact_details(profile_resp.text)
+                except requests.RequestException as e:
+                    logger.warning(f"Could not fetch {profile_url}: {e}")
+
+                email = contacts.get("email") or f"{name.replace(' ', '.').lower()}@seattle.gov"
+                person.add_contact_detail(type="email", value=email, note="Official email")
+                if "phone" in contacts:
+                    person.add_contact_detail(type="voice", value=contacts["phone"], note="Office phone")
+                if "fax" in contacts:
+                    person.add_contact_detail(type="fax", value=contacts["fax"], note="Office fax")
+                if "office_address" in contacts:
+                    person.add_contact_detail(type="address", value=contacts["office_address"], note="Office")
+                if "mailing_address" in contacts:
+                    person.add_contact_detail(type="address", value=contacts["mailing_address"], note="Mailing")
 
                 self.info(f"Scraped person: {name} ({district})")
 

--- a/seattle_app/management/commands/backfill_council_contacts.py
+++ b/seattle_app/management/commands/backfill_council_contacts.py
@@ -1,0 +1,110 @@
+"""Backfill `core.PersonContactDetail` rows for current/former Seattle
+City Council members from their per-member seattle.gov profile pages.
+
+The original pupa scrape only emitted a guessed
+`firstname.lastname@seattle.gov` email per member. The per-member
+detail page also exposes phone, fax, and office/mailing addresses (and
+the canonical email capitalization, which matters for multi-name
+members like Alexis Mercedes Rinck where the guess and the real
+mailbox differ).
+
+This command walks every Person that has a `City Council profile`
+link, fetches the URL, parses the Contact Us tile, and upserts contact
+detail rows. Idempotent — re-running won't duplicate.
+
+    python manage.py backfill_council_contacts
+    python manage.py backfill_council_contacts --dry-run
+"""
+
+from __future__ import annotations
+
+import requests
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from opencivicdata.core.models import Person
+
+from seattle.people import extract_contact_details
+
+
+# (type, note) tuples — match what the scraper emits in
+# seattle/people.py so the backfill and the live scrape stay aligned.
+_FIELD_MAP = {
+    "email":           ("email",   "Official email"),
+    "phone":           ("voice",   "Office phone"),
+    "fax":             ("fax",     "Office fax"),
+    "office_address":  ("address", "Office"),
+    "mailing_address": ("address", "Mailing"),
+}
+
+
+class Command(BaseCommand):
+    help = "Backfill council member contact details (phone/fax/address) from seattle.gov."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true",
+                            help="Print planned changes without writing.")
+        parser.add_argument("--person", type=str, default=None,
+                            help="Limit to a single Person by name (exact match).")
+
+    def handle(self, *args, **options):
+        dry = options["dry_run"]
+        only = options["person"]
+
+        qs = Person.objects.filter(links__note="City Council profile").distinct()
+        if only:
+            qs = qs.filter(name=only)
+
+        total = qs.count()
+        self.stdout.write(f"Backfilling contacts for {total} councilmembers (dry-run={dry}).")
+
+        for person in qs:
+            link = person.links.filter(note="City Council profile").first()
+            if not link:
+                continue
+            # See `seattle/people.py` for the redirect rationale.
+            try:
+                resp = requests.get(link.url, timeout=10, allow_redirects=False)
+            except requests.RequestException as e:
+                self.stderr.write(f"  {person.name}: fetch failed — {e}")
+                continue
+            if resp.status_code != 200:
+                self.stdout.write(
+                    f"  {person.name}: skipped (HTTP {resp.status_code} — likely a "
+                    f"former member whose URL redirects to their successor)"
+                )
+                continue
+
+            contacts = extract_contact_details(resp.text)
+            if not contacts:
+                self.stderr.write(f"  {person.name}: no Contact Us block at {link.url}")
+                continue
+
+            self._apply(person, contacts, dry=dry)
+
+        self.stdout.write(self.style.SUCCESS("Done."))
+
+    def _apply(self, person, contacts: dict, dry: bool):
+        actions: list[str] = []
+        with transaction.atomic():
+            for key, value in contacts.items():
+                ocd_type, note = _FIELD_MAP[key]
+                existing = person.contact_details.filter(type=ocd_type, note=note).first()
+                if existing:
+                    if existing.value == value:
+                        continue
+                    actions.append(f"update {ocd_type}/{note}: {existing.value!r} → {value!r}")
+                    if not dry:
+                        existing.value = value
+                        existing.save(update_fields=["value"])
+                else:
+                    actions.append(f"add    {ocd_type}/{note}: {value!r}")
+                    if not dry:
+                        person.contact_details.create(type=ocd_type, value=value, note=note)
+
+        prefix = f"  {person.name}:"
+        if not actions:
+            self.stdout.write(f"{prefix} already up to date")
+        else:
+            self.stdout.write(prefix)
+            for a in actions:
+                self.stdout.write(f"      {a}")


### PR DESCRIPTION
## Summary

- Pupa scraper now fetches each member's seattle.gov detail page during scrape and pulls the full Contact Us tile (phone, fax, canonical-cased email, office address, mailing address) into `core.PersonContactDetail` rows
- New `backfill_council_contacts` management command applies the same logic idempotently to existing Person rows so prod doesn't have to wait for a full pupa rerun
- API `_rep_row_to_dict` exposes `fax`, `office_address`, `mailing_address`; `RepDetail.jsx` renders them as new rows in the contacts card (Printer + MapPin icons)
- Multi-line addresses stored with `\n` separators, rendered with `white-space: pre-line`

## Notes

- **Redirect handling**: both scraper and backfill use `allow_redirects=False` and only parse HTTP 200. seattle.gov 301s former-member URLs to their successor (`sara-nelson` → Dionne Foster, `mark-solomon` → Eddie Lin); without this guard we'd attribute the successor's contact info to the former member's record. Sara Nelson and Mark Solomon retain their original guessed-email contact.
- **Email canonicalization**: the page email overwrites the guessed `firstname.lastname@seattle.gov`. Important for `Alexis Mercedes Rinck` where the real mailbox is `AlexisMercedes.Rinck@seattle.gov`.

## Post-deploy step

After merge, run `python manage.py backfill_council_contacts` once on prod to populate the new fields for the existing 11 Person rows. The next scheduled pupa scrape will keep them current after that. Already run locally; verified idempotent (`already up to date` on second invocation).

## Test plan

- [x] `backfill_council_contacts --dry-run` shows expected adds/updates for 9 current members; skips Sara Nelson + Mark Solomon (HTTP 301)
- [x] Real run populates voice/fax/address rows; second run reports `already up to date` for everyone (idempotent)
- [x] `/api/reps/dionne-foster/` returns all five new fields with correct multi-line addresses
- [x] Parser tested against 4 distinct member pages
- [ ] Visit `/reps/<slug>` in browser, confirm Phone, Fax, Office address, Mailing address rows render with line breaks intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)