### PR TITLE
ops: wire LLM pipelines into the nightly scheduler

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -184,30 +184,36 @@ Zero-downtime is NOT a goal of this setup — gunicorn restarts mean
 
 ### Post-deploy data population
 
-Some PRs ship management commands that populate LLM-derived data
-(rep bios, bill issue-area tags, rep summaries). The container
-restart applies migrations automatically but does NOT run these
-populations — they're one-off, sometimes API-paying, and gated by
-deploy-time judgment.
+**Ongoing automation:** as of 2026-05-16, the scheduler container's
+crontab runs the full LLM pipeline nightly — every new bill / event
+gets text-extracted, tagged, and summarized within ~25 hours of its
+first scrape. Rep summaries refresh weekly (Sunday). See
+[scripts/update_seattle.sh](scripts/update_seattle.sh),
+[scripts/poll_llm_batches.sh](scripts/poll_llm_batches.sh),
+[scripts/update_reps.sh](scripts/update_reps.sh), and
+[scheduler-crontab](scheduler-crontab) for the wiring.
 
-Check the PR description for any "after merge:" steps. Currently:
+**Manual runs** are still needed for first-time backfill on a new
+environment, after a prompt or vocabulary change (run with `--force`
+to regenerate), or when debugging. The table below documents each
+command's intent for those cases:
 
-| Command | When to run | Idempotent? |
+| Command | When to run manually | Idempotent? |
 | --- | --- | --- |
-| `python manage.py scrape_rep_bios` | After membership changes; bios on seattle.gov change rarely | Yes — UPSERTs by `person_id` |
-| `python manage.py backfill_council_terms` | When a member is sworn in, resigns, or is replaced | Yes — only writes when existing field is empty unless `--force` |
-| `python manage.py tag_bill_issue_areas` | New bills tag automatically when this command runs without `--force`; re-run with `--force` only when the prompt or vocabulary changes | Yes — UPSERTs by `bill_id`. Two-phase: submit, wait ~10-30 min, re-run to poll + persist |
-| `python manage.py summarize_reps` | After any of `scrape_rep_bios`, `backfill_council_terms`, or `tag_bill_issue_areas` runs against changed data; or when membership changes | Yes — UPSERTs by `person_id`. Two-phase: submit, wait ~5-10 min, re-run to poll + persist. Pass `--force` to regenerate existing rows |
-| `python manage.py extract_event_transcripts` | After any new council meeting (Full Council, Council Briefing, or committee) airs and Seattle Channel publishes the captioned SRT (typically a few days lag). Default scope is every past event since 2026-01-01; events without a Seattle Channel link skip gracefully | Yes — UPSERTs by `event_id`. Polite-paced HTTP only; no LLM cost |
-| `python manage.py summarize_events` | After `extract_event_transcripts` runs against new transcripts; re-run with `--force` after a prompt change or chapter-marker re-extraction | Yes — UPSERTs by `event_id`. Two-phase: submit, wait ~5-10 min, re-run to poll + persist. ~$0.10/meeting (committee meetings same cost shape) |
+| `python manage.py scrape_rep_bios` | After membership changes (the weekly cron also runs this) | Yes — UPSERTs by `person_id` |
+| `python manage.py backfill_council_terms` | When a member is sworn in, resigns, or is replaced. Not in the cron — the hardcoded term-date list is reviewed by hand | Yes — only writes when existing field is empty unless `--force` |
+| `python manage.py extract_bill_text` | Initial backfill on a new env, or after a parser change | Yes — UPSERTs by `bill_id` |
+| `python manage.py tag_bill_issue_areas` | Initial backfill, or with `--force` after a prompt / vocabulary change | Yes — UPSERTs by `bill_id`. Two-phase: submit, wait ~10-30 min, re-run to poll + persist |
+| `python manage.py summarize_legislation` | Initial backfill, or with `--force` after a prompt change | Yes — UPSERTs by `bill_id`. Two-phase: submit, wait ~5-10 min, re-run to poll + persist |
+| `python manage.py summarize_reps` | After any of `scrape_rep_bios`, `backfill_council_terms`, or `tag_bill_issue_areas` runs against changed data; or with `--force` after a prompt change | Yes — UPSERTs by `person_id`. Two-phase: submit, wait ~5-10 min, re-run to poll + persist |
+| `python manage.py extract_event_transcripts` | Initial backfill, or to pick up SRTs Seattle Channel published since the last cron tick | Yes — UPSERTs by `event_id`. Polite-paced HTTP; no LLM cost |
+| `python manage.py summarize_events` | Initial backfill, or with `--force` after a prompt change | Yes — UPSERTs by `event_id`. Two-phase: submit, wait ~5-10 min, re-run to poll + persist. ~$0.10/meeting |
+| `python manage.py import_event_summaries` | One-off env-sync — import summaries from a JSON export produced on another env (saves the LLM cost of regenerating) | Yes — UPSERTs by `event_id`, matched via `legistar_event_id` |
 
