### PR TITLE
votes: surface voting history on RepDetail (PR 2 of 3)

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -26,7 +26,7 @@ Prioritized to-do. Quick wins flagged with *(quick)*.
 
 **Councilmember data on rep detail pages**
 - ~~**Bills sponsored**~~ *(quick)*. Shipped on `reps/bills-sponsored`. `get_rep_by_slug()` now includes `sponsored_bills` (top 10 by latest action) + `sponsored_bills_total`; `RepDetail` renders them via the existing `LegislationCard` and falls through to a "View all N bills sponsored by [name]" link to the legislation index sponsor filter.
-- **Voting history.** The `SeattleVoteEventScraper` skeleton exists at `seattle/vote_events.py:5-9` but is stubbed to `pass`; `seattle/__init__.py:7-8` has the registration commented out. Legistar exposes `/matters/{id}/votes` per matter, which Pupa's `VoteEvent` + `VoteCount` schema already supports — implement the scraper, register it, run a backfill, then expose votes both on `RepDetail` (chronological list of "voted yes/no on CB X.Y") and on `LegislationDetail` (the existing action history could grow a roll-call section). Big lift — touches scraper, models, API, and two surfaces.
+- **Voting history → roll-call on `LegislationDetail`.** Scraper + RepDetail surface have shipped (PR 1: `votes/scraper-and-backfill` data, PR 2: `votes/repdetail-surface` UI). Remaining is a per-bill roll-call section on `LegislationDetail` — a bill can have multiple `VoteEvent`s (committee + full council), each with per-person yes/no. The existing action history timeline is the natural place to grow this. Lookup is `Bill.votes.all().prefetch_related('votes', 'counts')` in API, and the frontend renders an expandable per-event block listing each councilmember's option grouped by yes / no / abstain / absent.
 - **Committee involvements.** Today we surface `bill.extras.MatterBodyName` as the "committee" chip on bill cards but never roll it up per-rep, and we don't have committee *membership* data. Two paths to investigate: (a) Legistar `/bodies/` or `/events/` may expose committee rosters via an `EventBodyName` ↔ Person association — `seattle/events.py:171-173` already captures `EventInSiteURL`, audit whether the same response carries member lists; (b) fall back to scraping seattle.gov councilmember pages where committee assignments are listed prose-style. Once captured, render as a "Committees" section on `RepDetail` showing role (chair / member) + start/end date.
 - **Tenure / "serving since".** Schema has `Membership.start_date` / `end_date` but the data isn't actually populated — `seattle/people.py:48-52` calls `add_membership(...)` without passing dates, and the Legistar people endpoint we scrape doesn't expose them. So this is a data gap, not a quick win as previously noted: requires either (a) extending the people scraper to fetch term dates from seattle.gov councilmember pages or another source, or (b) hardcoding term boundaries based on Seattle's election cycle (Districts 1/3/5/7 vs 2/4/6/At-Large stagger). Once populated, surface as "Serving since June 2024" on the rep header. Pairs with relaxing the `is_current` filter to surface former councilmembers under e.g. `/reps/former/` when we want the historical view.
 - **File pointers**: `frontend/src/components/RepDetail.jsx`, `seattle_app/reps/services.py:320-365` (`_rep_row_to_dict`), `seattle_app/reps/views.py:108-118` (rep_detail), `seattle/vote_events.py` (stub), `seattle/__init__.py:7-8` (scraper registration).
@@ -63,6 +63,22 @@ Lower-priority backlog — fix when you're already in the area, not worth schedu
 ---
 
 ## Done
