### PR TITLE
frontend: render markdown tables in SectionText (#151)

### DIFF
--- a/frontend/src/components/SectionText.css
+++ b/frontend/src/components/SectionText.css
@@ -23,3 +23,45 @@
   color: #374151;
   margin-right: 0.25rem;
 }
+
+.smc-text-table-wrap {
+  margin: 1em 0;
+  overflow-x: auto;
+}
+
+.smc-text-table-wrap:focus-visible {
+  outline: 2px solid #2E3D5B;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.smc-text-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.95rem;
+}
+
+.smc-text-table th,
+.smc-text-table td {
+  border: 1px solid #d1d5db;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.smc-text-table th {
+  background-color: #f3f4f6;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.smc-text-table tbody tr:nth-child(even) td {
+  background-color: #fafafa;
+}
+
+.smc-text-footnote {
+  font-size: 0.9rem;
+  color: #4b5563;
+  font-style: italic;
+  margin: 0.25em 0;
+}

--- a/frontend/src/components/SectionText.jsx
+++ b/frontend/src/components/SectionText.jsx
@@ -9,6 +9,17 @@ import './SectionText.css'
 // line, and indent by marker level.
 const ENUM_RE = /^([A-Z]\.|[a-z]\.|\d+\.)\s+/
 
+// Markdown table row: starts and ends with `|`. The parser/extractor
+// emits these for the SMC's rate, dimensional, license, and use-permission
+// tables (~125 sections after extract_smc_tables runs). Without dedicated
+// rendering they leak through as literal pipe characters.
+const TABLE_ROW_RE = /^\s*\|.*\|\s*$/
+// Separator row: every cell is `---` or `:---:` etc. Splits header from body.
+const TABLE_SEP_CELL_RE = /^:?-+:?$/
+// Italics for table footnotes (extract_smc_tables emits these as
+// `_text_` lines just below the table). Render as <em> paragraphs.
+const FOOTNOTE_RE = /^_(.+)_\s*$/
+
 function markerLevel(marker) {
   if (!marker) return 0
   if (/^[A-Z]\./.test(marker)) return 1
@@ -16,52 +27,154 @@ function markerLevel(marker) {
   return 3 // lowercase
 }
 
-function reflow(text) {
-  if (!text) return []
-  const lines = text.split('\n')
-  const paragraphs = []
-  let buf = []
-  for (const raw of lines) {
-    const line = raw.trim()
-    if (!line) {
-      if (buf.length) {
-        paragraphs.push(buf.join(' '))
-        buf = []
-      }
-      continue
-    }
-    if (ENUM_RE.test(line) && buf.length > 0) {
-      paragraphs.push(buf.join(' '))
-      buf = [line]
-    } else {
-      buf.push(line)
+function parseTableRow(line) {
+  // Strip optional leading/trailing pipes, split on `|`, trim each cell.
+  const trimmed = line.trim().replace(/^\|/, '').replace(/\|$/, '')
+  return trimmed.split('|').map((c) => c.trim())
+}
+
+function isSeparatorRow(cells) {
+  return cells.length > 0 && cells.every((c) => TABLE_SEP_CELL_RE.test(c))
+}
+
+function finalizeTable(rows) {
+  // Locate separator row to split header/body. Rows before it are header
+  // (extract_smc_tables emits caption row + column-header row); rows after
+  // are body. With no separator, render everything as body.
+  const sepIdx = rows.findIndex(isSeparatorRow)
+  if (sepIdx < 0) {
+    return { type: 'table', header: [], body: rows }
+  }
+  return {
+    type: 'table',
+    header: rows.slice(0, sepIdx),
+    body: rows.slice(sepIdx + 1),
+  }
+}
+
+function finalizeParagraph(buf) {
+  const text = buf.join(' ')
+  const m = text.match(ENUM_RE)
+  if (m) {
+    return {
+      type: 'p',
+      marker: m[1],
+      rest: text.slice(m[0].length),
+      level: markerLevel(m[1]),
     }
   }
-  if (buf.length) paragraphs.push(buf.join(' '))
+  return { type: 'p', marker: null, rest: text, level: 0 }
+}
 
-  return paragraphs.map((p) => {
-    const m = p.match(ENUM_RE)
-    if (m) {
-      return { marker: m[1], rest: p.slice(m[0].length), level: markerLevel(m[1]) }
+function blockify(text) {
+  if (!text) return []
+  const lines = text.split('\n')
+  const blocks = []
+  let paraBuf = []
+  let tableBuf = []
+
+  const flushPara = () => {
+    if (paraBuf.length) {
+      blocks.push(finalizeParagraph(paraBuf))
+      paraBuf = []
     }
-    return { marker: null, rest: p, level: 0 }
-  })
+  }
+  const flushTable = () => {
+    if (tableBuf.length) {
+      blocks.push(finalizeTable(tableBuf))
+      tableBuf = []
+    }
+  }
+
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (TABLE_ROW_RE.test(line)) {
+      flushPara()
+      tableBuf.push(parseTableRow(line))
+      continue
+    }
+    flushTable()
+    if (!line) {
+      flushPara()
+      continue
+    }
+    const fnMatch = line.match(FOOTNOTE_RE)
+    if (fnMatch) {
+      flushPara()
+      blocks.push({ type: 'footnote', text: fnMatch[1] })
+      continue
+    }
+    if (ENUM_RE.test(line) && paraBuf.length > 0) {
+      flushPara()
+      paraBuf.push(line)
+    } else {
+      paraBuf.push(line)
+    }
+  }
+  flushTable()
+  flushPara()
+  return blocks
+}
+
+function Table({ header, body, billRefs }) {
+  return (
+    <div className="smc-text-table-wrap" tabIndex={0} role="region" aria-label="Data table">
+      <table className="smc-text-table">
+        {header.length > 0 && (
+          <thead>
+            {header.map((row, i) => (
+              <tr key={i}>
+                {row.map((cell, j) => (
+                  <th key={j}>
+                    <BillLinkify text={cell} refs={billRefs} />
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+        )}
+        <tbody>
+          {body.map((row, i) => (
+            <tr key={i}>
+              {row.map((cell, j) => (
+                <td key={j}>
+                  <BillLinkify text={cell} refs={billRefs} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
 }
 
 export default function SectionText({ text, billRefs }) {
-  const paragraphs = reflow(text)
-  if (paragraphs.length === 0) {
+  const blocks = blockify(text)
+  if (blocks.length === 0) {
     return <p className="smc-text-empty">No body text available for this section.</p>
   }
   return (
     <div className="smc-text">
-      {paragraphs.map((p, i) => (
-        <p key={i} className={`smc-text-p smc-text-l${p.level}`}>
-          {p.marker && <span className="smc-text-marker">{p.marker}</span>}
-          {p.marker ? ' ' : null}
-          <BillLinkify text={p.rest} refs={billRefs} />
-        </p>
-      ))}
+      {blocks.map((b, i) => {
+        if (b.type === 'table') {
+          return <Table key={i} header={b.header} body={b.body} billRefs={billRefs} />
+        }
+        if (b.type === 'footnote') {
+          return (
+            <p key={i} className="smc-text-footnote">
+              <BillLinkify text={b.text} refs={billRefs} />
+            </p>
+          )
+        }
+        return (
+          <p key={i} className={`smc-text-p smc-text-l${b.level}`}>
+            {b.marker && <span className="smc-text-marker">{b.marker}</span>}
+            {b.marker ? ' ' : null}
+            <BillLinkify text={b.rest} refs={billRefs} />
+          </p>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
Renders the markdown tables that PR #167's `extract_smc_tables` populates into `MunicipalCodeSection.full_text` as actual `<table>` elements, instead of leaking pipe characters as text.

## Why now

PR #167 just deployed to prod and is producing real markdown tables for ~125 SMC sections (master use-permissions matrices, fee schedules, boiler license tiers, stormwater BMP lists, etc.). Without this PR, all that data renders as raw `| --- |` text on the SPA. Shipping the renderer is the user-visible payoff for the entire Vision-extraction effort.

## Approach

Replaces the linear `reflow()` with `blockify()`, which pre-passes input lines into typed blocks:

- **`{type: 'p', marker, rest, level}`** — paragraphs, existing behavior preserved
- **`{type: 'table', header, body}`** — table rows split on the `| --- |` separator
- **`{type: 'footnote', text}`** — `_text_` italics lines emitted by the extractor below tables

Cells run through `BillLinkify` so CB/Res/Ord/RCW citations inside table cells continue to link correctly.

## Accessibility

Per the conventions in `AUDIT_FINDINGS.md`:

- Table wrapper has `tabIndex={0}` + `role="region"` + `aria-label="Data table"` so keyboard users can focus and scroll wide tables (23.47A.004's 99-row × 6-column zone matrix needs this)
- `:focus-visible` ring on the wrapper matches the navy brand outline used elsewhere
- Even-row striping uses `tbody tr:nth-child(even)` so header rows are not affected

## Visual

- `border-collapse: collapse` with 1px `#d1d5db` cell borders
- Header background `#f3f4f6` (gray-100)
- Even-row striping `#fafafa` for long-table legibility
- `overflow-x: auto` on the wrapper for tables wider than the available column

## Test plan

After merge + prod rebuild, spot-check on the live site:

- [ ] [/municode/2/04/634](https://www.seattlecouncilmatic.org/municode/2/04/634) — Campaign Valuations: 4 rows render as `<table>` instead of pipe text
- [ ] [/municode/22/805/070](https://www.seattlecouncilmatic.org/municode/22/805/070) — 4 stormwater BMP tables (A through D)
- [ ] [/municode/6/420/100](https://www.seattlecouncilmatic.org/municode/6/420/100) — 27-row Power Boilers + 20-row Low Pressure Boilers tables, with section dividers (`A. All Boilers`, etc.) preserved as wide cells
- [ ] [/municode/23/47A/004](https://www.seattlecouncilmatic.org/municode/23/47A/004) — 99-row × 6-column commercial-zone use-permission matrix; horizontal scroll on narrow viewports
- [ ] [/municode/22/900B/020](https://www.seattlecouncilmatic.org/municode/22/900B/020) — Tables B-1 and B-2 render as separate tables (split by extract_smc_tables's merge fix)
- [ ] Sections without tables render identically to before (no regressions on prose-only pages)
- [ ] Citations inside cells still link (any cell containing `RCW XX.XX.XXX` or `CB 12345`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)