### PR TITLE
reps: post-launch followups (#178, #179, #180)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -182,6 +182,31 @@ changed.
 Zero-downtime is NOT a goal of this setup — gunicorn restarts mean
 ~2-5s of 502s during deploys. Acceptable for this site's traffic.
 
+### Post-deploy data population
+
+Some PRs ship management commands that populate LLM-derived data
+(rep bios, bill issue-area tags, rep summaries). The container
+restart applies migrations automatically but does NOT run these
+populations — they're one-off, sometimes API-paying, and gated by
+deploy-time judgment.
+
+Check the PR description for any "after merge:" steps. Currently:
+
+| Command | When to run | Idempotent? |
+| --- | --- | --- |
+| `python manage.py scrape_rep_bios` | After membership changes; bios on seattle.gov change rarely | Yes — UPSERTs by `person_id` |
+| `python manage.py backfill_council_terms` | When a member is sworn in, resigns, or is replaced | Yes — only writes when existing field is empty unless `--force` |
+| `python manage.py tag_bill_issue_areas` | New bills tag automatically when this command runs without `--force`; re-run with `--force` only when the prompt or vocabulary changes | Yes — UPSERTs by `bill_id`. Two-phase: submit, wait ~10-30 min, re-run to poll + persist |
+| `python manage.py summarize_reps` | After any of `scrape_rep_bios`, `backfill_council_terms`, or `tag_bill_issue_areas` runs against changed data; or when membership changes | Yes — UPSERTs by `person_id`. Two-phase: submit, wait ~5-10 min, re-run to poll + persist. Pass `--force` to regenerate existing rows |
+
+Forgetting these steps is the most common reason prod data quality
+diverges from dev — see WORK_LOG entry on the rep-summary launch
+postmortem (2026-05-11).
+
+**For new LLM-data PRs:** add a one-line entry to this table in the
+same PR. Don't ship a populator command without documenting when to
+run it on prod.
+
 ### View logs
 
 ```

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -37,6 +37,8 @@ Parser corpus state (post-fix re-parse 2026-04-26 after `93cb885`): 7,435 sectio
 
 **Pre-flight at session start:** `git fetch && git log main..origin/main` to catch divergence between local and remote `main` before doing anything else. We lost time to a 16-commit divergence in 2026-04 that this would have caught in one command.
 
+**LLM-data PRs document their post-deploy populator commands in DEPLOY.md.** Any PR that introduces a management command which populates LLM-derived data (bios, tags, summaries, transcripts) must add a one-line entry to the "Post-deploy data population" table in `DEPLOY.md` in the same PR. We hit prod-vs-dev data divergence on the rep-summary launch (2026-05-11) because three sequential PRs each shipped a populator without telling deploy when to run it.
+
 ---
 
 ## Done

--- a/seattle/people.py
+++ b/seattle/people.py
@@ -37,6 +37,21 @@ ABOUT_PAGE_SLUGS = {
 }
 
 
+# Canonical committee names by URL slug. The scraper picks "first-seen
+# display name" per slug across all reps' /committees-and-calendar
+# pages, so when one rep's page renders a stale or wrong committee
+# name, that name becomes canonical for the org. The Parks & City
+# Light committee (slug `parks-and-city-light`) was getting picked
+# up as "Parks & City Light, Arts & Culture" because at least one
+# rep's page surfaces that erroneous suffix; seattle.gov's actual
+# committee name on the canonical page is "Parks & City Light".
+# Add entries here when a slug's canonical display name needs to be
+# pinned regardless of what individual rep pages render.
+COMMITTEE_NAME_OVERRIDES = {
+    "parks-and-city-light": "Parks & City Light",
+}
+
+
 def profile_slug(name: str) -> str:
     """Slug for the per-member seattle.gov profile page."""
     if name in PROFILE_SLUG_OVERRIDES:
@@ -439,13 +454,17 @@ class SeattlePersonScraper(Scraper):
         # vary in punctuation across reps' pages, and at least one page
         # has a copy-paste href/text mismatch — the URL slug is the
         # stable identifier. Pick the first-seen display name as
-        # canonical (consistent across the scrape and reasonable for UI).
+        # canonical (consistent across the scrape and reasonable for
+        # UI), overridden by `COMMITTEE_NAME_OVERRIDES` for slugs
+        # whose canonical seattle.gov name needs to be pinned (e.g.
+        # `parks-and-city-light` — see the override comment).
         canonical_committees: dict[str, dict] = {}
         for m in members_data:
             for c in m["committees_raw"]:
                 slug = c["slug"]
                 if slug not in canonical_committees:
-                    canonical_committees[slug] = {"name": c["name"], "url": c["url"]}
+                    name = COMMITTEE_NAME_OVERRIDES.get(slug, c["name"])
+                    canonical_committees[slug] = {"name": name, "url": c["url"]}
 
         # Yield each committee Organization once.
         for slug, data in canonical_committees.items():

--- a/seattle_app/services/claude_service.py
+++ b/seattle_app/services/claude_service.py
@@ -229,7 +229,14 @@ REP_SUMMARY_SYSTEM_PROMPT = (
     "popular, controversial, or aligned with any other body. Stick to "
     "what they do.\n"
     "  - If the bio is empty (no seattle.gov About page exists), skip "
-    "the background paragraph rather than padding the summary."
+    "the background paragraph rather than padding the summary.\n"
+    "  - Do not mention metadata about input availability in the prose "
+    "(e.g. 'subject tags are unavailable', 'no biographical information "
+    "from seattle.gov is available', 'no notable dissents are on record "
+    "in the current dataset'). Degrade silently to whatever you can "
+    "synthesize from the data you do have. Empty issue-area breakdowns "
+    "should be handled by describing sponsorships from their titles "
+    "alone; empty bios by simply omitting the background paragraph."
 )
 
 


### PR DESCRIPTION
Closes #178, #179, #180.

Three small fixes from prod feedback after #147 shipped. Bundled because they're all consequences of the same launch.

## Summary

- **#179** — rep-summary system prompt now suppresses input-availability metadata leaking into the prose ("subject tags are unavailable", "no biographical information from seattle.gov is available", "no notable dissents are on record in the current dataset"). Surfaced from the prod launch when prereq populators hadn't run; the model padded summaries with implementation language instead of degrading silently.
- **#178** — `COMMITTEE_NAME_OVERRIDES` dict in [seattle/people.py](seattle/people.py) pins the canonical name for slug `parks-and-city-light` to "Parks & City Light". Prevents the OCD scrape from re-introducing the erroneous "Parks & City Light, Arts & Culture" suffix that one of the rep's `/committees-and-calendar` pages renders. The DB row was already patched on prod via a one-off shell command; this protects future scrapes.
- **#180** — New "Post-deploy data population" section in DEPLOY.md tabulating the four LLM-data populator commands (`scrape_rep_bios`, `backfill_council_terms`, `tag_bill_issue_areas`, `summarize_reps`), when to run each, and idempotency. Plus a WORK_LOG conventions one-liner requiring future LLM-data PRs to update that table in the same PR.

## Test plan

- [x] Local DB committee name patched ("Parks & City Light, Arts & Culture" → "Parks & City Light")
- [x] `summarize_reps --force --person "Dan Strauss"` smoke — new summary reads "Parks & City Light" without the bad suffix
- [x] DEPLOY.md table renders cleanly (table-style markdown lint passes)
- [ ] After merge: re-run `summarize_reps --force` on prod (DB rename was already applied; this regenerates the summary prose for the 7 reps that mention the committee). Two-phase as documented.

## Notes

- Ran `summarize_reps --force --person "Dan Strauss"` only — didn't burn tokens regenerating all 9 in dev since #178's only effect is the committee name string. Prod re-run will catch them all.
- Did NOT bundle a fix for the bio scrape filter (`links__note='City Council profile'` vs. `is_current=True`) — that's worth a separate PR with its own discussion since it touches prod data shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)