### PR TITLE
parser: bump x_tolerance 2 → 3 (closes #150)

### DIFF
--- a/seattle_app/management/commands/parse_smc_pdf.py
+++ b/seattle_app/management/commands/parse_smc_pdf.py
@@ -1085,8 +1085,16 @@ class Command(BaseCommand):
             into a bag of bare codes (`X X X CCU CCU` / `P P P P P`) with
             no row labels attached.
         """
+        # x_tolerance bumped 2 → 3 to bridge the kerning gap on tight-
+        # set body pages (Title 21 utility rates, 22.805 stormwater,
+        # etc.) where neighboring words like
+        # "TherequirementsofthisSection" got merged into a single
+        # token. Section *titles* are emitted with looser kerning so
+        # 3 doesn't introduce title-side regressions; LLM summaries
+        # were already coping with the merged input but the on-page
+        # full_text rendering reads cleanly now. See #150.
         try:
-            words = page.extract_words(x_tolerance=2, y_tolerance=3)
+            words = page.extract_words(x_tolerance=3, y_tolerance=3)
         except Exception:
             return []
 


### PR DESCRIPTION
## Summary

One-line parser fix that resolves [#150](https://github.com/SeattleCouncilmatic/seattle-councilmatic/issues/150). \`pdfplumber.extract_words(x_tolerance=2)\` couldn't bridge the kerning gap on body-text-heavy pages, producing merged tokens like \`TherequirementsofthisSection\`. Bumping to 3 fixes them without affecting the looser-kerned section titles.

## Why no re-summarization

We spot-checked three of the worst sections (21.49.055 with 117 merge points, 6.420.100 with 73, 22.805.070 with 71). Sonnet's existing summaries are accurate and well-structured despite the merged input — modern tokenizers handle concatenated words via BPE without trouble. So we save the ~$15-25 re-summarization cost; only the on-page \`full_text\` rendering benefits from the parse fix.

## Deploy

After merge, on the Hetzner box:

\`\`\`
git pull
docker compose -f docker-compose.prod.yml up -d --build
docker compose -f docker-compose.prod.yml exec app python manage.py parse_smc_pdf
\`\`\`

The full re-parse takes a few minutes. After it finishes, hit any worst-case section in a browser to confirm — e.g. \`/municode/22/22.805/22.805.070/\` should now render the body text without merge artifacts.

## Test plan

- [ ] Section count stays at **7,435** (the post-fix re-parse 2026-04-26 count) — bumping x_tolerance shouldn't drop or add sections
- [ ] \`ParseValidationIssue\` row count stays at **28** or fewer
- [ ] Spot check 22.805.070 in the browser — \`TherequirementsofthisSection\` is now \`The requirements of this Section\`
- [ ] Spot check a non-affected section (any from 23.x or 25.x) — looks the same as before
- [ ] LLM \`plain_summary\` content unchanged on every section (confirms we didn't accidentally trigger a re-summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)