### PR TITLE
parser: skip search_vector in INSERTs (latent generated-column bug)

### DIFF
--- a/seattle_app/models.py
+++ b/seattle_app/models.py
@@ -10,6 +10,43 @@ import pytz
 app_timezone = pytz.timezone(settings.TIME_ZONE)
 
 
+class _GeneratedColumnAwareManager(models.Manager):
+    """Drops generated-column field names from the INSERT field list.
+
+    Migration 0014 made `MunicipalCodeSection.search_vector` a
+    `GENERATED ALWAYS AS ... STORED` tsvector at the DB level — its
+    value is computed from `section_number`, `title`, and `full_text`
+    by Postgres. Django's model state knows nothing about that
+    generation, so the default INSERT path includes a NULL value
+    for `search_vector` and Postgres rejects with:
+
+        cannot insert a non-DEFAULT value into column "search_vector"
+
+    This bites every code path that creates a row from scratch:
+    `Model.objects.create()`, `instance.save()` on a new object,
+    `bulk_create()`. Existing rows go through the UPDATE path which
+    happens to omit the field, which is why the bug was latent for
+    months — UPDATE-only re-parses didn't surface it; the first
+    INSERT in `parse_smc_pdf` did.
+
+    Fix: subclass the default manager and strip configured field
+    names from the INSERT field list before delegating. Affects
+    INSERTs only — UPDATEs are routed through `_update`, untouched.
+    Subclasses set `excluded_from_insert` to a tuple of field names.
+    """
+
+    excluded_from_insert: tuple[str, ...] = ()
+
+    def _insert(self, objs, fields, *args, **kwargs):
+        if self.excluded_from_insert:
+            fields = [f for f in fields if f.name not in self.excluded_from_insert]
+        return super()._insert(objs, fields, *args, **kwargs)
+
+
+class _MunicipalCodeSectionManager(_GeneratedColumnAwareManager):
+    excluded_from_insert = ("search_vector",)
+
+
 class MunicipalCodeSection(models.Model):
     """
     A section of the Seattle Municipal Code (SMC).
@@ -82,10 +119,23 @@ class MunicipalCodeSection(models.Model):
         auto_now_add=True
     )
     # PG-generated tsvector. Column is GENERATED ALWAYS AS ... STORED at the
-    # DB level (see migration 0014); Django never writes to it.
+    # DB level (see migration 0014); Django never writes to it. Custom
+    # manager below strips it from INSERT field lists so Django's
+    # default ORM path doesn't try to send NULL for it.
     search_vector = SearchVectorField(null=True, editable=False)
 
+    objects = _MunicipalCodeSectionManager()
+
     class Meta:
+        # `base_manager_name = "objects"` is the magic that makes
+        # Django route INSERTs through our custom manager. Without
+        # this, `Model._base_manager` falls back to a vanilla
+        # `Manager()` instance, the manager's `_insert` override is
+        # never called, and the search_vector exclusion silently
+        # does nothing. (Django 4.2 docs note this; the default-
+        # manager-as-base behavior some references describe is only
+        # for older versions.)
+        base_manager_name = "objects"
         ordering = ['title_number', 'chapter_number', 'section_number']
         unique_together = ['title_number', 'chapter_number', 'section_number']
         indexes = [


### PR DESCRIPTION
## Summary

Pre-existing bug, surfaced today by a re-parse on dev. \`Migration 0014\` made \`MunicipalCodeSection.search_vector\` a \`GENERATED ALWAYS AS ... STORED\` tsvector at the DB level — its value is computed by Postgres from \`section_number\`, \`title\`, and \`full_text\`. Django's model state knows nothing about that generation, so its default INSERT path sends \`search_vector=NULL\` and Postgres rejects:

\`\`\`
django.db.utils.ProgrammingError: cannot insert a non-DEFAULT value into column "search_vector"
DETAIL:  Column "search_vector" is a generated column.
\`\`\`

Latent because the parse_smc_pdf re-parse on 2026-04-26 (and presumably others) hit only the UPDATE path on already-existing rows. Today's re-parse on dev hit Title 10's first non-existing section → INSERT → bug.

## Fix

\`_GeneratedColumnAwareManager\` base class strips configured field names from the INSERT field list. \`MunicipalCodeSection.objects\` is now an instance whose \`excluded_from_insert\` includes \`search_vector\`.

Crucial detail discovered the hard way: \`Meta.base_manager_name = "objects"\` is required to make Django actually route INSERTs through this manager. Without it, \`Model._base_manager\` falls back to a vanilla \`Manager()\` and the override silently does nothing. (Django 4.2's default-manager-as-base behavior described in some older docs/blogs is misleading; check \`django/db/models/options.py:466-494\` for the actual lookup logic.)

## Test plan

- [x] Dev: \`MunicipalCodeSection.objects.create(...)\` succeeds in a transaction; \`search_vector\` populates after \`refresh_from_db\`
- [x] Dev: \`_base_manager\` reports as \`_MunicipalCodeSectionManager\`, not the default \`Manager\`
- [ ] Dev: full \`parse_smc_pdf\` run completes without the GeneratedAlways error (was blocking #162's verification)
- [ ] Prod: same — but prod parse runs are infrequent so urgency is moderate. Still ship since #162 will need it.

## Why this PR is separate from #162

#162 (x_tolerance bump) is correct on its own. This bug is unrelated — it would block ANY parse that needs to INSERT a new section, regardless of x_tolerance. Two PRs keeps the change scopes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)