### PR TITLE
ops: redirect bare /admin and /cms to slash variants in Django urls

### DIFF
--- a/seattle_app/urls.py
+++ b/seattle_app/urls.py
@@ -24,6 +24,15 @@ urlpatterns = [
     # would.
     path("favicon.ico", RedirectView.as_view(url="/static/favicon.svg", permanent=False)),
     path("favicon.png", RedirectView.as_view(url="/static/favicon.png", permanent=False)),
+    # `/admin` and `/cms` (no trailing slash) get an explicit redirect
+    # to the slash variant. Django's APPEND_SLASH would handle this on
+    # its own — but the SPA catch-all at the bottom (`<path:path>`)
+    # matches `/admin` first, so APPEND_SLASH never kicks in and the
+    # request lands on the React NotFound. The Vite dev server has a
+    # parallel middleware fix (see frontend/vite.config.js); this is
+    # the prod-side equivalent.
+    path("admin", RedirectView.as_view(url="/admin/", permanent=True)),
+    path("cms",   RedirectView.as_view(url="/cms/",   permanent=True)),
     path("admin/", admin.site.urls),
     path("api/reps/", include("reps.urls")),
     path("api/legislation/recent/", api_views.recent_legislation, name="api_legislation_recent"),


### PR DESCRIPTION
## Summary

Companion to #140 — same trailing-slash redirect, different layer. PR #140 fixed it for the Vite dev server (\`localhost:5173/admin\` → \`/admin/\`); prod doesn't go through Vite, so the bare paths were rendering the SPA's NotFound instead of the admin/CMS login.

**Cause:** the SPA catch-all \`path("<path:path>", views.react_app)\` at the bottom of \`urlpatterns\` matches \`/admin\` and \`/cms\` before Django's APPEND_SLASH middleware can kick in. APPEND_SLASH only fires when no URL matches; the catch-all matches everything.

**Fix:** explicit \`RedirectView\` entries for \`/admin\` and \`/cms\` before the include lines, mirroring the favicon redirects already in this file.

## Test plan

- [ ] \`curl -sI https://www.seattlecouncilmatic.org/admin\` returns \`HTTP/2 301\` to \`/admin/\`
- [ ] \`curl -sIL https://www.seattlecouncilmatic.org/admin\` follows to the admin login (302 → 200)
- [ ] Same for \`/cms\`
- [ ] SPA routes that don't conflict (e.g. \`/legislation/cb-121200/\`) still render via catch-all

🤖 Generated with [Claude Code](https://claude.com/claude-code)