### PR TITLE
reps: stop scraper from setting tenure dates; admin owns that field

### DIFF
--- a/reps/services.py
+++ b/reps/services.py
@@ -359,10 +359,19 @@ def _rep_row_to_dict(name: str, slug: str, label: str, person_id: str) -> Dict[s
         # (label = the District/Position string). Surfaces as the raw
         # ISO partial-date string; the frontend formats it to a
         # human-readable "Serving since <Month Year>" line.
-        seat_membership = (
-            person.memberships
-            .filter(organization__name='Seattle City Council', label=label)
-            .first()
+        # Defensive: if duplicate rows exist (e.g. from a transient
+        # scraper bug — see `dedup_council_memberships`), prefer the
+        # one that has a date set so the UI doesn't render blank
+        # while we're cleaning up.
+        seat_memberships = list(
+            person.memberships.filter(
+                organization__name='Seattle City Council',
+                label=label,
+            )
+        )
+        seat_membership = next(
+            (m for m in seat_memberships if m.start_date),
+            seat_memberships[0] if seat_memberships else None,
         )
         if seat_membership and seat_membership.start_date:
             rep_data['tenure_start'] = seat_membership.start_date

--- a/seattle/people.py
+++ b/seattle/people.py
@@ -294,28 +294,35 @@ def extract_contact_details(html_str: str) -> dict:
 class SeattlePersonScraper(Scraper):
 
     def _fetch_member_extras(self, profile_url: str, name: str
-                             ) -> tuple[dict, list[dict], str | None, list[dict], dict]:
-        """Fetch the per-member detail page for contacts + photo, the
-        `/committees-and-calendar` and `/staff` subpages, and the
-        `/about-<firstname>` page for tenure dates.
+                             ) -> tuple[dict, list[dict], str | None, list[dict]]:
+        """Fetch the per-member detail page for contacts + photo, and
+        the `/committees-and-calendar` and `/staff` subpages.
 
-        Returns (contacts_dict, committees_list, photo_url, staff_list,
-        tenure_dict). All can be empty/None when the corresponding
-        fetch returns non-200 or the page lacks the expected block.
-        `allow_redirects=False` because seattle.gov 301s former-member
-        URLs to their successor (`sara-nelson` → `dionne-foster`); only
-        a 200 means the URL really belongs to this person.
+        Returns (contacts_dict, committees_list, photo_url, staff_list).
+        All can be empty/None when the corresponding fetch returns
+        non-200 or the page lacks the expected block. `allow_redirects=False`
+        because seattle.gov 301s former-member URLs to their successor
+        (`sara-nelson` → `dionne-foster`); only a 200 means the URL
+        really belongs to this person.
 
-        About-page subpath comes from `ABOUT_PAGE_SLUGS` since each
-        office picks its own (`/about-joy`, `/about-eddie-lin`, etc.).
-        Members not in the dict get no tenure scrape — the membership
-        row stays unset, which is the right fallback for someone who
-        was just sworn in and hasn't had their About page populated."""
+        Tenure dates were briefly scraped here too (extract_tenure on
+        the About page), but pupa's MembershipImporter.get_object
+        includes start_date in its lookup spec — passing one to
+        add_membership creates a new row instead of updating the
+        existing dateless one. Result: every scrape was minting
+        duplicate council-seat memberships. Tenure data now lives in
+        the Django admin (Membership rows are editable there); the
+        scraper stays out of that field. extract_tenure remains
+        importable in case a future implementation wants to seed
+        admin defaults via a separate post-import step.
+        The `name` parameter is kept on the signature even though
+        the About-page fetch is gone, for future use and so the
+        caller doesn't have to thread it conditionally."""
+        del name  # currently unused; kept on signature for future use
         contacts: dict = {}
         committees: list[dict] = []
         photo_url: str | None = None
         staff: list[dict] = []
-        tenure: dict = {}
         try:
             r = requests.get(profile_url, timeout=10, allow_redirects=False)
             if r.status_code == 200:
@@ -337,16 +344,7 @@ class SeattlePersonScraper(Scraper):
                 staff = extract_staff(r.text)
         except requests.RequestException as e:
             logger.warning(f"Could not fetch staff for {profile_url}: {e}")
-        about_sub = ABOUT_PAGE_SLUGS.get(name)
-        if about_sub:
-            try:
-                r = requests.get(f"{profile_url}/{about_sub}",
-                                 timeout=10, allow_redirects=False)
-                if r.status_code == 200:
-                    tenure = extract_tenure(r.text)
-            except requests.RequestException as e:
-                logger.warning(f"Could not fetch about page for {profile_url}: {e}")
-        return contacts, committees, photo_url, staff, tenure
+        return contacts, committees, photo_url, staff
 
     def scrape(self):
         """Scrape Seattle City Council members from seattle.gov.
@@ -377,7 +375,7 @@ class SeattlePersonScraper(Scraper):
             district_type, number, name = match.group(1), match.group(2), match.group(3).strip()
             district = f"{district_type} {number}"
             profile_url = f"{url}/{profile_slug(name)}"
-            contacts, committees, photo_url, staff, tenure = self._fetch_member_extras(
+            contacts, committees, photo_url, staff = self._fetch_member_extras(
                 profile_url, name
             )
             members_data.append({
@@ -388,7 +386,6 @@ class SeattlePersonScraper(Scraper):
                 "committees_raw": committees,
                 "photo_url": photo_url,
                 "staff": staff,
-                "tenure": tenure,
             })
 
         # Build canonical_committees map: committee names on seattle.gov
@@ -428,23 +425,19 @@ class SeattlePersonScraper(Scraper):
                 # records, search them, link them to bills, etc.) — just
                 # display data attached to the rep.
                 person.extras["staff"] = m["staff"]
-            # Tenure dates parsed from the per-member /about-* page on
-            # seattle.gov ("In office since: 2024 / Current term:
-            # January 2024 - December 2027"). Members without the
-            # structured block (e.g. recently-sworn-in at-large
-            # members whose offices haven't filled their About page)
-            # get no dates here — those rows can be set via the
-            # `/admin/opencivicdata/membership/` admin as a fallback.
-            membership_kwargs = {
-                "role": "Councilmember",
-                "label": district,
-            }
-            tenure = m["tenure"]
-            if tenure.get("start_date"):
-                membership_kwargs["start_date"] = tenure["start_date"]
-            if tenure.get("end_date"):
-                membership_kwargs["end_date"] = tenure["end_date"]
-            person.add_membership("Seattle City Council", **membership_kwargs)
+            # Tenure dates (`start_date` / `end_date`) are intentionally
+            # NOT passed here — pupa's MembershipImporter.get_object
+            # uses start_date as part of its uniqueness key, so passing
+            # one to add_membership creates a *new* row instead of
+            # updating the existing dateless one. Result: every scrape
+            # was minting duplicates. The data lives in the Django
+            # admin (`/admin/core/membership/`) where it's editable
+            # without needing a deploy.
+            person.add_membership(
+                "Seattle City Council",
+                role="Councilmember",
+                label=district,
+            )
             person.add_source(url)
             person.add_link(m["profile_url"], note="City Council profile")
 

--- a/seattle_app/management/commands/dedup_council_memberships.py
+++ b/seattle_app/management/commands/dedup_council_memberships.py
@@ -1,0 +1,100 @@
+"""Merge duplicate council-seat Memberships caused by pupa's
+start-date-aware import logic.
+
+Pupa's `MembershipImporter.get_object` uses `start_date` as part of
+its uniqueness key. When a scraper that previously didn't pass
+`start_date` starts passing one, pupa can't find the existing
+dateless row → creates a new dated one → duplicate. The scraper has
+since been fixed to never pass start_date (admin owns that field
+now), but any prod DB that ran the dated-scrape version once already
+has duplicates that need cleaning up.
+
+For each (person, organization, label, role) group with > 1 row:
+- Keep the row with `start_date` set (or any date set, vs none)
+- If multiple rows have dates, keep the most-recently-updated one
+- If no row has dates, keep the most-recently-updated one
+- Delete the rest
+
+Idempotent — re-running on a clean DB does nothing.
+
+    python manage.py dedup_council_memberships
+    python manage.py dedup_council_memberships --dry-run
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand
+from opencivicdata.core.models import Membership
+
+
+class Command(BaseCommand):
+    help = "Merge duplicate council-seat Membership rows."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would be deleted; don't write to the DB.",
+        )
+
+    def handle(self, *args, **options):
+        dry = options["dry_run"]
+
+        # Group all memberships by (person_id, organization_id, label, role).
+        # That's the natural identity for "the same membership."
+        groups: dict[tuple, list[Membership]] = defaultdict(list)
+        for m in Membership.objects.select_related("person", "organization"):
+            key = (m.person_id, m.organization_id, m.label, m.role)
+            groups[key].append(m)
+
+        total_groups = len(groups)
+        dup_groups = {k: v for k, v in groups.items() if len(v) > 1}
+
+        if not dup_groups:
+            self.stdout.write(self.style.SUCCESS(
+                f"No duplicates found across {total_groups} membership groups."
+            ))
+            return
+
+        deleted_count = 0
+        for key, rows in dup_groups.items():
+            person = rows[0].person
+            org = rows[0].organization
+            label = rows[0].label
+            role = rows[0].role
+            person_name = person.name if person else "(no person)"
+            org_name = org.name if org else "(no org)"
+
+            # Keep the row that's most likely the canonical one:
+            #   1. Has start_date set (vs not)
+            #   2. Tiebreak by most-recent updated_at
+            rows.sort(
+                key=lambda r: (bool(r.start_date or r.end_date), r.updated_at),
+                reverse=True,
+            )
+            keep = rows[0]
+            drop = rows[1:]
+
+            self.stdout.write(
+                f"  GROUP  {person_name:30s}  {org_name[:35]:35s}  {label!r:14s}  {role!r}"
+            )
+            self.stdout.write(
+                f"    KEEP {keep.id[-8:]}  start={keep.start_date or '(unset)':>10s}  "
+                f"end={keep.end_date or '(unset)':>10s}  updated={keep.updated_at}"
+            )
+            for r in drop:
+                self.stdout.write(
+                    f"    DROP {r.id[-8:]}  start={r.start_date or '(unset)':>10s}  "
+                    f"end={r.end_date or '(unset)':>10s}  updated={r.updated_at}"
+                )
+                if not dry:
+                    r.delete()
+                deleted_count += 1
+
+        verb = "would delete" if dry else "deleted"
+        self.stdout.write(self.style.SUCCESS(
+            f"\n{verb} {deleted_count} duplicate Membership row(s) "
+            f"across {len(dup_groups)} group(s)."
+        ))


### PR DESCRIPTION
## Summary

Yesterday's PR #158 had the scraper extract tenure dates from seattle.gov About pages and pass them to `Person.add_membership(start_date=..., end_date=...)`. That worked in code review but bit us hard the first time the prod scrape actually ran: every councilmember whose About page had the structured block ended up with a *duplicate* Seattle City Council membership row.

## Root cause

\`pupa/importers/memberships.py\`:

\`\`\`python
def get_object(self, membership):
    spec = {
        "organization_id": membership["organization_id"],
        "person_id": membership["person_id"],
        "label": membership["label"],
        "role": membership["role"],
    }
    ...
    if membership["start_date"]:
        spec["start_date"] = membership["start_date"]
\`\`\`

Pupa includes \`start_date\` in its lookup spec when present. The pre-existing council-seat membership rows have \`start_date=""\`. The new scrape passed \`start_date="2024-01-01"\`. Spec mismatch → no existing row matched → pupa created a new one. Old dateless row stayed; new dated row joined it.

## Fix

Three coordinated changes:

1. **Scraper** stops passing \`start_date\` / \`end_date\` to \`add_membership\`. Pupa goes back to its pre-#158 upsert behavior (org + person + label + role uniquely identifies a row). \`extract_tenure\` stays importable as a library function in case a future post-import reconciliation step wants to seed admin defaults.
2. **\`dedup_council_memberships\` management command** merges existing duplicates. Keeps the row with a date set (or most-recently-updated as tiebreak); deletes the others.
3. **API** \`_rep_row_to_dict\` defensively prefers the row with \`start_date\` when duplicates exist, so the UI doesn't render blank between deploy and dedup.

## Trade-off

Loses the auto-population of the 5 reps whose About pages had structured tenure blocks (Saka, Hollingsworth, Rivera, Strauss, Kettle). They go back to needing admin entries — which is fine because (a) admin entries are how the user wanted to manage this anyway, and (b) the entries are already in the DB from the post-#158 scrape; the dedup will *keep* those rows.

## Deploy

After merge:
\`\`\`
git pull
docker compose -f docker-compose.prod.yml up -d --build
docker compose -f docker-compose.prod.yml exec app python manage.py dedup_council_memberships --dry-run    # preview
docker compose -f docker-compose.prod.yml exec app python manage.py dedup_council_memberships              # run
docker compose -f docker-compose.prod.yml exec app python manage.py shell -c "from django.core.cache import cache; cache.clear()"
\`\`\`

Then the rep pages should show "Serving since…" for the 5 dated reps. The 4 mid-term replacements (Lin, Juarez, Rinck, Foster) still need their admin entries.

## Test plan

- [ ] Dev: \`dedup_council_memberships --dry-run\` reports 0 (dev has no dupes — only prod's scrape created them)
- [ ] Prod: \`--dry-run\` reports the 5 expected duplicates, then real run deletes them
- [ ] Prod: \`/reps/dan-strauss/\` shows "Serving since January 2020" after deploy + dedup + cache flush
- [ ] Prod: tomorrow's 2 AM scrape doesn't recreate the duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)