-Forgetting these steps is the most common reason prod data quality
-diverges from dev — see WORK_LOG entry on the rep-summary launch
-postmortem (2026-05-11).
-
-**For new LLM-data PRs:** add a one-line entry to this table in the
-same PR. Don't ship a populator command without documenting when to
-run it on prod.
+**For new LLM-data PRs:** add a one-line entry to this table AND a
+corresponding step to [scripts/update_seattle.sh](scripts/update_seattle.sh)
+or [scripts/poll_llm_batches.sh](scripts/poll_llm_batches.sh) so the
+new pipeline is in the automation from day one.
 
 ### View logs
 

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -37,13 +37,37 @@ Parser corpus state (post-fix re-parse 2026-04-26 after `93cb885`): 7,435 sectio
 
 **Pre-flight at session start:** `git fetch && git log main..origin/main` to catch divergence between local and remote `main` before doing anything else. We lost time to a 16-commit divergence in 2026-04 that this would have caught in one command.
 
-**LLM-data PRs document their post-deploy populator commands in DEPLOY.md.** Any PR that introduces a management command which populates LLM-derived data (bios, tags, summaries, transcripts) must add a one-line entry to the "Post-deploy data population" table in `DEPLOY.md` in the same PR. We hit prod-vs-dev data divergence on the rep-summary launch (2026-05-11) because three sequential PRs each shipped a populator without telling deploy when to run it.
+**LLM-data PRs document their post-deploy populator commands in DEPLOY.md AND wire them into the scheduler.** Any PR that introduces a management command which populates LLM-derived data (bios, tags, summaries, transcripts) must (a) add a one-line entry to the "Post-deploy data population" table in `DEPLOY.md` and (b) add a corresponding step to the appropriate cron script — `scripts/update_seattle.sh` (synchronous + Batch-submit), `scripts/poll_llm_batches.sh` (Batch-poll), or `scripts/update_reps.sh` (weekly rep refresh) — so new pipelines run from day one without manual intervention. We hit prod-vs-dev data divergence on the rep-summary launch (2026-05-11) because three sequential PRs each shipped a populator without telling deploy when to run it. The nightly cron wiring (2026-05-16) means that gap can't repeat for routine new data.
 
 **Pin git-URL dependencies to a commit SHA or tag, never to a branch.** Branch URLs (e.g. `.../archive/refs/heads/5.x.zip` or `git+https://.../<repo>@5.x`) re-resolve to whatever the branch's HEAD is at build time. That means dev and prod images can pick up different upstream snapshots without anything in our repo changing — caused a prod outage on 2026-05-16 (issue #187) when a seattle_app migration declared a dep on a councilmatic_core node that only existed in dev's image. Bump pins intentionally when adopting upstream changes.
 
 ---
 
 ## Done
