### PR TITLE
reps: scrape councilmember bios from seattle.gov About pages (#147 phase 1a)

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -41,6 +41,18 @@ Parser corpus state (post-fix re-parse 2026-04-26 after `93cb885`): 7,435 sectio
 
 ## Done
 
+### Reps — scrape councilmember bios from seattle.gov About pages — committed 2026-05-10
+
+Phase 1a of #147 (LLM rep summary card). New `RepBio` model (`reps/models.py`) — one row per `core.Person`, raw prose only. Resisted splitting the prose into `education` / `professional_background` columns because bio shape varies wildly across reps (Eddie Lin and Dionne Foster come back as a single `<p>`; Juarez/Rinck/Hollingsworth span 4-5); the LLM synthesis pass extracts structured pieces at prompt time, so re-scrapes stay cheap (whole-prose UPSERT) and the prompt can evolve without schema churn.
+
+**URL pattern is a subpath, not a sibling.** First dry-run revealed 100% 404s — `scrape_rep_bios` was building `/council/<about-slug>` (e.g. `/council/about-rob`) when the real layout is `/council/members/<profile-slug>/<about-slug>` (e.g. `/council/members/rob-saka/about-rob`). The `ABOUT_PAGE_SLUGS` dict in `seattle/people.py` had been authored as a *subpath under each member's profile* (its docstring at line 19 says so), but the new scrape command read the slug as a top-level path. Fixed to compose `_HOST + /council/members/ + profile_slug(name) + / + about_slug`. Lesson: dry-run before opening the PR, even when the URL building looks "obvious" — the constants here are subpaths whose context lives in another module's docstring.
+
+**Tenure-block skip via `<strong>` label sniff.** `extract_bio` walks `<p>` elements in the page's `<main>`, keeping paragraphs ≥50 chars. The first paragraph on most About pages is the structured tenure block (`<strong>In office since:</strong> …` / `<strong>Council district:</strong> …`), which is owned by `extract_tenure` and shouldn't double-render in the bio. Skip is by `<strong>` text matching one of `("in office since", "council district", "current term")` — purely a content sniff, not a CSS class, because seattle.gov templates vary in markup but the strong-labeled tenure fields are uniform.
+
+**9 of 11 reps populated**; Mark Solomon and Sara Nelson have no published About page and stay out of `ABOUT_PAGE_SLUGS`. Same posture as the existing tenure scrape — explicit dict membership rather than guessing.
+
+**Scheduling.** Idempotent UPSERT by `person_id`, 2 s polite delay between requests. Safe to wire to a monthly cron once #147 phase 2 (LLM synthesis) lands and we know the cadence the summary pipeline wants.
+
 ### Parser — recover section titles truncated by line wrap — committed 2026-05-08
 
 Spot-fix from prod: `23.47A.009` rendered with title `"Standardsapplicabletospecific"` and the missing word `"areas"` as a stray first body line. Scan found 978 sections in the same shape — the parser's `SECTION_RE` (`parse_smc_pdf.py:20`) captures one line of `<num> <title>`, and the existing soft-hyphen fold (`parse_smc_pdf.py:973`) only fires when the title ends with `-`. Non-hyphenated wraps (most of them) slipped through, with the wrap-leftover word becoming body line 0.

--- a/reps/admin.py
+++ b/reps/admin.py
@@ -1,5 +1,18 @@
 from django.contrib.gis import admin
-from .models import District
+from .models import District, RepBio
+
+
+@admin.register(RepBio)
+class RepBioAdmin(admin.ModelAdmin):
+    """Read-mostly admin for scraped rep bios. Edits are allowed so
+    curators can fix extraction artifacts, but the next
+    ``scrape_rep_bios`` run will overwrite them — `scraped_at` shows
+    when that's likely to happen next."""
+
+    list_display = ("person", "source_url", "scraped_at")
+    search_fields = ("person__name",)
+    readonly_fields = ("scraped_at", "created_at")
+    fields = ("person", "bio", "source_url", "scraped_at", "created_at")
 
 
 @admin.register(District)

--- a/reps/migrations/0003_repbio.py
+++ b/reps/migrations/0003_repbio.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0009_auto_20241111_1450'),
+        ('reps', '0002_district_description'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RepBio',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('bio', models.TextField(help_text="Biographical prose, paragraphs joined with '\\n\\n'.")),
+                ('source_url', models.URLField(help_text='seattle.gov URL the bio was scraped from.', max_length=500)),
+                ('scraped_at', models.DateTimeField(auto_now=True, help_text='Last time the bio was (re-)scraped.')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('person', models.OneToOneField(help_text='OCD Person this bio belongs to.', on_delete=django.db.models.deletion.CASCADE, related_name='rep_bio', to='core.person')),
+            ],
+            options={
+                'verbose_name': 'Rep biographical text',
+                'verbose_name_plural': 'Rep biographical texts',
+            },
+        ),
+    ]

