### PR TITLE
ops: chmod +x entrypoint scripts inside the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,13 @@ RUN pip install -r requirements.txt
 
 COPY . /app
 
+# Restore the executable bit on shell scripts. Files committed from
+# Windows often land in git with mode 644 because `core.fileMode`
+# defaults to false there; the Linux container's OCI runtime then
+# refuses to exec them. Doing this in the image avoids a per-deploy
+# manual `chmod +x` on the host.
+RUN chmod +x /app/docker-entrypoint.sh /app/scripts/*.sh
+
 # Pull the production-built SPA from the node stage so the image
 # contains a real `frontend/dist/` regardless of the host's state.
 # In dev compose this gets shadowed by the source-mount volume — the


### PR DESCRIPTION
## Summary

First production deploy on Hetzner failed at container start with:

\`\`\`
Error response from daemon: failed to create task for container:
  failed to create shim task: OCI runtime create failed:
  runc create failed: unable to start container process:
  error during container init: exec: "/app/docker-entrypoint.sh":
  permission denied
\`\`\`

\`docker-entrypoint.sh\` and \`scripts/*.sh\` were committed from a
Windows host where \`core.fileMode\` defaults to false, so they
landed in git with mode 644 instead of 755. The Linux container's
OCI runtime then refuses to exec them.

Adding \`RUN chmod +x /app/docker-entrypoint.sh /app/scripts/*.sh\`
after the source \`COPY\` makes the image self-correcting — the
bit gets set inside the image regardless of how the host's git
checkout came out.

## Test plan

- [ ] \`docker compose -f docker-compose.prod.yml up -d --build\` on a fresh checkout, no manual chmod, all containers reach \`running\` (or \`healthy\`).
- [ ] Dev compose still works (\`docker compose up -d\`) — the chmod runs in both targets since the Dockerfile is shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)