### PR TITLE
scrapers: retry-with-backoff on Legistar HTTP fetches

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -64,6 +64,14 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 
 ## Done
 
+### Scrapers — retry-with-backoff on Legistar HTTP — committed 2026-05-02
+
+Cron logs show ~1-2 `RemoteDisconnected` hits per daily run from Legistar's API. Most are inside per-record fetches (sponsors / attachments / histories for a single bill, agenda items for a single event) — the scraper logged a warning, returned empty, and the run continued with that record silently incomplete. **One run today (2026-05-02) hit the bulk events list endpoint instead** — `_fetch_events` returned `[]` on the disconnect, pupa raised `ScrapeError: no objects returned from SeattleEventScraper scrape`, and the entire daily sync (events + bills + sync_councilmatic) failed. Monday's Council Briefing didn't show up in the UI as a result.
+
+New `seattle/_http.py:request_with_retry` wraps `requests.get` with exponential backoff (1s, 2s, 4s — 3 attempts default) and re-raises `RequestException` on final failure. Wired into all five fetch points: `_fetch_events`, `_fetch_event_items`, `_fetch_packet_url` in events.py; `fetch_bills`, `fetch_matter_detail` in bills.py.
+
+Behavior change at the edges: per-record helpers still swallow + log on final failure (a missing sponsor list on one bill is preferable to dropping the bill), but `_fetch_events` no longer swallows — if all retries fail we want the run to die visibly with the network exception, not silently produce no events. Today's failure mode of "drift in for a day with stale data and nobody noticed" is the worse outcome.
+
 ### Reps — scrape phone, fax, addresses from per-member contact tile — committed 2026-05-02
 
 The per-member seattle.gov detail pages each carry a Contact Us tile with phone, fax, email, office address, and mailing address. The pupa scraper only emitted a guessed `firstname.lastname@seattle.gov` email before. Now it also fetches the per-member page during scrape and pulls the rest of the tile into `core.PersonContactDetail` rows. Two address rows per person (`note='Office'` / `note='Mailing'`), one phone (`type='voice'`), one fax (`type='fax'`), and the canonical-capitalization email (which matters for `Alexis Mercedes Rinck` since the real mailbox is `AlexisMercedes.Rinck@seattle.gov`, not the guessed `alexis.mercedes.rinck@seattle.gov`).

--- a/seattle/_http.py
+++ b/seattle/_http.py
@@ -1,0 +1,64 @@
+"""Shared HTTP helper for the pupa scrapers.
+
+Legistar's API drops connections at random — historical cron logs show
+~1-2 `RemoteDisconnected` hits per daily run. Without retry these cause
+silent partial data on per-record fetches (sponsors / attachments /
+histories arrive empty for one bill, and the run continues with that
+record incomplete) and a hard `ScrapeError: no objects returned` on
+the bulk events list (which kills the entire daily sync).
+
+`request_with_retry` is a thin wrapper around `requests.get` that
+retries on `RequestException` with exponential backoff. Final failure
+re-raises so callers can decide whether to swallow + log (for
+per-record helpers, where partial data is preferable to dropping the
+whole record) or let the exception bubble (for bulk fetches that we'd
+rather have crash visibly than silently produce nothing).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def request_with_retry(
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    timeout: float = 30,
+    retries: int = 3,
+    backoff_base: float = 1.0,
+) -> requests.Response:
+    """GET `url` with exponential-backoff retries on transient failures.
+
+    Backoff schedule with defaults: 1s, 2s, 4s between attempts. Re-raises
+    the last `RequestException` if all attempts fail.
+
+    Retries cover `ConnectionError` (which is what `RemoteDisconnected`
+    surfaces as), `Timeout`, `ChunkedEncodingError`, and `HTTPError` from
+    `raise_for_status`. The 4xx case is rare in practice — Legistar
+    matter/event IDs we hit always exist — and retrying a permanent 4xx
+    just delays the inevitable, not a correctness issue.
+    """
+    last_exc: requests.RequestException | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            resp = requests.get(url, params=params, timeout=timeout)
+            resp.raise_for_status()
+            return resp
+        except requests.RequestException as e:
+            last_exc = e
+            if attempt < retries:
+                delay = backoff_base * (2 ** (attempt - 1))
+                logger.info(
+                    f"Request to {url} failed (attempt {attempt}/{retries}); "
+                    f"retrying in {delay:.1f}s: {e}"
+                )
+                time.sleep(delay)
+    assert last_exc is not None
+    raise last_exc

--- a/seattle/bills.py
+++ b/seattle/bills.py
@@ -4,6 +4,8 @@ import requests
 
 from pupa.scrape import Bill, Scraper
 
+from seattle._http import request_with_retry
+
 CLIENT = "seattle"
 BASE_URL = f"https://webapi.legistar.com/v1/{CLIENT}"
 ENDPOINT = "matters"
@@ -47,8 +49,7 @@ class SeattleBillScraper(Scraper):
             "$orderby": "MatterIntroDate desc",
         }
         try:
-            response = requests.get(url, params=parameters)
-            response.raise_for_status()
+            response = request_with_retry(url, params=parameters)
             return response.json()
         except Exception as e:
             print("API call failed:", e)
@@ -66,8 +67,7 @@ class SeattleBillScraper(Scraper):
         """
         url = f"{BASE_URL}/{ENDPOINT}/{matter_id}/{endpoint}"
         try:
