### PR TITLE
ops: createcachetable on boot

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,13 @@ set -e
 
 if [ "$DJANGO_MANAGEPY_MIGRATE" = 'on' ]; then
     python manage.py migrate --noinput
+    # `db.DatabaseCache` (prod CACHES backend) requires this table to
+    # exist; FetchFromCache / UpdateCache middleware error 500 on every
+    # request without it. `createcachetable` reads the cache config and
+    # is idempotent (no-op if the table is already there), so it's safe
+    # to run on every boot. Cheap insurance against a fresh prod DB or
+    # a forgotten one-time setup step.
+    python manage.py createcachetable
 fi
 
 exec "$@"


### PR DESCRIPTION
## Summary

Settings uses \`db.DatabaseCache\` in prod (\`DEBUG=False\`). \`FetchFromCacheMiddleware\` + \`UpdateCacheMiddleware\` hit this backend on every request, which 500s if the underlying table doesn't exist. First Hetzner deploy surfaced this — gunicorn was booting cleanly (after #144) but every request returned 500 with \`relation "councilmatic_cache_table" does not exist\`.

\`createcachetable\` is idempotent (no-op if the table is already there), so adding it to \`docker-entrypoint.sh\` right after \`migrate\` is safe to run on every boot and avoids the easy-to-miss one-time setup step.

## Test plan

- [ ] Fresh prod boot, no manual \`createcachetable\`, requests return real responses (not 500)
- [ ] Existing prod boots are no-ops (table already exists, command exits clean)
- [ ] Dev compose unaffected (DummyCache backend doesn't use the table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)