### PR TITLE
events: delete 91 stale midnight Event duplicates from pre-EventTime fix

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -64,6 +64,12 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 
 ## Done
 
+### Events — clean up 91 stale midnight Event duplicates — committed 2026-05-02
+
+Pre-PR-#34 (committed 2026-04-28) the events scraper read only Legistar's `EventDate` field, which always carries midnight; the wall-clock time lives in a separate `EventTime` field. Every event scraped before that fix landed at midnight Pacific (07:00 UTC during PDT, 08:00 UTC during PST). When the fix shipped the next scrape created *new* event rows at the correct time — pupa upserts on (name + start_date), so a different start_date yielded a new row rather than updating the existing one. Result was 91 (name, date) groups in the DB with both a stale midnight row and a corrected row, double-displaying in `/events/`.
+
+Migration `0022` deletes the stale midnight rows in groups that also contain a non-midnight sibling — that sibling guarantees we know the real meeting time, so the deletion is non-destructive. (Verified pre-flight: 91 candidates, 0 unsafe groups where every sibling is midnight.) Uses Django ORM `.delete()` so OCD's model-level `on_delete=CASCADE` fires for the related EventAgendaItem / Document / Link / Media / Participant / Source rows plus the downstream `councilmatic_core.Event` row — the DB-level FKs are `NO ACTION`, so a raw-SQL `DELETE` on `opencivicdata_event` would have errored. Total events 1230 → 1139.
+
 ### Scrapers — retry-with-backoff on Legistar HTTP — committed 2026-05-02
 
 Cron logs show ~1-2 `RemoteDisconnected` hits per daily run from Legistar's API. Most are inside per-record fetches (sponsors / attachments / histories for a single bill, agenda items for a single event) — the scraper logged a warning, returned empty, and the run continued with that record silently incomplete. **One run today (2026-05-02) hit the bulk events list endpoint instead** — `_fetch_events` returned `[]` on the disconnect, pupa raised `ScrapeError: no objects returned from SeattleEventScraper scrape`, and the entire daily sync (events + bills + sync_councilmatic) failed. Monday's Council Briefing didn't show up in the UI as a result.

--- a/seattle_app/migrations/0022_delete_stale_midnight_event_duplicates.py
+++ b/seattle_app/migrations/0022_delete_stale_midnight_event_duplicates.py
@@ -1,0 +1,78 @@
+"""Delete pre-2026-04-28 stale midnight Event rows.
+
+Before PR #34 (committed 2026-04-28) the events scraper read only
+Legistar's `EventDate` field, which always carries midnight; the wall-
+clock time lives in a separate `EventTime` field. Every event scraped
+before that fix landed at midnight Pacific (07:00 UTC during PDT,
+08:00 UTC during PST). When the fix shipped, the next scrape created
+*new* event rows at the correct time — pupa upserts on (name +
+start_date), so a different start_date produces a new row rather than
+updating the existing one. Result: 91 (name, date) groups in the DB
+with both a stale midnight row and a corrected row, double-displaying
+in `/events/`.
+
+Criterion (verified safe — runs against the production DB return:
+91 candidates, 0 unsafe groups):
+- group all Event rows by (name, date-prefix-of-start_date)
+- a row is a deletion candidate if its time component is exactly
+  `T07:00:00+00:00` or `T08:00:00+00:00` (midnight Pacific in PDT/PST)
+  *and* the (name, date) group contains at least one non-midnight
+  sibling. The sibling guarantees we know the real meeting time and
+  preserves it; we never delete the only row for a given (name, date).
+
+Uses Django ORM `.delete()` so OCD's model-level `on_delete=CASCADE`
+fires for the related EventAgendaItem / EventDocument / EventLink /
+EventMedia / EventParticipant / EventSource rows, plus the downstream
+`councilmatic_core.Event` row that also has CASCADE on its OCD FK
+(checked: the DB-level FK constraints are `NO ACTION`, but Django
+model code is `CASCADE`, so ORM delete is the only safe path —
+raw-SQL DELETE on `opencivicdata_event` would error on the FK).
+
+Reverse is a no-op: the deleted rows were buggy data; restoring them
+would re-create the duplicate display.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from django.db import migrations
+
+
+_MIDNIGHT_SUFFIXES = ("T07:00:00+00:00", "T08:00:00+00:00")
+
+
+def delete_midnight_duplicates(apps, schema_editor):
+    Event = apps.get_model("legislative", "Event")
+
+    buckets: dict[tuple[str, str], list] = defaultdict(list)
+    for event in Event.objects.all():
+        buckets[(event.name, event.start_date[:10])].append(event)
+
+    to_delete_ids: list[str] = []
+    for evs in buckets.values():
+        if len(evs) < 2:
+            continue
+        midnight = [e for e in evs if e.start_date[10:] in _MIDNIGHT_SUFFIXES]
+        non_midnight = [e for e in evs if e not in midnight]
+        if midnight and non_midnight:
+            to_delete_ids.extend(e.id for e in midnight)
+
+    if to_delete_ids:
+        Event.objects.filter(id__in=to_delete_ids).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("seattle_app", "0021_update_council_profile_urls"),
+        # Make sure the OCD legislative app's tables are in their final
+        # shape before we touch them.
+        ("legislative", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            delete_midnight_duplicates,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]


### PR DESCRIPTION
## Summary

- Migration `0022` deletes 91 stale midnight Event rows that have been double-displaying on `/events/` since the EventTime fix (PR #34, 2026-04-28)
- Total events `1230 → 1139` after apply

## Why

Pre-#34 the scraper read only Legistar's `EventDate` (always midnight); the wall-clock time lives in a separate `EventTime` field. Every pre-fix event landed at midnight Pacific (07:00 UTC PDT / 08:00 UTC PST). When #34 shipped, pupa's `(name + start_date)` upsert key produced **new** rows at the corrected time rather than updating the originals — so 91 (name, date) groups carry both a stale midnight row and the correct row.

## Deletion criterion

A row is deleted only when both:
1. Its time component is exactly `T07:00:00+00:00` or `T08:00:00+00:00`
2. The (name, date) group contains at least one **non-midnight sibling**

The sibling guarantees we know the real meeting time, so we never delete the only row for a given (name, date). Pre-flight on the production-mirror DB: **91 candidates, 0 unsafe groups**.

## Why ORM, not raw SQL

The DB-level FK constraints from `opencivicdata_event{agendaitem,document,link,media,participant,source}` and from `councilmatic_core_event` are all `NO ACTION` — a raw `DELETE` on `opencivicdata_event` would have errored on the FK. Django ORM's `Event.objects.filter(id__in=...).delete()` invokes the model-level `on_delete=CASCADE` (defined in OCD and councilmatic_core model code), which issues child-table deletes first. ORM is the only safe path here.

## Test plan

- [x] Migration applies cleanly locally; 91 rows deleted; spot-checked previously-duplicated dates (`2026-02-02`, `2026-02-03`, `2026-05-06`) now have only the corrected-time row
- [x] Re-run of the same bucketing query: `0 remaining (name, date) duplicate groups`
- [ ] Visit `/events/` post-deploy; confirm no double-displays of the same meeting

🤖 Generated with [Claude Code](https://claude.com/claude-code)