--- a/reps/models.py
+++ b/reps/models.py
@@ -1,6 +1,47 @@
 from django.contrib.gis.db import models
 
 
+class RepBio(models.Model):
+    """Biographical prose scraped from a council member's seattle.gov
+    ``/about-<firstname>`` page. One row per person.
+
+    Kept as raw text rather than split into ``education`` /
+    ``professional_background`` columns — bio shape varies across
+    reps, and the LLM summary pipeline (issue #147 / Phase 2) extracts
+    structured pieces at synthesis time. That keeps re-scrapes cheap
+    (whole-prose UPSERT) and lets the prompt evolve without schema
+    churn.
+
+    Re-scraping is idempotent — ``scrape_rep_bios`` re-runs UPSERT
+    by ``person_id``."""
+
+    person = models.OneToOneField(
+        "core.Person",
+        on_delete=models.CASCADE,
+        related_name="rep_bio",
+        help_text="OCD Person this bio belongs to.",
+    )
+    bio = models.TextField(
+        help_text="Biographical prose, paragraphs joined with '\\n\\n'.",
+    )
+    source_url = models.URLField(
+        max_length=500,
+        help_text="seattle.gov URL the bio was scraped from.",
+    )
+    scraped_at = models.DateTimeField(
+        auto_now=True,
+        help_text="Last time the bio was (re-)scraped.",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        verbose_name = "Rep biographical text"
+        verbose_name_plural = "Rep biographical texts"
+
+    def __str__(self):
+        return f"Bio for {self.person.name}"
+
+
 class District(models.Model):
     """
     Represents a Seattle City Council district with its geographic boundary.

--- a/seattle/people.py
+++ b/seattle/people.py
@@ -251,6 +251,53 @@ def extract_tenure(html_str: str) -> dict:
     return out
 
 
+def extract_bio(html_str: str) -> str | None:
+    """Pull the biographical prose from a councilmember's About page.
+
+    Strategy: walk all ``<p>`` elements inside the main content area,
+    keep paragraphs longer than 50 chars that aren't part of the
+    structured tenure block (those carry ``<strong>`` labels like
+    ``In office since:`` / ``Council district:`` and are owned by
+    ``extract_tenure``). Joins the remaining paragraphs with a blank
+    line so downstream renderers / the rep-summary LLM see distinct
+    paragraphs.
+
+    Returns ``None`` if no qualifying prose is found (page structure
+    changed, page is purely structured info, etc.). Callers decide
+    whether that's a hard error or just "bio pending."
+    """
+    h = lxml_html.fromstring(html_str)
+    main = (
+        h.xpath('//main')
+        or h.xpath('//div[contains(@class, "ContentComponent")]')
+        or [h]
+    )
+    paras = main[0].xpath('.//p')
+
+    bio_paras: list[str] = []
+    for p in paras:
+        text = " ".join(p.text_content().split())  # collapse whitespace
+        if len(text) < 50:
+            continue
+        # Skip the tenure block — its <strong> labels are owned by
+        # extract_tenure. Some templates render the tenure block in the
+        # same <p> as the bio's first paragraph; in that case the
+        # paragraph still surfaces, just shortened by 50-char filter
+        # rarely (depends on bio length). Tradeoff: cleaner skip beats
+        # capturing tenure-as-bio.
+        strong_text = " ".join(p.xpath(".//strong/text()")).lower()
+        if any(
+            label in strong_text
+            for label in ("in office since", "council district", "current term")
+        ):
+            continue
+        bio_paras.append(text)
+
+    if not bio_paras:
+        return None
+    return "\n\n".join(bio_paras)
+
+
 def extract_contact_details(html_str: str) -> dict:
     """Parse the Contact Us tile on a per-member seattle.gov profile
     page. Returns a dict with any of `phone`, `fax`, `email`,

--- a/seattle_app/management/commands/scrape_rep_bios.py
+++ b/seattle_app/management/commands/scrape_rep_bios.py
@@ -1,0 +1,152 @@
+"""Scrape biographical prose from seattle.gov About pages and upsert
+``RepBio`` rows for current council members.
+
+Background — issue #147 phase 1a
+================================
+
+The rep-summary LLM pipeline needs bio prose (education, professional
+background, prior public service) for each councilmember. seattle.gov
+already publishes these on per-member About pages
+(``/about-<firstname>``). We persist the raw prose so the summary
+pipeline can be re-run cheaply against the same source text without
+re-scraping each time.
+
+Bio shape varies across reps — some bios are a single paragraph,
+others span 4–5 — so we keep the prose as one ``RepBio.bio`` text
+field and let the LLM extract structured pieces (education, prior
+roles, etc.) at synthesis time.
+
+Idempotent — re-running upserts by ``person_id``. Safe to schedule at
+monthly cadence.
+
+Usage
+=====
+
+::
+
+    python manage.py scrape_rep_bios            # all current members
+    python manage.py scrape_rep_bios --dry-run  # report, no DB writes
+    python manage.py scrape_rep_bios --person "Joy Hollingsworth"
+
+Pages that don't yield a bio (404, no qualifying paragraphs, etc.)
+log a warning and continue — the summary pipeline downstream marks
+those reps as "bio pending" rather than blocking.
+"""
+
+from __future__ import annotations
+
+import time
+
+import requests
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from opencivicdata.core.models import Person
+
+from reps.models import RepBio
+from seattle.people import ABOUT_PAGE_SLUGS, extract_bio, profile_slug
+
+
+_HOST = "https://www.seattle.gov"
+# About pages are a subpath under each member's profile, e.g.
+# /council/members/rob-saka/about-rob — see seattle/people.py.
+_MEMBERS_PATH_PREFIX = "/council/members"
+_REQUEST_DELAY_SECONDS = 2
+
+
+def _about_page_url(person_name: str) -> str | None:
+    """seattle.gov About-page URL for a councilmember, or None if
+    we don't have an About-page slug mapping for them."""
+    about_slug = ABOUT_PAGE_SLUGS.get(person_name)
+    if not about_slug:
+        return None
+    return f"{_HOST}{_MEMBERS_PATH_PREFIX}/{profile_slug(person_name)}/{about_slug}"
+
+
+class Command(BaseCommand):
+    help = "Scrape councilmember bios from seattle.gov About pages into RepBio."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print what would change; don't write to the DB.",
+        )
+        parser.add_argument(
+            "--person",
+            help="Limit to a single Person by exact name match.",
+        )
+
+    def handle(self, *args, **options):
+        dry = options["dry_run"]
+        only = options.get("person")
+
+        # Current council members are Persons with a `City Council
+        # profile` link AND an About-page slug we know about. The
+        # latter filter excludes former members whose About page URL
+        # may redirect to a successor.
+        qs = Person.objects.filter(links__note="City Council profile").distinct()
+        if only:
+            qs = qs.filter(name=only)
+
+        total = qs.count()
+        self.stdout.write(f"Scraping bios for up to {total} councilmember(s) (dry-run={dry}).")
+
+        n_updated = 0
+        n_skipped = 0
+        n_errors = 0
+
+        for person in qs:
+            url = _about_page_url(person.name)
+            if not url:
+                self.stdout.write(self.style.NOTICE(
+                    f"  {person.name}: no About-page slug; skipping"
+                ))
+                n_skipped += 1
+                continue
+
+            try:
+                # allow_redirects=False so a former member whose About
+                # page redirects to their successor doesn't silently
+                # overwrite with the wrong bio.
+                resp = requests.get(url, timeout=10, allow_redirects=False)
+            except requests.RequestException as e:
+                self.stderr.write(self.style.WARNING(
+                    f"  {person.name}: fetch failed ({type(e).__name__}: {e})"
+                ))
+                n_errors += 1
+                continue
+
+            if resp.status_code != 200:
+                self.stdout.write(self.style.NOTICE(
+                    f"  {person.name}: HTTP {resp.status_code} at {url}; skipping"
+                ))
+                n_skipped += 1
+                time.sleep(_REQUEST_DELAY_SECONDS)
+                continue
+
+            bio = extract_bio(resp.text)
+            if not bio:
+                self.stderr.write(self.style.WARNING(
+                    f"  {person.name}: no bio prose found at {url}"
+                ))
+                n_skipped += 1
+                time.sleep(_REQUEST_DELAY_SECONDS)
+                continue
+
+            self.stdout.write(
+                f"  {person.name}: {len(bio):,} chars from {url}"
+            )
+
+            if not dry:
+                with transaction.atomic():
+                    RepBio.objects.update_or_create(
+                        person=person,
+                        defaults={"bio": bio, "source_url": url},
+                    )
+                n_updated += 1
+
+            time.sleep(_REQUEST_DELAY_SECONDS)
+
+        self.stdout.write(self.style.SUCCESS(
+            f"\nDone. Updated: {n_updated}. Skipped: {n_skipped}. Errors: {n_errors}."
+        ))


