### PR TITLE
ops: filter empty CORS origins; set Wagtail base URL

### DIFF
--- a/seattle_app/settings.py
+++ b/seattle_app/settings.py
@@ -205,6 +205,13 @@ if DEBUG:
     ]
 
 WAGTAIL_SITE_NAME = "Seattle Councilmatic"
+# Used by Wagtail for outbound notification email URLs. Without it,
+# the admin's W003 system check fires every boot. Default points at
+# the canonical prod hostname; override via env for staging deploys.
+WAGTAILADMIN_BASE_URL = os.getenv(
+    "WAGTAILADMIN_BASE_URL",
+    "https://www.seattlecouncilmatic.org/cms/",
+)
 
 OCD_CITY_COUNCIL_NAME = os.getenv("OCD_CITY_COUNCIL_NAME", WAGTAIL_SITE_NAME)
 
@@ -256,7 +263,13 @@ if DEBUG:
         "http://127.0.0.1:5173",
     ]
 else:
-    # In production, configure based on your deployment
-    CORS_ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "").split(",")
+    # In production, the SPA is served same-origin by Django so CORS
+    # isn't strictly needed. Empty list is valid; comma-split-and-
+    # filter mirrors the CSRF_TRUSTED_ORIGINS pattern so a missing
+    # env var doesn't leave a `[""]` that fails the corsheaders
+    # system check.
+    CORS_ALLOWED_ORIGINS = [
+        o for o in os.getenv("CORS_ALLOWED_ORIGINS", "").split(",") if o
+    ]
 
 CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
## Summary

First production boot on Hetzner failed with corsheaders E013 and warned with wagtailadmin W003. Both surfaced from settings shapes that worked fine when the env vars were unset locally (DEBUG=True takes the dev branch) but broke in prod.

**E013 — `Origin '' in CORS_ALLOWED_ORIGINS is missing scheme or netloc`** — settings did `os.getenv("CORS_ALLOWED_ORIGINS", "").split(",")`, which returns `[""]` when the env var is unset. Filtering empty strings (same pattern as `CSRF_TRUSTED_ORIGINS`) leaves an empty list, which is valid. The SPA is served same-origin by Django in prod, so CORS isn't strictly needed — empty is correct.

**W003 — `WAGTAILADMIN_BASE_URL not defined`** — Wagtail uses this for outbound notification email URLs. Defaulting to `https://www.seattlecouncilmatic.org/cms/` with env override.

## Test plan

- [ ] First Hetzner boot proceeds past `python manage.py check` without E013.
- [ ] No W003 in startup logs.
- [ ] Dev compose still works (DEBUG=True branch unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)