+
+### Votes — surface voting history on RepDetail — committed 2026-05-03
+
+PR 2 of 3 for voting history. Now that the scraper + backfill (PR 1) populated 552 `VoteEvent` + 4,113 `PersonVote` rows, `/api/reps/<slug>/` ships a `voting_history` block and `RepDetail` renders it as the third right-column section under Committees and Bills sponsored.
+
+**API** — new `_get_voting_history(person_id, limit=25)` in `reps/services.py`. Two queries: a `Count` aggregation by option for the lifetime breakdown, and a `select_related('vote_event__bill__councilmatic_bill')` fetch of the most recent N PersonVote rows for the per-row card data. Filters on `voter_id` (the OCD Person primary key) rather than `voter_name`, which sidesteps the name-collision problem the bills sponsorship query has with former and current members. Returns `{total, breakdown: {option: count, ...}, recent: [{date, option, option_label, result, bill: {identifier, title, slug}}, ...]}`. Returns `total=0` for any rep with no PersonVote rows (the three former councilmembers in the historical data who weren't in our Person table get `voter_id=NULL` and so produce empty payloads here).
+
+`vote_event.start_date` is an OCD CharField storing ISO-8601 strings with fixed-offset suffixes — lex-sort `-vote_event__start_date` matches Pacific wall-clock chronology because the date prefix dominates the comparison even across the PST/PDT boundary.
+
+**Frontend** — new `<section class="rep-detail-votes">` after Bills sponsored on `RepDetail.jsx`. Two pieces:
+1. **Lifetime breakdown row** — one pill per non-zero option (Yes/No/Abstain/Absent/Excused/Not voting/Other) with the count and label, ordered by significance. The pill's left-edge accent color matches the per-row option chip below so the breakdown reads as a summary of the list.
+2. **Recent votes list** — most recent 25 as `<ol>`, each row showing date, option chip, pass/fail result, and a link to `/legislation/<slug>/` with the bill identifier + title. When `total > 25` a footer line declares "Showing the 25 most recent of N recorded votes."
+
+Color is paired with text labels everywhere (Yes/No/Abstain) so contrast doesn't carry meaning alone — yes is green-on-white, no is red-on-white, abstain is amber, the procedural options (absent / excused / not voting / other) share a quieter gray. `<time dateTime>` for accessible date semantics. `aria-labelledby` ties the section to its h2.
+
+Live shape across current councilmembers: Hollingsworth 494 votes (486 yes / 4 no / 1 abstain / 2 absent / 1 not voting), Foster 53 (52 yes / 1 not voting), Lin 82 (76 / 2 / 3 / 1), Rinck 393 (372 / 10 / 0 / 2 / 8 / 1 other). No section at all when total=0 (none in the current 9 actually hit that, but the guard is in for the future).
 
 ### Votes — implement SeattleVoteEventScraper (data only, no UI yet) — committed 2026-05-03
 

--- a/frontend/src/components/RepDetail.css
+++ b/frontend/src/components/RepDetail.css
@@ -319,3 +319,150 @@
   font-size: 0.9375rem;
   text-decoration: underline;
 }
