### PR TITLE
ops: fix wsgi.py settings module

### DIFF
--- a/seattle_app/wsgi.py
+++ b/seattle_app/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "councilmatic.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "seattle_app.settings")
 
 application = get_wsgi_application()


### PR DESCRIPTION
## Summary

First Hetzner production boot died with:

\`\`\`
ModuleNotFoundError: No module named 'councilmatic'
\`\`\`

Cause: \`seattle_app/wsgi.py\` line 14 was a leftover from the original Councilmatic template:

\`\`\`python
os.environ.setdefault("DJANGO_SETTINGS_MODULE", "councilmatic.settings")
\`\`\`

The actual settings module is \`seattle_app.settings\`. Dev didn't catch this because \`python manage.py runserver\` uses manage.py's already-correct default. Gunicorn imports wsgi.py instead, hits the wrong default, and dies.

## Test plan

- [ ] After merge + rebuild on the Hetzner box, gunicorn workers start cleanly (no more \`Worker failed to boot\`)
- [ ] \`https://www.seattlecouncilmatic.org/\` returns 200 (was 502)
- [ ] Dev compose still runs (manage.py runserver path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)