### PR TITLE
dev: skip cache middleware when DEBUG=True

### DIFF
--- a/seattle_app/settings.py
+++ b/seattle_app/settings.py
@@ -84,10 +84,17 @@ MIDDLEWARE = [
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.cache.UpdateCacheMiddleware",
+    # Cache middleware emits Cache-Control: max-age=600 on every cacheable
+    # response. In dev (DEBUG=True) the cache backend is `dummy.DummyCache`
+    # so server-side caching is a no-op, but the headers still tell the
+    # browser to cache for 10 minutes — which makes admin-edit-then-
+    # refresh workflows confusing (saves persist, API returns fresh data,
+    # but the browser keeps showing the old response). Skip it entirely
+    # in dev. Closes #159.
+    *([] if DEBUG else ["django.middleware.cache.UpdateCacheMiddleware"]),
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
-    "django.middleware.cache.FetchFromCacheMiddleware",
+    *([] if DEBUG else ["django.middleware.cache.FetchFromCacheMiddleware"]),
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",


### PR DESCRIPTION
## Summary

Closes #159. `UpdateCacheMiddleware` emits `Cache-Control: max-age=600` on every cacheable response based on `CACHES.default.TIMEOUT`. In dev the backend is `dummy.DummyCache` (no-op server-side), but the browser still honors the header and caches API responses for 10 minutes — making admin-edit-then-refresh workflows confusing.

Skip both cache middlewares when `DEBUG=True`. Production unaffected.

## Test plan

- [ ] Dev: `curl -I http://localhost:5173/api/reps/<slug>/` returns no `Cache-Control: max-age=600` (verified — header is gone after Django auto-reload)
- [ ] Dev: edit a Membership in `/admin/core/membership/`, refresh the rep page → new value appears immediately (no hard-refresh needed)
- [ ] Prod: `curl -I https://www.seattlecouncilmatic.org/api/reps/<slug>/` still shows `Cache-Control: max-age=600`

🤖 Generated with [Claude Code](https://claude.com/claude-code)