### PR TITLE
events: pin migration dep to councilmatic_core 0053 (hotfix for #184)

### DIFF
--- a/seattle_app/migrations/0023_eventtranscript.py
+++ b/seattle_app/migrations/0023_eventtranscript.py
@@ -7,7 +7,15 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('councilmatic_core', '0054_remove_person_councilmatic_biography_and_more'),
+        # Pinned to 0053 (the latest councilmatic_core migration that
+        # exists in both prod's and dev's installed package versions).
+        # makemigrations originally emitted a 0054 dep because the dev
+        # container had pulled a newer 5.x-branch zip than prod did at
+        # build time. requirements.txt pins django-councilmatic to the
+        # 5.x branch URL rather than a specific commit, so each `docker
+        # compose ... build` can pull a different snapshot. See the
+        # follow-up issue on pinning to a commit instead of a branch.
+        ('councilmatic_core', '0053_add_councilmatic_bio'),
         ('seattle_app', '0022_delete_stale_midnight_event_duplicates'),
     ]
 


### PR DESCRIPTION
**Hotfix for prod outage** — PR #184's migration 0023_eventtranscript depends on \`councilmatic_core/0054\`, which exists in dev's installed \`django-councilmatic\` package but not in prod's. Prod's app container is in a restart loop with:

\`\`\`
NodeNotFoundError: Migration seattle_app.0023_eventtranscript dependencies
reference nonexistent parent node ('councilmatic_core',
'0054_remove_person_councilmatic_biography_and_more')
\`\`\`

## Root cause

\`requirements.txt\` pins django-councilmatic to a **branch URL** (\`https://github.com/datamade/django-councilmatic/archive/refs/heads/5.x.zip\`) rather than a commit/tag. Each \`docker compose ... --build\` re-downloads the current state of the 5.x branch. Dev's image was built when the branch zip included migration 0054; prod's later build pulled an earlier snapshot whose latest migration is 0053.

## Fix

Switch the dep from \`0054\` to \`0053_add_councilmatic_bio\` (the latest councilmatic_core migration that exists in both environments' current installed packages). The migration's operations don't reference any of 0054's changes (which only drop two unused Person fields), so this is safe.

Verified locally: dev's already-applied 0023 stays consistent under the new dep (\`migrate --check\` clean, \`showmigrations\` unchanged).

## Test plan

- [x] \`migrate --check\` on dev passes
- [ ] After merge + prod \`docker compose up -d --build\`: app container starts; \`extract_event_transcripts\` runs as expected

## Follow-up

Pin django-councilmatic to a specific commit hash (or tag, if upstream cuts one) so dev and prod can't drift between builds. Filing as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)