### PR TITLE
frontend: consolidate EventDetail title-card layout (#190)

### DIFF
--- a/frontend/src/components/EventDetail.css
+++ b/frontend/src/components/EventDetail.css
@@ -44,6 +44,10 @@
 
 /* ── Header ───────────────────────────────────────────────────── */
 
+/* Consolidated header card carries title + status + date/location/
+   Legistar metadata + PDF doc buttons. Refactor in #190 dropped the
+   former sidebar Details card and the standalone docs-row between
+   header and body — everything now lives here as one block. */
 .evt-detail-header {
   background: #ffffff;
   border: 2px solid #e5e7eb;
@@ -52,19 +56,62 @@
   margin-bottom: 1.5rem;
 }
 
+/* Title + StatusBadge sit on one line; status is centered against
+   the title block. Wrap on narrow screens. */
+.evt-detail-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
 .evt-detail-title {
   font-size: 1.5rem;
   font-weight: 700;
   color: #111827;
   line-height: 1.35;
-  margin: 0 0 1rem;
+  margin: 0;
 }
 
-.evt-detail-meta-row {
+/* Metadata stack — date/time, location, Legistar link. Rendered as
+   a <dl> for semantics (date → "Tuesday, ..."; location → "Council
+   Chambers"; legistar → link), with the <dt>s visually hidden via
+   .evt-sr-only because each <dd> is self-describing in context. */
+.evt-detail-meta {
+  margin: 0 0 1.25rem;
+  padding: 0;
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 0.375rem;
+  font-size: 0.9375rem;
+  color: #374151;
+}
+
+.evt-detail-meta-item {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.evt-detail-meta-location {
+  /* OCD location strings can be multi-line ("Council Chambers,
+     2nd Floor\nCity Hall") — render the breaks. */
+  white-space: pre-line;
+}
+
+/* Visually hidden but available to screen readers — gives the
+   metadata <dt>s semantic meaning without cluttering the visual
+   layout. Standard "sr-only" recipe. */
+.evt-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* ── Status badge ─────────────────────────────────────────────── */
@@ -95,28 +142,14 @@
 
 /* ── Body layout ──────────────────────────────────────────────── */
 
+/* Single-column body since #190 — the former 280px sidebar carried
+   metadata that now lives in the header card. Keeping the wrapper
+   for layout hooks (max-width, spacing). */
 .evt-detail-body {
-  display: grid;
-  grid-template-columns: 280px 1fr;
-  gap: 1.5rem;
-  align-items: start;
+  display: block;
 }
 
-@media (max-width: 768px) {
-  .evt-detail-body {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* ── Shared section card ──────────────────────────────────────── */
-
-.evt-detail-section {
-  background: #ffffff;
-  border: 2px solid #e5e7eb;
-  border-radius: 0.75rem;
-  padding: 1.5rem;
-  margin-bottom: 1rem;
-}
+/* ── Shared section title ─────────────────────────────────────── */
 
 .evt-detail-section-title {
   font-size: 0.75rem;
@@ -125,32 +158,6 @@
   letter-spacing: 0.1em;
   color: #6b7280;
   margin: 0 0 1rem;
-}
-
-/* ── Details dl ───────────────────────────────────────────────── */
-
-.evt-detail-dl {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.5rem 1rem;
-  margin: 0;
-  font-size: 0.875rem;
-}
-
-.evt-detail-dl dt {
-  font-weight: 600;
-  color: #6b7280;
-  white-space: nowrap;
-}
-
-.evt-detail-dl dd {
-  color: #111827;
-  margin: 0;
-}
-
-.evt-detail-location {
-  white-space: pre-line;
-  line-height: 1.5;
 }
 
 .evt-detail-external-link {
@@ -200,11 +207,12 @@
 
 /* ── Agenda & Minutes document buttons ────────────────────────── */
 
+/* Now lives inside the header card (#190) — no bottom margin needed
+   since the header card supplies its own padding. */
 .evt-docs-row {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  margin-bottom: 1.5rem;
 }
 
 .evt-doc-btn {

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -19,6 +19,17 @@ function formatDateTime(isoString) {
   })
 }
 
+// Compact time-only formatter for the end-of-range suffix in the
+// header meta line (e.g. "Tuesday, April 14, 2026 · 9:00 PM – 11:30 PM").
+function formatTime(isoString) {
+  if (!isoString) return ''
+  const d = new Date(isoString)
+  return d.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
 function StatusBadge({ status }) {
   const MAP = {
     confirmed: { label: 'Confirmed', cls: 'evt-badge--confirmed' },
@@ -184,70 +195,65 @@ export default function EventDetail() {
           <span className="evt-detail-breadcrumb-current">{event.name}</span>
         </nav>
 
-        {/* Header */}
+        {/* Header — consolidates title, status, date/time, location,
+            Legistar link, and PDF doc buttons into one card so the
+            metadata reads as a single block (#190). */}
         <header className="evt-detail-header">
-          <h1 className="evt-detail-title">{event.name}</h1>
-          <div className="evt-detail-meta-row">
+          <div className="evt-detail-title-row">
+            <h1 className="evt-detail-title">{event.name}</h1>
             <StatusBadge status={event.status} />
           </div>
+
+          <dl className="evt-detail-meta">
+            <dt className="evt-sr-only">Date and time</dt>
+            <dd className="evt-detail-meta-item">
+              {formatDateTime(event.start_date)}
+              {event.end_date && <> – {formatTime(event.end_date)}</>}
+            </dd>
+
+            {event.location && (
+              <>
+                <dt className="evt-sr-only">Location</dt>
+                <dd className="evt-detail-meta-item evt-detail-meta-location">
+                  {event.location}
+                </dd>
+              </>
+            )}
+
+            {legistarUrl && (
+              <>
+                <dt className="evt-sr-only">Legistar</dt>
+                <dd className="evt-detail-meta-item">
+                  <a
+                    href={legistarUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="evt-detail-external-link"
+                  >
+                    View on Legistar ↗
+                  </a>
+                </dd>
+              </>
+            )}
+          </dl>
+
+          <AgendaDocButtons
+            agendaUrl={event.agenda_file_url}
+            agendaStatus={event.agenda_status}
+            packetUrl={event.packet_url}
+            minutesUrl={event.minutes_file_url}
+            minutesStatus={event.minutes_status}
+          />
         </header>
 
-        {/* Agenda & Minutes PDF buttons */}
-        <AgendaDocButtons
-          agendaUrl={event.agenda_file_url}
-          agendaStatus={event.agenda_status}
-          packetUrl={event.packet_url}
-          minutesUrl={event.minutes_file_url}
-          minutesStatus={event.minutes_status}
-        />
-
-        {/* Body */}
+        {/* Body — single column now that metadata moved into the
+            header card (#190). Summary card sits as a top-level
+            sibling of the agenda-items section (not nested inside it)
+            to match the visual pattern of other LLM summary cards
+            elsewhere in the app. */}
         <div className="evt-detail-body">
-
-          {/* Sidebar: key facts */}
-          <aside className="evt-detail-sidebar">
-            <section className="evt-detail-section">
-              <h2 className="evt-detail-section-title">Details</h2>
-              <dl className="evt-detail-dl">
-                <dt>Date &amp; Time</dt>
-                <dd>{formatDateTime(event.start_date)}</dd>
-
-                {event.end_date && (
-                  <>
-                    <dt>Ends</dt>
-                    <dd>{formatDateTime(event.end_date)}</dd>
-                  </>
-                )}
-
-                {event.location && (
-                  <>
-                    <dt>Location</dt>
-                    <dd className="evt-detail-location">{event.location}</dd>
-                  </>
-                )}
-
-                {legistarUrl && (
-                  <>
-                    <dt>Legistar</dt>
-                    <dd>
-                      <a
-                        href={legistarUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="evt-detail-external-link"
-                      >
-                        View on Legistar ↗
-                      </a>
-                    </dd>
-                  </>
-                )}
-              </dl>
-            </section>
-          </aside>
-
-          {/* Main: LLM summary card + agenda items */}
+          <EventSummaryCard summary={event.llm_summary} />
           <section className="evt-detail-main">
-            <EventSummaryCard summary={event.llm_summary} />
             <h2 className="evt-detail-section-title">Agenda Items</h2>
             {substantiveItems.length === 0 ? (
               <p className="evt-detail-empty">

--- a/frontend/src/components/EventSummaryCard.css
+++ b/frontend/src/components/EventSummaryCard.css
@@ -25,7 +25,6 @@
 
 .evt-summary-card-p {
   margin: 0 0 0.75rem;
-  max-width: 70ch;
 }
 
 .evt-summary-card-p:last-child {


### PR DESCRIPTION
Closes #190.

## Summary

The prior EventDetail layout had three competing visual blocks: a big title card holding just the meeting name, a standalone PDF docs row between header and body, and a small left-rail Details card carrying date/time/location/Legistar that didn't earn its card chrome.

Consolidate into one header card holding everything: title + status inline, then a metadata stack (date/time, location, Legistar link), then the agenda/minutes PDF buttons. Drop the sidebar entirely; the body becomes single-column.

## What's in it

- **`<header className="evt-detail-header">`** now contains:
  - Title row: `<h1>` + `StatusBadge` on one line (wraps on narrow widths)
  - Metadata `<dl>`: date/time (with optional end-time suffix), location, Legistar link — rendered as a clean stack; `<dt>`s visually hidden via `.evt-sr-only` for screen-reader semantics without visual clutter
  - `AgendaDocButtons` for the PDF action buttons
- **Body is single-column.** Dropped `.evt-detail-body { display: grid; grid-template-columns: 280px 1fr }` plus the entire `<aside className="evt-detail-sidebar">` block + the unused `.evt-detail-section` / `.evt-detail-dl` / `.evt-detail-location` rules
- **New `formatTime` helper** for the start/end time-range suffix
- **`.evt-sr-only` recipe** added for the visually-hidden `<dt>` labels

## Follow-on tweaks (after user review)

- **EventSummaryCard un-nested.** Now sits as a top-level sibling of the agenda-items section, not nested inside it. Matches the visual pattern of `<RepSummaryCard>` and the Legislation Plain-language summary card.
- **Dropped `max-width: 70ch`** on the summary card prose paragraphs. The cap was correct for the prior narrow main column but felt hemmed-in once the body went full-width.

## Test plan

- [x] Visual check at `localhost:5173/events/<slug>` — title row, meta stack, docs row, single-column body all read clean
- [x] Wrap behavior on narrow screens — title row stacks status pill below the `<h1>` when there's not enough room
- [x] Indigo summary card sits at the same indentation as the agenda-items card (not nested)
- [x] Prose fills the full card width
- [ ] After merge: no prod data populate needed; this is a frontend-only change

## Notes

- Did NOT revisit the LLM-summary-vs-agenda hierarchy (the optional question in #190). Confirmed during scoping; staying out of scope here.
- Empty markup deltas (e.g. removed `.evt-detail-section`) didn't show usage elsewhere per `grep` — safe to delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)