+
+/* Voting history — sits below Bills sponsored. Two pieces:
+   (1) lifetime breakdown row (counts of yes/no/abstain/...) so the
+       overall pattern is visible at a glance, and
+   (2) the most recent N votes as a compact list with bill links.
+   Color is paired with the explicit text label (`Yes`/`No`/...) so
+   contrast doesn't carry the meaning alone. */
+.rep-detail-votes {
+  margin-top: 2.5rem;
+}
+
+.rep-detail-vote-breakdown {
+  list-style: none;
+  margin: 0 0 1.5rem;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.625rem;
+}
+
+.rep-detail-vote-stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  padding: 0.5rem 0.875rem;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-left: 4px solid #9ca3af;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+}
+.rep-detail-vote-stat-n {
+  font-weight: 700;
+  font-size: 1.125rem;
+  color: #1f2937;
+}
+.rep-detail-vote-stat-label {
+  color: #4b5563;
+}
+/* Match the option-chip colors below so the breakdown reads as a
+   summary of the row chips. The left-edge accent carries the cue
+   without coloring the whole pill (which would compete with the
+   chips). */
+.rep-detail-vote-stat--yes        { border-left-color: #047857; }
+.rep-detail-vote-stat--no         { border-left-color: #b91c1c; }
+.rep-detail-vote-stat--abstain    { border-left-color: #b45309; }
+.rep-detail-vote-stat--absent     { border-left-color: #6b7280; }
+.rep-detail-vote-stat--excused    { border-left-color: #6b7280; }
+.rep-detail-vote-stat--not-voting { border-left-color: #6b7280; }
+.rep-detail-vote-stat--other      { border-left-color: #6b7280; }
+
+.rep-detail-vote-recent-h3 {
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #4b5563;
+  margin: 0 0 0.75rem;
+}
+
+.rep-detail-vote-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.rep-detail-vote-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding: 0.75rem 0.875rem;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+}
+
+.rep-detail-vote-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.625rem;
+  font-size: 0.8125rem;
+}
+
+.rep-detail-vote-date {
+  color: #6b7280;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Pupa option chip. Solid color + uppercase short label so the
+   value is unambiguous even with the color stripped. Yes/No/Abstain
+   carry policy meaning; Absent/Excused/etc. are procedural and use
+   a quieter gray to keep the eye on the substantive options. */
+.rep-detail-vote-option {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-radius: 0.25rem;
+  color: #ffffff;
+  background: #6b7280;
+}
+.rep-detail-vote-option--yes        { background: #047857; }
+.rep-detail-vote-option--no         { background: #b91c1c; }
+.rep-detail-vote-option--abstain    { background: #b45309; }
+.rep-detail-vote-option--absent     { background: #6b7280; }
+.rep-detail-vote-option--excused    { background: #6b7280; }
+.rep-detail-vote-option--not-voting { background: #6b7280; }
+.rep-detail-vote-option--other      { background: #6b7280; }
+
+.rep-detail-vote-result {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #4b5563;
+}
+.rep-detail-vote-result--pass { color: #047857; }
+.rep-detail-vote-result--fail { color: #b91c1c; }
+
+.rep-detail-vote-bill {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  text-decoration: none;
+}
+.rep-detail-vote-bill-id {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #2E3D5B;
+  text-decoration: underline;
+}
+.rep-detail-vote-bill:hover .rep-detail-vote-bill-id { color: #1f2937; }
+.rep-detail-vote-bill-title {
+  font-size: 0.875rem;
+  color: #4b5563;
+  line-height: 1.35;
+}
+
+.rep-detail-vote-truncated {
+  margin: 1rem 0 0;
+  font-size: 0.8125rem;
+  color: #6b7280;
+}

--- a/frontend/src/components/RepDetail.jsx
+++ b/frontend/src/components/RepDetail.jsx
@@ -6,6 +6,14 @@ import LegislationCard from './LegislationCard'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import './RepDetail.css'
 
+// Order in which option tallies appear in the breakdown row. Keys
+// match `_OPTION_LABELS` on the API side. Display labels are taken
+// from each row's `option_label` so the source of truth lives in one
+// place (Python).
+const VOTE_OPTION_ORDER = ['yes', 'no', 'abstain', 'absent', 'excused', 'not voting', 'other']
+
+const optionSlug = (s) => s.replace(/\s+/g, '-')
+
 export default function RepDetail() {
   const { slug } = useParams()
   const [data, setData] = useState(null)
@@ -191,6 +199,75 @@ export default function RepDetail() {
                   >
                     View all {data.sponsored_bills_total} bills sponsored by {data.name} →
                   </Link>
+                )}
+              </section>
+            )}
+
+            {(data.voting_history?.total || 0) > 0 && (
+              <section className="rep-detail-votes" aria-labelledby="rep-votes-h2">
+                <h2 id="rep-votes-h2" className="rep-detail-section-h2">
+                  Voting history
+                  <span className="rep-detail-section-count">
+                    {' '}({data.voting_history.total})
+                  </span>
+                </h2>
+                <ul className="rep-detail-vote-breakdown" aria-label="Lifetime vote totals">
+                  {VOTE_OPTION_ORDER.map(opt => {
+                    const n = data.voting_history.breakdown[opt] || 0
+                    if (!n) return null
+                    return (
+                      <li
+                        key={opt}
+                        className={`rep-detail-vote-stat rep-detail-vote-stat--${optionSlug(opt)}`}
+                      >
+                        <span className="rep-detail-vote-stat-n">{n}</span>
+                        <span className="rep-detail-vote-stat-label">
+                          {opt === 'not voting' ? 'Not voting'
+                            : opt.charAt(0).toUpperCase() + opt.slice(1)}
+                        </span>
+                      </li>
+                    )
+                  })}
+                </ul>
+                <h3 className="rep-detail-vote-recent-h3">Recent votes</h3>
+                <ol className="rep-detail-vote-list">
+                  {data.voting_history.recent.map((v, i) => (
+                    <li
+                      key={`${v.bill.slug}-${v.date}-${i}`}
+                      className="rep-detail-vote-row"
+                    >
+                      <div className="rep-detail-vote-meta">
+                        <time className="rep-detail-vote-date" dateTime={v.date}>
+                          {v.date}
+                        </time>
+                        <span
+                          className={`rep-detail-vote-option rep-detail-vote-option--${optionSlug(v.option)}`}
+                        >
+                          {v.option_label}
+                        </span>
+                        <span
+                          className={`rep-detail-vote-result rep-detail-vote-result--${v.result}`}
+                        >
+                          {v.result === 'pass' ? 'Passed' : 'Failed'}
+                        </span>
+                      </div>
+                      <Link
+                        to={`/legislation/${v.bill.slug}/`}
+                        className="rep-detail-vote-bill"
+                      >
+                        <span className="rep-detail-vote-bill-id">{v.bill.identifier}</span>
+                        {v.bill.title && (
+                          <span className="rep-detail-vote-bill-title">{v.bill.title}</span>
+                        )}
+                      </Link>
+                    </li>
+                  ))}
+                </ol>
+                {data.voting_history.total > data.voting_history.recent.length && (
+                  <p className="rep-detail-vote-truncated">
+                    Showing the {data.voting_history.recent.length} most recent
+                    {' '}of {data.voting_history.total} recorded votes.
+                  </p>
                 )}
               </section>
             )}

--- a/reps/services.py
+++ b/reps/services.py
@@ -17,7 +17,8 @@ from django.contrib.gis.geos import Point
 from django.db import connection, models
 
 from councilmatic_core.models import Bill, Person, Membership
-from django.db.models import Max
+from opencivicdata.legislative.models import PersonVote
+from django.db.models import Count, Max
 from .models import District
 
 
@@ -495,7 +496,95 @@ def get_rep_by_slug(slug: str) -> Optional[Dict[str, Any]]:
     bills, total = _get_sponsored_bills(name)
     rep['sponsored_bills'] = bills
     rep['sponsored_bills_total'] = total
+    rep['voting_history'] = _get_voting_history(person_id)
     return rep
+
+
+# Pupa's standard vote-option keys → display labels. The keys come from
+# `seattle/vote_events.py:_VOTE_VALUE_MAP`; "not voting" is the only one
+# with a space, which the frontend slug-cases for class names.
+_OPTION_LABELS = {
+    'yes':         'Yes',
+    'no':          'No',
+    'abstain':     'Abstain',
+    'absent':      'Absent',
+    'excused':     'Excused',
+    'not voting':  'Not voting',
+    'other':       'Other',
+}
+
+
+def _get_voting_history(person_id: str, limit: int = 25) -> Dict[str, Any]:
+    """Aggregate voting stats + the most recent N PersonVote rows for
+    this rep, with bill info attached. Filtering by `voter_id` (the OCD
+    Person primary key) rather than `voter_name` avoids the ambiguity
+    the bills sponsor query has with name collisions across former and
+    current members; the scraper sets `voter` whenever the name resolves
+    to a Person we've scraped.
+
+    Shape:
+        {
+          'total':     N,
+          'breakdown': {'yes': ..., 'no': ..., 'abstain': ..., ...},
+          'recent':    [{'date', 'option', 'option_label', 'result',
+                         'bill': {'identifier', 'title', 'slug'}}, ...],
+        }
+
+    `breakdown` only contains options the rep has actually cast — drops
+    zero entries on the API side so the frontend can iterate without
+    filtering. `recent` is capped at `limit` items, ordered most-recent
+    first; pre-scrape historical members get total=0 here."""
+    if not person_id:
+        return {'total': 0, 'breakdown': {}, 'recent': []}
+
+    # Aggregate all option counts in one query.
+    breakdown_qs = (
+        PersonVote.objects
+        .filter(voter_id=person_id)
+        .values('option')
+        .annotate(n=Count('id'))
+    )
+    breakdown = {row['option']: row['n'] for row in breakdown_qs}
+    total = sum(breakdown.values())
+    if total == 0:
+        return {'total': 0, 'breakdown': {}, 'recent': []}
+
+    # Most recent N votes. `vote_event.start_date` is an ISO-8601 string
+    # with a fixed-offset suffix; lexicographic ordering matches Pacific
+    # wall-clock chronology because the date prefix dominates the sort.
+    recent_qs = (
+        PersonVote.objects
+        .filter(voter_id=person_id)
+        .select_related('vote_event__bill__councilmatic_bill')
+        .order_by('-vote_event__start_date')
+        [:limit]
+    )
+
+    recent: List[Dict[str, Any]] = []
+    for pv in recent_qs:
+        ve = pv.vote_event
+        ocd_bill = ve.bill
+        cm_bill = getattr(ocd_bill, 'councilmatic_bill', None) if ocd_bill else None
+        if not cm_bill:
+            # Defensive — the scraper pre-filters out votes whose bill
+            # isn't in our DB, but skip cleanly if anything slips through.
+            continue
+        recent.append({
+            'date':         (ve.start_date or '')[:10],
+            'option':       pv.option,
+            'option_label': _OPTION_LABELS.get(pv.option, pv.option.title()),
+            'result':       ve.result,
+            'bill': {
+                'identifier': ocd_bill.identifier,
+                'title':      cm_bill.title or '',
+                'slug':       cm_bill.slug,
+            },
+        })
+    return {
+        'total':     total,
+        'breakdown': breakdown,
+        'recent':    recent,
+    }
 
 
 # Mirrors `_normalise_status` in seattle_app/api_views.py — same status


### PR DESCRIPTION
## Summary

PR 2 of 3 for voting history. Now that PR #134 populated 552 `VoteEvent` + 4,113 `PersonVote` rows, surface that data on each councilmember's detail page.

- **API** — `/api/reps/<slug>/` ships a new `voting_history` block: `{total, breakdown: {option: count, ...}, recent: [{date, option, option_label, result, bill: {identifier, title, slug}}, ...]}`. Filters on `voter_id` (OCD Person PK) rather than `voter_name` to sidestep the name-collision pitfall the bills sponsorship query has across former and current members.
- **Frontend** — new `<section class="rep-detail-votes">` after Bills sponsored on `RepDetail`. Renders a lifetime breakdown row (one pill per non-zero option) plus the most recent 25 votes as `<ol>` rows with date / option chip / pass-fail / link to the bill. When `total > 25`, a footer line declares the truncation count.
- **A11y** — color is paired with text labels everywhere (Yes/No/Abstain/...) so contrast doesn't carry meaning alone; `<time dateTime>` for accessible date semantics; `aria-labelledby` ties the section to its h2; aria-label on the breakdown list.

Live shape across current councilmembers: Hollingsworth 494 (486/4/1/2/1), Foster 53 (52/0/0/0/1), Lin 82 (76/2/3/1/0), Rinck 393 (372/10/0/2/8/1 other).

## Test plan

- [ ] `/reps/joy-hollingsworth/` — 494 total, exercises truncation footer + full breakdown row
- [ ] `/reps/dionne-foster/` — 53 total, no truncation footer (recent list shows all 25 of 53)
- [ ] `/reps/alexis-mercedes-rinck/` — has every option category including a rare `Other` chip
- [ ] Tab order through the votes section is sensible; bill links focus visibly
- [ ] Mobile width — vote-meta row wraps cleanly, bill identifier + title stack
- [ ] Bill links land on `/legislation/<slug>/` without a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)