-            response = requests.get(url)
-            response.raise_for_status()
+            response = request_with_retry(url)
             return response.json() or []
         except Exception as e:
             self.warning(f"Failed to fetch {endpoint} for matter {matter_id}: {e}")

--- a/seattle/events.py
+++ b/seattle/events.py
@@ -16,6 +16,8 @@ import time
 import pytz
 import logging
 
+from seattle._http import request_with_retry
+
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://webapi.legistar.com/v1/seattle"
@@ -94,15 +96,14 @@ class SeattleEventScraper(Scraper):
             ),
             "$orderby": "EventDate asc",
         }
-        try:
-            resp = requests.get(f"{BASE_URL}/events", params=params, timeout=30)
-            resp.raise_for_status()
-            events = resp.json()
-            logger.info(f"Fetched {len(events)} events from Legistar API")
-            return events
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Failed to fetch events: {e}")
-            return []
+        # No swallow on the bulk events fetch: if all retries fail, let
+        # the ScrapeError bubble. An empty `[]` here was the failure mode
+        # that crashed the entire daily sync on 2026-05-02 — we'd rather
+        # see the network exception than mask it as "no events".
+        resp = request_with_retry(f"{BASE_URL}/events", params=params, timeout=30)
+        events = resp.json()
+        logger.info(f"Fetched {len(events)} events from Legistar API")
+        return events
 
     def _fetch_packet_url(self, legistar_page_url: str) -> str | None:
         """
@@ -110,8 +111,7 @@ class SeattleEventScraper(Scraper):
         The packet URL is not in the REST API — it only appears in the HTML.
         """
         try:
-            resp = requests.get(legistar_page_url, timeout=15)
-            resp.raise_for_status()
+            resp = request_with_retry(legistar_page_url, timeout=15)
             match = re.search(
                 r'id="ctl00_ContentPlaceHolder1_hypAgendaPacket"\s+href="([^"]+)"',
                 resp.text,
@@ -127,12 +127,11 @@ class SeattleEventScraper(Scraper):
         """Fetch agenda items for a single event, including attachments."""
         try:
             url = f"{BASE_URL}/events/{event_id}/eventitems"
-            resp = requests.get(
+            resp = request_with_retry(
                 url,
                 params={"AgendaNote": 1, "MinutesNote": 1, "Attachments": 1},
                 timeout=30,
             )
-            resp.raise_for_status()
             return resp.json() or []
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to fetch event items for event {event_id}: {e}")


### PR DESCRIPTION
## Summary

- New `seattle/_http.py:request_with_retry` — thin wrapper around `requests.get` with exponential backoff (1s, 2s, 4s; 3 attempts default) that re-raises `RequestException` on final failure
- Wired into all five Legistar fetch points: `_fetch_events`, `_fetch_event_items`, `_fetch_packet_url` (events); `fetch_bills`, `fetch_matter_detail` (bills)
- `_fetch_events` no longer swallows the exception on final failure — let the run die visibly rather than silently produce zero events

## Why

Legistar's API drops connections at random. Cron logs show **~1-2 `RemoteDisconnected` hits per daily run** across the past 8 days. Most landed inside per-record helpers and just produced silent partial data (one bill missing its sponsors / attachments). Today's run (2026-05-02) hit the bulk events list endpoint, which had no graceful fallback — `_fetch_events` returned `[]`, pupa raised `ScrapeError: no objects returned`, and the entire daily sync (events + bills + sync_councilmatic) failed. Monday's Council Briefing didn't surface in the UI as a result.

## Behavior change at the edges

- **Per-record helpers** (per-event items, per-bill sponsors/attachments/histories, packet URL): keep their swallow + log behavior. One bill missing its sponsor list is preferable to dropping the bill entirely.
- **Bulk events list**: now lets the exception bubble. Today's "stale data drifts in for a day, nobody notices" is the worse failure mode than a visible crash.

## Test plan

- [x] Imports clean; live Legistar fetch via the helper returns 200
- [ ] Watch the next scheduled cron run and confirm zero `RemoteDisconnected` warnings (or, if any fire, that the retry succeeds and the run completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)