### PR DESCRIPTION
## Summary

- New `RepBio` model — one row per `core.Person`, raw prose only. Migration `reps/0003_repbio` (verified against `makemigrations --dry-run --check`).
- New `scrape_rep_bios` management command. Idempotent UPSERT by `person_id`, 2 s polite delay, `--dry-run` and `--person <name>` flags.
- New `extract_bio` helper in `seattle/people.py` — walks `<p>` in `<main>`, keeps paragraphs ≥50 chars, skips the structured tenure block (`<strong>` text matching `in office since` / `council district` / `current term`).
- Wagtail-style `RepBioAdmin` registration so curators can spot-fix extraction artifacts (with a docstring warning that the next scrape will overwrite manual edits).

Phase 1a of #147. Phase 2 (LLM summary card) consumes `RepBio.bio` plus stat counts; this PR only persists the raw prose.

## Notable design calls

- **URL pattern is a subpath, not a sibling.** First dry-run revealed 100% 404s — the command was building `/council/<about-slug>` (e.g. `/council/about-rob`) when the real layout is `/council/members/<profile-slug>/<about-slug>` (e.g. `/council/members/rob-saka/about-rob`). The `ABOUT_PAGE_SLUGS` dict had been authored as a *subpath under each member's profile* per its docstring at [seattle/people.py:19](seattle/people.py#L19), but the new command read the slug as a top-level path. Fixed by composing through `profile_slug(name)`.
- **Raw prose, not structured columns.** Bio shape varies wildly (Eddie Lin / Dionne Foster come back as a single `<p>`; Juarez / Rinck / Hollingsworth span 4-5). The LLM synthesis pass extracts structured pieces at prompt time, so re-scrapes stay cheap (whole-prose UPSERT) and the prompt can evolve without schema churn.
- **9 of 11 reps populated**; Mark Solomon and Sara Nelson have no published About page, stay out of `ABOUT_PAGE_SLUGS`. Same posture as the existing tenure scrape — explicit dict membership rather than guessing slugs.

## Test plan

- [x] `makemigrations reps --dry-run --check` — "No changes detected" (hand-written migration matches generator output)
- [x] `migrate reps` — applied via container entrypoint
- [x] `scrape_rep_bios --dry-run` — 9 hits, 2 expected "no slug" skips, 0 errors
- [x] `scrape_rep_bios` (real run) — 9 `RepBio` rows persisted, OneToOne integrity OK
- [x] Spot-check encoding (curly quotes, em-dashes survive the round-trip)
- [ ] After merge: review at localhost:8000 admin → Reps → Rep biographical texts

🤖 Generated with [Claude Code](https://claude.com/claude-code)