+
+### Ops — wire LLM pipelines into the nightly scheduler — committed 2026-05-16
+
+Closes the gap surfaced when reviewing new legislation on prod and noticing nothing had summaries. The scheduler container previously ran scrape + sync only; LLM-derived data (bill text extraction, issue-area tagging, bill summaries, event transcripts, event summaries, rep bios, rep summaries) only got generated when someone manually ran the commands. That's why three new bills showed up unsummarized — there was no automation for them.
+
+**Daily cron (2 AM Pacific):** `scripts/update_seattle.sh` now runs the full chain after sync:
+
+1. `pupa update seattle` (existing scrape)
+2. `python manage.py sync_councilmatic` (existing)
+3. `python manage.py extract_bill_text` — synchronous, idempotent; pulls attachment text for new bills
+4. `python manage.py extract_event_transcripts` — synchronous; pulls Seattle Channel SRTs for new past meetings (events without SC link skip gracefully)
+5. `python manage.py tag_bill_issue_areas` — Anthropic Batch SUBMIT (poll happens at 3 AM)
+6. `python manage.py summarize_legislation` — Batch SUBMIT
+7. `python manage.py summarize_events` — Batch SUBMIT
+
+**Daily cron (3 AM Pacific):** new `scripts/poll_llm_batches.sh` polls all in-flight Batch jobs. Re-invoking each Batch command at poll time either picks up the 2 AM batch or no-ops with "No rows need ...".
+
+**Weekly cron (Sunday 2:30 AM):** new `scripts/update_reps.sh` runs `scrape_rep_bios` and submits the `summarize_reps` Batch. Sunday 3 AM daily poll catches the rep batch. Rep memberships change rarely (every few years per seat), so daily would be wasteful.
+
+**Lesson from smoke-testing.** Running `poll_llm_batches.sh` on dev for verification submitted a real 315-bill `tag_bill_issue_areas` batch (~$1 of API credit) because the Batch commands' two-phase design means "no in-flight batch → try to submit." That's the right behavior for production (gives the 3 AM poll a second chance to submit if the 2 AM run failed transiently), but it means smoke-testing the poll script has cost side effects when there's accumulated work. Worth knowing.
+
+**Convention updated** (alongside the existing populator-table-in-DEPLOY.md rule from #180): new LLM-data PRs must also add a corresponding step to `scripts/update_seattle.sh` (synchronous + Batch-submit), `scripts/poll_llm_batches.sh` (Batch-poll), or `scripts/update_reps.sh` (weekly) so the new pipeline is automated from day one.
+
+**Cost.** ~$0.10-0.30/day in API spend depending on bill volume; ~$3-9/month at steady state. Trivial relative to the value of "every new piece of legislation has a summary within 25 hours of its scrape."
 
 ### Events — extend transcripts + summaries to committee + briefing meetings — committed 2026-05-16
 

--- a/scheduler-crontab
+++ b/scheduler-crontab
@@ -4,11 +4,24 @@
 # obviously local-time without grepping the compose file.
 CRON_TZ=America/Los_Angeles
 
-# Run full update (scrape + sync) daily at 2 AM Pacific.
-# Source /etc/cron-env first — cron sanitizes the environment, so without
+# Run full update (scrape + sync + extract bill text + extract event
+# transcripts + submit LLM batches) daily at 2 AM Pacific. Source
+# /etc/cron-env first — cron sanitizes the environment, so without
 # this DATABASE_URL etc. from .env aren't visible and Django falls back
 # to localhost:5432. The file is written by scripts/scheduler-entrypoint.sh
 # at container start.
 0 2 * * * . /etc/cron-env && cd /app && /app/scripts/update_seattle.sh >> /var/log/cron/sync.log 2>&1
+
+# Poll Anthropic Batch jobs submitted at 2 AM and persist results.
+# Batches typically complete in 5-30 minutes for our daily volumes;
+# an hour's headroom is generous. Includes summarize_reps so the
+# Sunday weekly rep batch (submitted 2:30 AM) gets polled at 3 AM
+# without needing its own daily entry.
+0 3 * * * . /etc/cron-env && cd /app && /app/scripts/poll_llm_batches.sh >> /var/log/cron/sync.log 2>&1
+
+# Weekly rep refresh (Sunday 2:30 AM): scrape bios from seattle.gov
+# and submit the summarize_reps batch. The 3 AM daily poll covers
+# polling + persistence.
+30 2 * * 0 . /etc/cron-env && cd /app && /app/scripts/update_reps.sh >> /var/log/cron/sync.log 2>&1
 
 # Empty line required at end of crontab file

--- a/scripts/poll_llm_batches.sh
+++ b/scripts/poll_llm_batches.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e  # Exit on error
+
+# Poll any in-flight Anthropic Batch jobs submitted by the 2 AM
+# `update_seattle.sh` run an hour earlier, and persist results.
+#
+# Each Batch command (`tag_bill_issue_areas`, `summarize_legislation`,
+# `summarize_events`, `summarize_reps`) is two-phase: the first
+# invocation submits a batch and writes the batch ID to its state
+# file; the second invocation polls that batch and (when ended)
+# writes results to the DB. Re-running a command does the right
+# thing based on its own state file:
+#
+#   - State file has an in-flight batch_id  → poll + persist (if ended)
+#   - State file is empty / batch processed → try to submit (no-op if
+#                                              nothing to do)
+#
+# So calling each command here at 3 AM does the poll for batches
+# submitted at 2 AM. If a command has no in-flight batch, it
+# attempts a submit; for daily commands that's the same submit that
+# already happened at 2 AM (so the bills/events queries return
+# empty and it no-ops with "No rows need …").
+#
+# `summarize_reps` is included even though it's submitted weekly
+# (via `update_reps.sh`, not the daily script). Calling it daily
+# just polls the weekly batch on the morning after submission and
+# no-ops the rest of the week.
+
+echo "================================"
+echo "Poll LLM Batches"
+echo "================================"
+
+echo ""
+echo "1. Polling tag_bill_issue_areas..."
+python manage.py tag_bill_issue_areas
+
+echo ""
+echo "2. Polling summarize_legislation..."
+python manage.py summarize_legislation
+
+echo ""
+echo "3. Polling summarize_events..."
+python manage.py summarize_events
+
+echo ""
+echo "4. Polling summarize_reps..."
+python manage.py summarize_reps
+
+echo ""
+echo "================================"
+echo "✓ Poll cycle complete!"
+echo "================================"

--- a/scripts/update_reps.sh
+++ b/scripts/update_reps.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e  # Exit on error
+
+# Weekly rep refresh — bios from seattle.gov and the LLM rep-summary
+# card. Memberships change rarely (every few years per seat) so daily
+# isn't worth it; this fires once a week.
+#
+# The summary submit lives here; polling + persistence happens in
+# `poll_llm_batches.sh` (which runs daily and no-ops on days when
+# no rep batch is in flight). Cycle is: Sun 2:30 AM submit → Sun
+# 3 AM poll picks it up (covered by the daily poll cron).
+
+echo "================================"
+echo "Seattle Councilmatic Rep Refresh"
+echo "================================"
+
+echo ""
+echo "1. Scraping rep bios from seattle.gov..."
+python manage.py scrape_rep_bios
+
+echo ""
+echo "2. Submitting rep-summary batch (will be polled at 3 AM)..."
+python manage.py summarize_reps
+
+echo ""
+echo "================================"
+echo "✓ Rep refresh complete!"
+echo "================================"

--- a/scripts/update_seattle.sh
+++ b/scripts/update_seattle.sh
@@ -13,6 +13,27 @@ echo ""
 echo "2. Syncing to Councilmatic models..."
 python manage.py sync_councilmatic
 
+# Steps 3-7 below were added when wiring the LLM pipelines into the
+# nightly cron. Each command is idempotent — runs against new rows
+# only (skips items that already have a tag/summary/transcript).
+# The Batch commands (`tag_bill_issue_areas`, `summarize_legislation`,
+# `summarize_events`) only SUBMIT here; polling + persistence happens
+# in `poll_llm_batches.sh` an hour later.
+
+echo ""
+echo "3. Extracting plain text for new bills..."
+python manage.py extract_bill_text
+
+echo ""
+echo "4. Extracting Seattle Channel transcripts for new past meetings..."
+python manage.py extract_event_transcripts
+
+echo ""
+echo "5. Submitting LLM batches (will be polled at 3 AM)..."
+python manage.py tag_bill_issue_areas
+python manage.py summarize_legislation
+python manage.py summarize_events
+
 echo ""
 echo "================================"
 echo "✓ Update complete!"


### PR DESCRIPTION
## Problem

The scheduler container previously ran scrape + sync only. New bills and meetings landed in the DB without LLM-derived data (text extraction, issue-area tags, summaries, transcripts) until someone manually ran the commands. Surfaced when reviewing new legislation on prod and noticing nothing was summarized.

## Summary

Three new cron entries chain the LLM pipelines after the existing scrape + sync. Idempotent end-to-end — every command no-ops when there's nothing new, UPSERTs when re-run.

### Daily 2 AM Pacific — `scripts/update_seattle.sh` (extended)

1. `pupa update seattle` *(existing)*
2. `sync_councilmatic` *(existing)*
3. `extract_bill_text` — synchronous, idempotent
4. `extract_event_transcripts` — synchronous; polite-paced HTTP only
5. `tag_bill_issue_areas` — Batch SUBMIT (polled at 3 AM)
6. `summarize_legislation` — Batch SUBMIT
7. `summarize_events` — Batch SUBMIT

### Daily 3 AM Pacific — `scripts/poll_llm_batches.sh` (new)

Polls all in-flight Batch jobs from the 2 AM run. Re-invoking each Batch command either picks up the 2 AM batch or no-ops with "No rows need …". Also covers `summarize_reps` so the Sunday weekly cycle gets polled without its own daily entry.

### Weekly Sunday 2:30 AM — `scripts/update_reps.sh` (new)

`scrape_rep_bios` + `summarize_reps` SUBMIT. Daily 3 AM poll catches the rep batch. Memberships change rarely (every few years per seat), so daily would be wasteful.

## Cost

~$3-9/month at steady state depending on bill / event volume. Trivial relative to "every new piece of legislation has a summary within 25 hours of its scrape."

## Notable design call

The poll script does double duty as submit-when-empty. That's the intended Batch-command behavior — if the 2 AM submit failed transiently (network blip, API hiccup), the 3 AM poll-or-submit gives it a second chance. Side effect: smoke-testing `poll_llm_batches.sh` on a dev DB with accumulated untagged work has real LLM cost. Worth knowing; the script header comments it.

## Convention added (DEPLOY.md + WORK_LOG)

New LLM-data PRs must:
1. Add a one-line entry to the "Post-deploy data population" table in `DEPLOY.md` (existing rule from #180)
2. **AND** add a corresponding step to the appropriate cron script (`scripts/update_seattle.sh` for sync + Batch-submit, `scripts/poll_llm_batches.sh` for Batch-poll, or `scripts/update_reps.sh` for weekly) so the new pipeline is automated from day one.

## Test plan

- [x] Smoke-tested `poll_llm_batches.sh` on dev — all four Batch commands behaved correctly (one submitted a real 315-bill batch from accumulated untagged work; the rest no-op'd cleanly)
- [x] Scripts marked executable (`chmod +x`)
- [x] DEPLOY.md updated to reflect new automation + retain the manual-run table for backfill / debugging
- [x] WORK_LOG Done entry + convention update
- [ ] After merge: `docker compose up -d --build scheduler` to reload the crontab; first automatic run lands at 2 AM Pacific the following morning

## Notes

- The scheduler entrypoint already re-installs the crontab from the mounted source on container restart, so no manual `crontab` step needed
- Existing nightly state files (in `data/`) are gitignored; nothing about Batch state needs special handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)