### PR TITLE
reps: banner photo + 2-column RepDetail layout

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -64,6 +64,16 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 
 ## Done
 
+### Reps — banner photo + 2-column RepDetail layout — committed 2026-05-02
+
+The pupa scraper now captures each councilmember's banner photo URL from the main per-member page and persists it to `core.Person.image`. URL pattern: `https://www.seattle.gov/images/Council/Members/CouncilmemberBanners/<lastname>_635x250.{jpg,png}`. `extract_photo_url(html_str)` regex-matches the `images/Council/Members/CouncilmemberBanners/...` substring and prepends the canonical host — sidesteps a CMS quirk where seattle.gov's HTML emits a doubled `images//images/` prefix. (One real-world wrinkle: Strauss's filename is `struass_635x250.jpg` — a typo on the seattle.gov side; we use the typo'd URL because that's what 200s.)
+
+API: `_rep_row_to_dict` returns `image` when `Person.image` is set. Former members (Sara Nelson, Mark Solomon) get no photo because the existing redirect-skip pattern keeps us off their successors' pages.
+
+Frontend: `RepDetail` shifts from a single-column stack to a 2-column grid at ≥1024px (`20rem` left rail + flexible right). Left rail = identity (photo, district eyebrow, h1 name, district description, contacts card, external-link buttons). Right column = substantive content (Committees, Bills sponsored). Below 1024px it's single-column with the same source order. Container max-width bumped 56rem → 72rem to give the right column breathing room. h1 dropped from 2.25rem → 1.75rem so longer names like "Alexis Mercedes Rinck" don't wrap in the rail width. Photo uses `aspect-ratio: 635/250` with a neutral `#f3f4f6` placeholder background.
+
+We supply our own `alt={Councilmember <name>}` rather than trust the seattle.gov source — at least one banner has a stale alt text from a predecessor (Foster's says "Sara Nelson").
+
 ### Reps — scrape committee memberships → OCD Organization + Membership — committed 2026-05-02
 
 Each councilmember's `/council/members/<slug>/committees-and-calendar` page lists 4-6 committee assignments with role (Chair / Vice-Chair / Member). The pupa scraper now fetches that page during the people scrape, parses the committees ul, and yields one OCD `Organization` per unique committee plus one `Membership` per (person, committee) with the role.

--- a/frontend/src/components/RepDetail.css
+++ b/frontend/src/components/RepDetail.css
@@ -5,8 +5,54 @@
 }
 
 .rep-detail-container {
-  max-width: 56rem;
+  max-width: 72rem;
   margin: 0 auto;
+}
+
+/* Two-column body on desktop, single-column on tablet/mobile.
+   Left rail = identity (photo, name, district, contacts, external
+   links). Right column = substantive content (committees, bills).
+   `align-items: start` keeps the rail anchored to the top instead of
+   stretching to match the right column's height. */
+.rep-detail-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+@media (min-width: 1024px) {
+  .rep-detail-grid {
+    grid-template-columns: 20rem 1fr;
+    align-items: start;
+  }
+}
+
+.rep-detail-rail {
+  display: flex;
+  flex-direction: column;
+}
+
+.rep-detail-main {
+  min-width: 0; /* prevent grid item from blowing out wider than its track */
+}
+
+/* Banner photo — seattle.gov serves them at 635×250, so we honor
+   that aspect ratio and let the image fill the rail's width. The
+   neutral background shows through during load and as a fallback
+   for the rare case where the image 404s. Border-radius matches
+   the contact card for visual consistency. */
+.rep-detail-photo {
+  margin: 0 0 1rem;
+  width: 100%;
+  aspect-ratio: 635 / 250;
+  background: #f3f4f6;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+.rep-detail-photo img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .rep-detail-breadcrumb {
@@ -23,8 +69,6 @@
 .rep-detail-breadcrumb-sep { color: #9ca3af; font-weight: 400; }
 .rep-detail-breadcrumb-current { color: #6b7280; font-weight: 500; }
 
-.rep-detail-header { margin-bottom: 2rem; }
-
 .rep-detail-eyebrow {
   font-size: 0.875rem;
   font-weight: 600;
@@ -35,7 +79,10 @@
 }
 
 .rep-detail-h1 {
-  font-size: 2.25rem;
+  /* Smaller in the rail than the old full-width header, since the
+     rail is ~20rem on desktop and the old 2.25rem h1 would wrap on
+     longer names like "Alexis Mercedes Rinck". */
+  font-size: 1.75rem;
   font-weight: 800;
   color: #1f2937;
   margin: 0 0 0.5rem;
@@ -43,7 +90,7 @@
 }
 
 .rep-detail-sub {
-  margin: 0;
+  margin: 0 0 1rem;
   color: #6b7280;
   font-size: 0.95rem;
 }
@@ -123,11 +170,12 @@
 }
 
 /* Committees — list of committee assignments with a role pill on
-   the left. Sits between the external-link row and the bills list.
-   Role colors graduate from filled navy (Chair, the strongest
-   commitment) → outlined navy (Vice-Chair) → light gray (Member). */
+   the left. Top section in the right column on desktop; first
+   thing under the rail on mobile. Role colors graduate from filled
+   navy (Chair, the strongest commitment) → outlined navy (Vice-Chair)
+   → light gray (Member). */
 .rep-detail-committees {
-  margin-top: 2rem;
+  margin-bottom: 2rem;
 }
 
 .rep-detail-committee-list {
@@ -183,14 +231,14 @@
 }
 .rep-detail-committee-name:hover { color: #2E3D5B; }
 
-/* Bills sponsored — sits below the contact + external-link rows.
+/* Bills sponsored — sits below committees in the right column.
    Renders the same LegislationCard chrome used on /legislation/ so
    the card style stays consistent across the SPA. We cap the inline
    list at 10 cards from the API; the "View all" link below falls
    through to the existing legislation index sponsor filter when the
    rep has more than that. */
 .rep-detail-bills {
-  margin-top: 2rem;
+  margin-top: 0;
 }
 
 .rep-detail-section-h2 {

--- a/frontend/src/components/RepDetail.jsx
+++ b/frontend/src/components/RepDetail.jsx
@@ -45,129 +45,138 @@ export default function RepDetail() {
           <span className="rep-detail-breadcrumb-current">{data.name}</span>
         </nav>
 
-        <header className="rep-detail-header">
-          <div className="rep-detail-eyebrow">{data.district}</div>
-          <h1 className="rep-detail-h1">{data.name}</h1>
-          {data.district_description && (
-            <p className="rep-detail-sub">{data.district_description}</p>
-          )}
-        </header>
-
-        <section className="rep-detail-contacts" aria-label="Contact">
-          {data.phone && (
-            <div className="rep-detail-contact-row">
-              <Phone size={16} aria-hidden="true" />
-              <div>
-                <div className="rep-detail-contact-label">Phone</div>
-                <a href={`tel:${data.phone}`} className="rep-detail-contact-value">{data.phone}</a>
-              </div>
-            </div>
-          )}
-          {data.email && (
-            <div className="rep-detail-contact-row">
-              <Mail size={16} aria-hidden="true" />
-              <div>
-                <div className="rep-detail-contact-label">Email</div>
-                <a href={`mailto:${data.email}`} className="rep-detail-contact-value">{data.email}</a>
-              </div>
-            </div>
-          )}
-          {data.fax && (
-            <div className="rep-detail-contact-row">
-              <Printer size={16} aria-hidden="true" />
-              <div>
-                <div className="rep-detail-contact-label">Fax</div>
-                <div className="rep-detail-contact-value rep-detail-contact-static">{data.fax}</div>
-              </div>
-            </div>
-          )}
-          {data.office_address && (
-            <div className="rep-detail-contact-row">
-              <MapPin size={16} aria-hidden="true" />
-              <div>
-                <div className="rep-detail-contact-label">Office address</div>
-                <div className="rep-detail-contact-value rep-detail-contact-static rep-detail-contact-address">
-                  {data.office_address}
-                </div>
-              </div>
-            </div>
-          )}
-          {data.mailing_address && (
-            <div className="rep-detail-contact-row">
-              <MapPin size={16} aria-hidden="true" />
-              <div>
-                <div className="rep-detail-contact-label">Mailing address</div>
-                <div className="rep-detail-contact-value rep-detail-contact-static rep-detail-contact-address">
-                  {data.mailing_address}
-                </div>
-              </div>
-            </div>
-          )}
-        </section>
-
-        <section className="rep-detail-actions" aria-label="External links">
-          {data.profile_url && (
-            <a href={data.profile_url} target="_blank" rel="noopener noreferrer"
-               className="rep-detail-action">
-              <ExternalLink size={14} aria-hidden="true" />
-              City Council profile
-            </a>
-          )}
-          {data.office_hours_url && (
-            <a href={data.office_hours_url} target="_blank" rel="noopener noreferrer"
-               className="rep-detail-action">
-              <Clock size={14} aria-hidden="true" />
-              Office hours
-            </a>
-          )}
-        </section>
-
-        {(data.committees || []).length > 0 && (
-          <section className="rep-detail-committees" aria-label="Committee assignments">
-            <h2 className="rep-detail-section-h2">Committees</h2>
-            <ul className="rep-detail-committee-list">
-              {data.committees.map(c => (
-                <li key={c.organization_id} className="rep-detail-committee-row">
-                  <span className={`rep-detail-committee-role rep-detail-committee-role--${c.role.toLowerCase().replace(/[^a-z]/g, '-')}`}>
-                    {c.role}
-                  </span>
-                  {c.source_url ? (
-                    <a href={c.source_url} target="_blank" rel="noopener noreferrer"
-                       className="rep-detail-committee-name">
-                      {c.name}
-                    </a>
-                  ) : (
-                    <span className="rep-detail-committee-name">{c.name}</span>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-
-        {(data.sponsored_bills_total || 0) > 0 && (
-          <section className="rep-detail-bills" aria-label="Bills sponsored">
-            <h2 className="rep-detail-section-h2">
-              Bills sponsored
-              <span className="rep-detail-section-count">
-                {' '}({data.sponsored_bills_total})
-              </span>
-            </h2>
-            <div className="rep-detail-bill-list">
-              {data.sponsored_bills.map(bill => (
-                <LegislationCard key={bill.slug} bill={bill} />
-              ))}
-            </div>
-            {data.sponsored_bills_total > data.sponsored_bills.length && (
-              <Link
-                to={`/legislation?sponsor=${encodeURIComponent(data.name)}`}
-                className="rep-detail-bills-viewall"
-              >
-                View all {data.sponsored_bills_total} bills sponsored by {data.name} →
-              </Link>
+        <div className="rep-detail-grid">
+          <header className="rep-detail-rail">
+            {data.image && (
+              <figure className="rep-detail-photo">
+                <img src={data.image} alt={`Councilmember ${data.name}`} />
+              </figure>
             )}
-          </section>
-        )}
+            <div className="rep-detail-eyebrow">{data.district}</div>
+            <h1 className="rep-detail-h1">{data.name}</h1>
+            {data.district_description && (
+              <p className="rep-detail-sub">{data.district_description}</p>
+            )}
+
+            <section className="rep-detail-contacts" aria-label="Contact">
+              {data.phone && (
+                <div className="rep-detail-contact-row">
+                  <Phone size={16} aria-hidden="true" />
+                  <div>
+                    <div className="rep-detail-contact-label">Phone</div>
+                    <a href={`tel:${data.phone}`} className="rep-detail-contact-value">{data.phone}</a>
+                  </div>
+                </div>
+              )}
+              {data.email && (
+                <div className="rep-detail-contact-row">
+                  <Mail size={16} aria-hidden="true" />
+                  <div>
+                    <div className="rep-detail-contact-label">Email</div>
+                    <a href={`mailto:${data.email}`} className="rep-detail-contact-value">{data.email}</a>
+                  </div>
+                </div>
+              )}
+              {data.fax && (
+                <div className="rep-detail-contact-row">
+                  <Printer size={16} aria-hidden="true" />
+                  <div>
+                    <div className="rep-detail-contact-label">Fax</div>
+                    <div className="rep-detail-contact-value rep-detail-contact-static">{data.fax}</div>
+                  </div>
+                </div>
+              )}
+              {data.office_address && (
+                <div className="rep-detail-contact-row">
+                  <MapPin size={16} aria-hidden="true" />
+                  <div>
+                    <div className="rep-detail-contact-label">Office address</div>
+                    <div className="rep-detail-contact-value rep-detail-contact-static rep-detail-contact-address">
+                      {data.office_address}
+                    </div>
+                  </div>
+                </div>
+              )}
+              {data.mailing_address && (
+                <div className="rep-detail-contact-row">
+                  <MapPin size={16} aria-hidden="true" />
+                  <div>
+                    <div className="rep-detail-contact-label">Mailing address</div>
+                    <div className="rep-detail-contact-value rep-detail-contact-static rep-detail-contact-address">
+                      {data.mailing_address}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </section>
+
+            <section className="rep-detail-actions" aria-label="External links">
+              {data.profile_url && (
+                <a href={data.profile_url} target="_blank" rel="noopener noreferrer"
+                   className="rep-detail-action">
+                  <ExternalLink size={14} aria-hidden="true" />
+                  City Council profile
+                </a>
+              )}
+              {data.office_hours_url && (
+                <a href={data.office_hours_url} target="_blank" rel="noopener noreferrer"
+                   className="rep-detail-action">
+                  <Clock size={14} aria-hidden="true" />
+                  Office hours
+                </a>
+              )}
+            </section>
+          </header>
+
+          <div className="rep-detail-main">
+            {(data.committees || []).length > 0 && (
+              <section className="rep-detail-committees" aria-label="Committee assignments">
+                <h2 className="rep-detail-section-h2">Committees</h2>
+                <ul className="rep-detail-committee-list">
+                  {data.committees.map(c => (
+                    <li key={c.organization_id} className="rep-detail-committee-row">
+                      <span className={`rep-detail-committee-role rep-detail-committee-role--${c.role.toLowerCase().replace(/[^a-z]/g, '-')}`}>
+                        {c.role}
+                      </span>
+                      {c.source_url ? (
+                        <a href={c.source_url} target="_blank" rel="noopener noreferrer"
+                           className="rep-detail-committee-name">
+                          {c.name}
+                        </a>
+                      ) : (
+                        <span className="rep-detail-committee-name">{c.name}</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            {(data.sponsored_bills_total || 0) > 0 && (
+              <section className="rep-detail-bills" aria-label="Bills sponsored">
+                <h2 className="rep-detail-section-h2">
+                  Bills sponsored
+                  <span className="rep-detail-section-count">
+                    {' '}({data.sponsored_bills_total})
+                  </span>
+                </h2>
+                <div className="rep-detail-bill-list">
+                  {data.sponsored_bills.map(bill => (
+                    <LegislationCard key={bill.slug} bill={bill} />
+                  ))}
+                </div>
+                {data.sponsored_bills_total > data.sponsored_bills.length && (
+                  <Link
+                    to={`/legislation?sponsor=${encodeURIComponent(data.name)}`}
+                    className="rep-detail-bills-viewall"
+                  >
+                    View all {data.sponsored_bills_total} bills sponsored by {data.name} →
+                  </Link>
+                )}
+              </section>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/reps/services.py
+++ b/reps/services.py
@@ -352,6 +352,8 @@ def _rep_row_to_dict(name: str, slug: str, label: str, person_id: str) -> Dict[s
     # and pull her predecessor's contact info).
     person = OCDPerson.objects.filter(id=person_id).first()
     if person:
+        if person.image:
+            rep_data['image'] = person.image
         for contact in person.contact_details.all():
             if contact.type == 'email':
                 rep_data['email'] = contact.value

--- a/seattle/people.py
+++ b/seattle/people.py
@@ -111,6 +111,24 @@ def extract_committee_assignments(html_str: str) -> list[dict]:
     return out
 
 
+_PHOTO_PATH_RE = re.compile(r"images/Council/Members/CouncilmemberBanners/[^\"'?]+")
+
+
+def extract_photo_url(html_str: str) -> str | None:
+    """Return the absolute URL of the rep's banner photo, if any.
+
+    The seattle.gov main per-member page emits the banner with a
+    relative src like `images//images/Council/Members/CouncilmemberBanners/foster_635x250.jpg`
+    (the double-slash is a CMS artifact and the server tolerates it,
+    but we normalize to the canonical single-slash absolute URL).
+    Returns None if the page lacks a banner img — callers leave
+    `person.image` unset in that case."""
+    m = _PHOTO_PATH_RE.search(html_str)
+    if not m:
+        return None
+    return "https://www.seattle.gov/" + m.group(0)
+
+
 def extract_contact_details(html_str: str) -> dict:
     """Parse the Contact Us tile on a per-member seattle.gov profile
     page. Returns a dict with any of `phone`, `fax`, `email`,
@@ -153,22 +171,24 @@ def extract_contact_details(html_str: str) -> dict:
 
 class SeattlePersonScraper(Scraper):
 
-    def _fetch_member_extras(self, profile_url: str) -> tuple[dict, list[dict]]:
-        """Fetch the per-member detail page for contacts and the
-        `/committees-and-calendar` subpage for committee assignments.
+    def _fetch_member_extras(self, profile_url: str) -> tuple[dict, list[dict], str | None]:
+        """Fetch the per-member detail page for contacts + photo, and
+        the `/committees-and-calendar` subpage for committee assignments.
 
-        Returns (contacts_dict, committees_list). Both are empty when
-        the corresponding fetch returns non-200 or the page lacks the
-        expected block. `allow_redirects=False` because seattle.gov
-        301s former-member URLs to their successor (`sara-nelson` →
-        `dionne-foster`); only a 200 means the URL really belongs to
-        this person."""
+        Returns (contacts_dict, committees_list, photo_url). All can be
+        empty/None when the corresponding fetch returns non-200 or the
+        page lacks the expected block. `allow_redirects=False` because
+        seattle.gov 301s former-member URLs to their successor
+        (`sara-nelson` → `dionne-foster`); only a 200 means the URL
+        really belongs to this person."""
         contacts: dict = {}
         committees: list[dict] = []
+        photo_url: str | None = None
         try:
             r = requests.get(profile_url, timeout=10, allow_redirects=False)
             if r.status_code == 200:
                 contacts = extract_contact_details(r.text)
+                photo_url = extract_photo_url(r.text)
         except requests.RequestException as e:
             logger.warning(f"Could not fetch {profile_url}: {e}")
         try:
@@ -178,7 +198,7 @@ class SeattlePersonScraper(Scraper):
                 committees = extract_committee_assignments(r.text)
         except requests.RequestException as e:
             logger.warning(f"Could not fetch committees for {profile_url}: {e}")
-        return contacts, committees
+        return contacts, committees, photo_url
 
     def scrape(self):
         """Scrape Seattle City Council members from seattle.gov.
@@ -209,13 +229,14 @@ class SeattlePersonScraper(Scraper):
             district_type, number, name = match.group(1), match.group(2), match.group(3).strip()
             district = f"{district_type} {number}"
             profile_url = f"{url}/{profile_slug(name)}"
-            contacts, committees = self._fetch_member_extras(profile_url)
+            contacts, committees, photo_url = self._fetch_member_extras(profile_url)
             members_data.append({
                 "name": name,
                 "district": district,
                 "profile_url": profile_url,
                 "contacts": contacts,
                 "committees_raw": committees,
+                "photo_url": photo_url,
             })
 
         # Build canonical_committees map: committee names on seattle.gov
@@ -246,6 +267,8 @@ class SeattlePersonScraper(Scraper):
             district = m["district"]
             contacts = m["contacts"]
             person = Person(name=name, district=district, role="Councilmember")
+            if m["photo_url"]:
+                person.image = m["photo_url"]
             person.add_membership(
                 "Seattle City Council",
                 role="Councilmember",


### PR DESCRIPTION
## Summary

- Pupa scraper now captures each councilmember's banner photo URL from the main per-member page and persists it to `core.Person.image`
- API `_rep_row_to_dict` returns `image` when set
- `RepDetail` shifts from a single-column stack to a 2-column grid at ≥1024px:
  - **Left rail (`20rem`)** = identity: photo, district eyebrow, h1 name, district description, contacts card, external-link buttons
  - **Right column (flex)** = substantive content: Committees, Bills sponsored
- Below 1024px it stacks single-column with the same source order

## Notes

- `extract_photo_url` regex-matches `images/Council/Members/CouncilmemberBanners/…` and prepends the canonical host. Sidesteps a CMS quirk where seattle.gov's HTML emits a doubled `images//images/` prefix (server tolerates it but the canonical URL is cleaner).
- Container max-width bumped `56rem → 72rem`; h1 dropped `2.25rem → 1.75rem` so longer names like "Alexis Mercedes Rinck" don't wrap in the rail width.
- We supply our own `alt={Councilmember <name>}` — Foster's source banner has stale alt text reading "Sara Nelson".
- Real-world wrinkle: Strauss's filename on seattle.gov is `struass_635x250.jpg` (their typo). The corrected `strauss_635x250.jpg` 404s, so we use the typo'd URL.
- Former members (Sara Nelson, Mark Solomon) get no photo because the existing `allow_redirects=False` + skip-non-200 pattern keeps us off their successors' pages.

## Post-deploy

Run `pupa update seattle people` once on prod to populate `Person.image` for the existing 9 current councilmembers. Next scheduled scrape keeps it current.

## Test plan

- [x] Scrape populates `core.Person.image` for all 9 current members; the 2 former members stay null
- [x] `/api/reps/<slug>/` returns `image` for current reps
- [x] Frontend builds clean
- [x] Visit `/reps/<slug>` ≥1024px: 2-column with photo top of rail. Resize to <1024px: stacks single-column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)