### PR TITLE
frontend: redirect bare /admin and /cms to trailing-slash on :5173

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,33 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+// Vite's SPA history-fallback middleware intercepts extensionless
+// paths and serves index.html before the proxy runs, so a bare
+// `/admin` or `/cms` (no trailing slash) ends up on the SPA's
+// NotFound instead of getting proxied to Django. Django itself
+// would APPEND_SLASH-redirect these to the slash form; we do the
+// same here, ahead of every other middleware, so the proxy then
+// matches the slash variant and forwards to Django cleanly.
+const djangoTrailingSlashRedirect = {
+  name: 'django-bare-route-trailing-slash',
+  configureServer(server) {
+    const bare = new Set(['/admin', '/cms'])
+    server.middlewares.use((req, res, next) => {
+      // Strip any querystring before the comparison so `/admin?foo=bar`
+      // also redirects to `/admin/?foo=bar` cleanly.
+      const [path, query] = (req.url || '').split('?')
+      if (bare.has(path)) {
+        res.writeHead(302, {
+          Location: path + '/' + (query ? '?' + query : ''),
+        })
+        res.end()
+        return
+      }
+      next()
+    })
+  },
+}
+
 // https://vite.dev/config/
 //
 // `base` is conditional:
@@ -17,9 +44,14 @@ import react from '@vitejs/plugin-react'
 // `/@vite/...` and `/src/...`, so they don't clash with `/static`.
 // SPA routes (anything else) get the index.html fallback and
 // React Router renders the correct page.
+//
+// Plain string-prefix proxy keys. The bare `/admin` / `/cms` cases
+// are handled separately by the `djangoTrailingSlashRedirect` plugin
+// above (regex keys don't help because Vite's SPA fallback runs
+// before the proxy for extensionless paths).
 export default defineConfig(({ command }) => ({
   base: command === 'build' ? '/static/' : '/',
-  plugins: [react()],
+  plugins: [djangoTrailingSlashRedirect, react()],
   server: {
     proxy: {
       '/api':    { target: 'http://app:8000', changeOrigin: true },


### PR DESCRIPTION
## Summary

Follow-up to #139. The earlier fix made `/admin/` and `/cms/` (with trailing slash) proxy to Django correctly via `:5173`, but bare `/admin` and `/cms` (no trailing slash) still landed on the SPA's NotFound — Vite's history fallback serves `index.html` for extensionless paths before the proxy gets a chance, so the request never reached Django (which would have done the slash redirect itself via `APPEND_SLASH=True`).

Adding a `configureServer` middleware that 302-redirects the two bare paths to their trailing-slash variants ahead of every other Vite middleware. Querystrings preserved through the redirect.

## Verified locally

```
/admin    → 302 → /admin/ → 302 → /admin/login/ → 200
/cms      → 302 → /cms/   → 302 → /cms/login/   → 200
```

(And the existing trailing-slash forms keep working unchanged.)

## Test plan

- [ ] `localhost:5173/admin` (no trailing slash) lands on Django admin login
- [ ] `localhost:5173/cms` (no trailing slash) lands on Wagtail CMS login
- [ ] `localhost:5173/admin?next=/foo` preserves the querystring through the redirect
- [ ] SPA routes that happen to start with `/admin` (e.g. an "admin" username slug) — there are none today, but `/administrator` would still SPA-route correctly because the middleware checks for exact-equality, not prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)