### PR TITLE
events: link matter_file label to bill detail page (#181)

### DIFF
--- a/frontend/src/components/EventDetail.css
+++ b/frontend/src/components/EventDetail.css
@@ -326,6 +326,17 @@
   font-family: monospace;
 }
 
+a.evt-agenda-file--link {
+  color: #2E3D5B;
+  text-decoration: underline;
+}
+
+a.evt-agenda-file--link:hover,
+a.evt-agenda-file--link:focus-visible {
+  color: #1f2a40;
+  text-decoration-thickness: 2px;
+}
+
 .evt-agenda-status {
   font-size: 0.75rem;
   color: #6b7280;

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -93,7 +93,15 @@ function AgendaItemRow({ item, index }) {
             <span className="evt-agenda-title">{titleNode}</span>
           </div>
           <div className="evt-agenda-meta">
-            {matter_file && <span className="evt-agenda-file">{matter_file}</span>}
+            {matter_file && (
+              bill_slug ? (
+                <Link to={`/legislation/${bill_slug}`} className="evt-agenda-file evt-agenda-file--link">
+                  {matter_file}
+                </Link>
+              ) : (
+                <span className="evt-agenda-file">{matter_file}</span>
+              )
+            )}
             {matter_status && <span className="evt-agenda-status">{matter_status}</span>}
             {action_text && <span className="evt-agenda-action">{action_text}</span>}
           </div>


### PR DESCRIPTION
## Summary

- The matter_file identifier shown under each agenda item (e.g. **Res 32203**) was a plain `<span>`. The long bill description above it was already a `<Link>` to `/legislation/<bill_slug>`, but the short, scannable identifier is the obvious thing to click — users saw the reference but had no affordance to jump to the legislation.
- Now wraps `matter_file` in a `<Link>` when `bill_slug` is present; falls back to the plain span when it isn't (procedural notes, unmatched matters).
- CSS adds a link variant on `.evt-agenda-file` that keeps the monospace identifier styling and adds the standard underline + focus affordance.

Closes #181.

## Test plan

- [ ] On a bill-bearing event (e.g. the Select Committee on the Comprehensive Plan, 2026-05-14), confirm the "Res 32203" label under the agenda item is underlined and navigates to `/legislation/res-32203`.
- [ ] On a procedural agenda item (no `matter_file`, no `bill_slug`), nothing renders for that slot — no broken empty link.
- [ ] On an item with `matter_file` but no `bill_slug` (unmatched), the label still appears as plain monospace text, not a link.
- [ ] Keyboard focus reaches the new link with a visible focus ring (a11y conventions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)