### PR TITLE
frontend: global box-sizing border-box + scroll-to-top on route change

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { useEffect } from 'react'
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import Header from './components/Header'
 import Footer from './components/Footer'
 import LegislationHero from './components/LegislationHero'
@@ -21,6 +22,25 @@ import NotFound from './components/NotFound'
 import useDocumentTitle from './hooks/useDocumentTitle'
 import './App.css'
 
+// React Router v7 `BrowserRouter` doesn't reset scroll on route change
+// (the data-router's `<ScrollRestoration />` would, but migrating
+// routers is a bigger change). Without this, navigating between
+// detail pages carries over the previous page's scroll position —
+// e.g., scrolling down `/legislation` then clicking a rep loaded
+// `/reps/<slug>` already scrolled past the portrait. Closes #156.
+//
+// Skips when there's a hash in the URL so deep links to anchors
+// (e.g., the skip-link's `#main-content`) still scroll to their
+// target instead of the top.
+function ScrollToTop() {
+  const { pathname, hash } = useLocation()
+  useEffect(() => {
+    if (hash) return
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
+  }, [pathname, hash])
+  return null
+}
+
 function HomePage() {
   useDocumentTitle(null) // Just "Seattle Councilmatic" — site is the page subject.
   return (
@@ -34,6 +54,7 @@ function HomePage() {
 function App() {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       {/* Skip-link for keyboard / screen-reader users — first
           focusable element on every page, visible only when focused.
           Lets users bypass the header + main nav to reach page content

--- a/frontend/src/components/MuniCodeIndex.css
+++ b/frontend/src/components/MuniCodeIndex.css
@@ -79,7 +79,6 @@
   border-radius: 0.5rem;
   background: #ffffff;
   color: #1f2937;
-  box-sizing: border-box;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 .smc-index-search:focus {

--- a/frontend/src/components/Search.css
+++ b/frontend/src/components/Search.css
@@ -56,7 +56,6 @@
   border-radius: 0.5rem;
   background: #ffffff;
   color: #1f2937;
-  box-sizing: border-box;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 .search-input:focus {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,6 +18,19 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Global box-sizing reset. Modern-framework default — `width: 100%`
+   plus padding stays inside the declared 100% rather than overflowing
+   it. Prevents the `.header-container` horizontal-scroll bug class
+   (closes #154) and any future recurrence. Two component files
+   (`MuniCodeIndex.css`, `Search.css`) previously declared this
+   locally; those rules are dropped now that the global default
+   covers them. */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   min-width: 320px;


### PR DESCRIPTION
## Summary

Two reported quick-win bugs, fixed together since they're both small frontend behavior fixes with no API touches.

### #154 — Horizontal scrollbar on every page

`App.css:48-54` had `width: 100%` + horizontal `padding` with default content-box, overflowing the viewport by 2rem at every breakpoint. Added the modern-framework default to `index.css`:

\`\`\`css
*, *::before, *::after {
  box-sizing: border-box;
}
\`\`\`

Two scattered local declarations (`MuniCodeIndex.css:82`, `Search.css:59`) dropped now that the global rule covers them.

### #156 — Rep detail loads scrolled past the portrait

React Router v7 `BrowserRouter` doesn't reset scroll on route change. Native `<ScrollRestoration />` only works with the data router (\`createBrowserRouter\`), and migrating routers is a bigger change. Added a tiny `ScrollToTop` component using \`useLocation\` + \`useEffect\` (\~10 LOC) that scrolls to top on pathname change. Skips when the URL has a hash so anchor links and the skip-link's `#main-content` keep working.

## Test plan

- [x] Hard-refresh `https://www.seattlecouncilmatic.org/` — no horizontal scrollbar at desktop or mobile widths
- [x] Scroll partway down `/legislation`, click any bill → bill detail loads at top
- [x] Scroll on rep detail, navigate to another rep → second rep loads at top
- [x] Browser back from rep detail to the index → returns to index (no scroll-y guarantee, but page state preserved)
- [x] Tab to skip-link, hit Enter → page scrolls to `#main-content` (anchor still works)

Closes #154
Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)