### PR TITLE
dev: auto-trust localhost:5173/:8000 origins for CSRF when DEBUG=True

### DIFF
--- a/seattle_app/settings.py
+++ b/seattle_app/settings.py
@@ -25,6 +25,19 @@ ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1").split("
 CSRF_TRUSTED_ORIGINS = [
     o for o in os.getenv("CSRF_TRUSTED_ORIGINS", "").split(",") if o
 ]
+# Dev-mode auto-allow for the Vite dev server (:5173) and Django
+# itself (:8000). When the browser hits `localhost:5173/admin/`, the
+# `Origin` header is `http://localhost:5173`; Vite proxies the
+# request to Django on :8000, which Django would otherwise reject
+# as cross-origin. Production is unaffected — DEBUG=False there, so
+# only the explicit env-var values count.
+if DEBUG:
+    CSRF_TRUSTED_ORIGINS.extend([
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+        "http://localhost:8000",
+        "http://127.0.0.1:8000",
+    ])
 
 # Application definition
 INSTALLED_APPS = [


### PR DESCRIPTION
## Summary

Companion to #139 / #140 (the Vite `:5173` direct-URL work). Logging into Django admin or Wagtail CMS via `localhost:5173` triggered:

```
CSRF verification failed.
Reason: Origin checking failed - http://localhost:5173 does not match any trusted origins.
```

Django 4+ checks the `Origin` header against `CSRF_TRUSTED_ORIGINS` for any state-changing POST. The browser sends `Origin: http://localhost:5173`; Vite proxies to Django on `:8000`; Django sees the mismatch and refuses the form.

Appending the four dev origins (localhost + 127.0.0.1, both `:5173` and `:8000`) when `DEBUG=True`. Production is unaffected — `DEBUG=False` there, so only the explicit `CSRF_TRUSTED_ORIGINS` env var values count, and no localhost addresses leak into the trusted list.

## Test plan

- [ ] `localhost:5173/admin/login/` — submit the form, lands authenticated on /admin/
- [ ] `localhost:5173/cms/login/` — same for Wagtail
- [ ] `localhost:8000/admin/login/` — direct (no Vite proxy) still works
- [ ] Production unaffected (no behavior change when `DEBUG=False`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)