### PR TITLE
frontend: fix :5173 dev URL routing

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,15 +2,31 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
-  base: '/static/',
+//
+// `base` is conditional:
+//   * Production build → `/static/` so the bundle's hashed asset URLs
+//     match Django's STATIC_URL when the SPA is served by the
+//     `react_app` view in prod.
+//   * Dev server → `/` so `localhost:5173/reps/<slug>/` "just works".
+//     Vite's history fallback serves index.html for unknown paths,
+//     and React Router takes over from there.
+//
+// The `server.proxy` block forwards everything Django owns
+// (`/api`, `/admin`, `/cms`, `/static`, `/media`) to the app
+// container at port 8000. Note: Vite's own dev assets live at
+// `/@vite/...` and `/src/...`, so they don't clash with `/static`.
+// SPA routes (anything else) get the index.html fallback and
+// React Router renders the correct page.
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/static/' : '/',
   plugins: [react()],
   server: {
     proxy: {
-      '/api': {
-        target: 'http://app:8000',
-        changeOrigin: true,
-      },
+      '/api':    { target: 'http://app:8000', changeOrigin: true },
+      '/admin':  { target: 'http://app:8000', changeOrigin: true },
+      '/cms':    { target: 'http://app:8000', changeOrigin: true },
+      '/static': { target: 'http://app:8000', changeOrigin: true },
+      '/media':  { target: 'http://app:8000', changeOrigin: true },
     },
   },
-})
+}))


### PR DESCRIPTION
## Summary

`localhost:5173/` redirected and `localhost:5173/reps/<slug>/` returned 404 because the Vite config used `base: '/static/'` unconditionally and only proxied `/api` to Django. With the production deploy in flight, this matters more — devs working against the live URL pattern want direct `:5173/...` routes to work for HMR.

**Fix:**
- `base` is now conditional: `/static/` only for `vite build` (matches Django's `STATIC_URL` when the SPA is served by Django in prod), `/` for the dev server so SPA history fallback can serve `index.html` for any unknown path.
- `server.proxy` expanded to forward `/api`, `/admin`, `/cms`, `/static`, `/media` to the app container at port 8000. Django-owned URLs still work when hit via `:5173`. SPA routes (anything not in that list, not Vite's own `/@vite/*` and `/src/*`, and not a real file) fall through to `index.html` and React Router renders.

## Verified locally

```
curl :5173/                              → 200 (SPA shell)
curl :5173/reps/joy-hollingsworth/       → 200 (SPA shell, React Router renders RepDetail)
curl :5173/api/reps/                     → 200 (proxied to Django)
curl :5173/admin/                        → 200 (proxied to Django)
curl :5173/static/favicon.svg            → 200 (proxied to Django)
```

## Test plan

- [x] `localhost:5173` opens the homepage with HMR working
- [x] `localhost:5173/reps/joy-hollingsworth/` renders the rep detail page (involvement table, committees in rail, etc.)
- [x] `localhost:5173/legislation/cb-121200/` renders the bill detail page (with rollcall once #137 lands)
- [ ] `localhost:5173/admin/` lands on Django admin
- [ ] Hot reload still fires on .jsx/.css edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)