### PR TITLE
frontend: update RepSummaryCard to indigo palette (#192)

### DIFF
--- a/frontend/src/components/RepSummaryCard.css
+++ b/frontend/src/components/RepSummaryCard.css
@@ -1,22 +1,27 @@
+/* Indigo palette matches the Legislation Plain-language summary card
+   (`.leg-summary-card` in LegislationDetail.css) and EventSummaryCard
+   so LLM-generated content reads as a single coordinated system
+   across surfaces (#192). */
 .rep-summary-card {
   margin-bottom: 1.5rem;
   padding: 1.25rem 1.25rem 0.875rem;
-  border: 1px solid #e5e7eb;
-  background: #f9fafb;
+  border: 1px solid #c7d2fe;
+  background: #eef2ff;
   border-radius: 0.5rem;
 }
 
 .rep-summary-card-h2 {
   font-size: 1.25rem;
   font-weight: 700;
-  color: #1f2937;
+  color: #3730a3;
   margin: 0 0 0.75rem;
 }
 
 .rep-summary-card-body {
   font-size: 0.9375rem;
-  line-height: 1.55;
-  color: #1f2937;
+  line-height: 1.65;
+  /* Deep indigo body text on the indigo card — matches `.leg-summary-prose`. */
+  color: #1e1b4b;
 }
 
 .rep-summary-card-p {
@@ -29,14 +34,14 @@
 
 /* Generation provenance — small print at the bottom of the card so
    readers know the prose is LLM-synthesized from structured stats
-   rather than authored by staff. Tone-down color contrast keeps it
-   from competing with the body but stays above WCAG AA (4.5:1) on
-   the card's #f9fafb background. */
+   rather than authored by staff. #4338ca on #eef2ff hits ~7:1
+   contrast (WCAG AA pass at small text); matches the legislation +
+   event summary card footers. */
 .rep-summary-card-footer {
   margin-top: 0.875rem;
   padding-top: 0.625rem;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid #c7d2fe;
   font-size: 0.75rem;
   line-height: 1.45;
-  color: #6b7280;
+  color: #4338ca;
 }


### PR DESCRIPTION
Closes #192.

## Summary

The rep summary card was the visual outlier — gray (`#f9fafb` bg, `#1f2937` text) while the Legislation Plain-language summary card and the EventSummaryCard (PR #189) both use the indigo system (`#eef2ff` bg, `#3730a3` title, `#1e1b4b` body, `#4338ca` footer with `#c7d2fe` dividers).

CSS-only change. Color tokens copied verbatim from EventSummaryCard; the rep card's existing structure (no per-item disclosure, no footnotes, no video link block) is unchanged. Body line-height bumped from 1.55 → 1.65 to match the other two cards.

## Test plan

- [x] Visual check at `localhost:5173/reps/joy-hollingsworth` (and a few others) — card matches the indigo of the Legislation and EventSummary cards
- [x] Footer contrast verified: `#4338ca` on `#eef2ff` is ~7:1 (WCAG AA pass at small text)
- [ ] After merge: frontend-only deploy; no data populate needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)