### PR TITLE
llm: port batch commands to adaptive thinking + effort knob

### DIFF
--- a/seattle_app/management/commands/summarize_events.py
+++ b/seattle_app/management/commands/summarize_events.py
@@ -46,6 +46,7 @@ from seattle_app.services.claude_service import (
     EVENT_SUMMARY_OUTPUT_SCHEMA,
     EVENT_SUMMARY_SYSTEM_PROMPT,
     _supports_adaptive_thinking,
+    format_batch_error,
 )
 from seattle_app.services.event_chunker import chunk_by_chapters
 
@@ -53,13 +54,13 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_STATE_PATH = "data/summarize_events_state.json"
 
-# Per-request token + thinking budgets. Input per meeting is ~25k
-# tokens (auto-captioned transcript ~100KB) plus roster/agenda context.
-# Output is bounded by the prompt (overview ≤350 words + N item
-# summaries ≤80 words each); 8k tokens gives generous room for a
-# 12-chapter meeting.
+# Per-request token ceiling. Input per meeting is ~25k tokens
+# (auto-captioned transcript ~100KB) plus roster/agenda context. Output
+# is bounded by the prompt (overview ≤350 words + N item summaries ≤80
+# words each); 8k tokens gives generous room for a 12-chapter meeting.
+# Thinking is bounded via ``output_config.effort``.
 MAX_TOKENS_PER_REQUEST = 8192
-THINKING_BUDGET_TOKENS = 4096
+THINKING_EFFORT = "medium"
 
 
 def _encode_custom_id(event_id: str) -> str:
@@ -226,7 +227,7 @@ class Command(BaseCommand):
             event_id = _decode_custom_id(result.custom_id)
             kind = result.result.type
             if kind != "succeeded":
-                errors.append((event_id, kind))
+                errors.append((event_id, format_batch_error(result.result)))
                 continue
 
             message = result.result.message
@@ -363,14 +364,12 @@ class Command(BaseCommand):
                     "format": {
                         "type": "json_schema",
                         "schema": EVENT_SUMMARY_OUTPUT_SCHEMA,
-                    }
+                    },
                 },
             }
             if _supports_adaptive_thinking(model):
-                params["thinking"] = {
-                    "type": "enabled",
-                    "budget_tokens": THINKING_BUDGET_TOKENS,
-                }
+                params["thinking"] = {"type": "adaptive"}
+                params["output_config"]["effort"] = THINKING_EFFORT
             requests.append({
                 "custom_id": _encode_custom_id(ev.id),
                 "params": params,

--- a/seattle_app/management/commands/summarize_legislation.py
+++ b/seattle_app/management/commands/summarize_legislation.py
@@ -46,20 +46,19 @@ from seattle_app.services.claude_service import (
     LEGISLATION_OUTPUT_SCHEMA,
     LEGISLATION_SYSTEM_PROMPT,
     _supports_adaptive_thinking,
+    format_batch_error,
 )
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_STATE_PATH = "data/summarize_legislation_state.json"
 
-# Per-request token + thinking ceilings. Mirrors the explicit-budget
-# pattern that worked for the SMC bulk summarizer (PR #70): max_tokens
-# accommodates THINKING_BUDGET tokens of thinking plus generous output
-# room. The structured JSON output for legislation is more verbose
-# than a section summary because it has summary + impact_analysis +
-# multi-item key_changes — give it more output room.
+# Per-request token ceiling. Thinking is bounded via
+# ``output_config.effort`` ("medium" gives ample synthesis room while
+# leaving headroom for the structured JSON output: summary +
+# impact_analysis + multi-item key_changes).
 MAX_TOKENS_PER_REQUEST = 16384
-THINKING_BUDGET_TOKENS = 8192
+THINKING_EFFORT = "medium"
 
 # Hard cap on input chars per bill. Opus 4.7 has a 200k-token context;
 # at ~4 chars/token that's ~800k chars, but we need room for the system
@@ -236,7 +235,7 @@ class Command(BaseCommand):
             identifier = _decode_custom_id(result.custom_id)
             kind = result.result.type
             if kind != "succeeded":
-                errors.append((identifier, kind))
+                errors.append((identifier, format_batch_error(result.result)))
                 continue
 
             message = result.result.message
@@ -380,14 +379,12 @@ class Command(BaseCommand):
                     "format": {
                         "type": "json_schema",
                         "schema": LEGISLATION_OUTPUT_SCHEMA,
-                    }
+                    },
                 },
             }
             if _supports_adaptive_thinking(model):
-                params["thinking"] = {
-                    "type": "enabled",
-                    "budget_tokens": THINKING_BUDGET_TOKENS,
-                }
+                params["thinking"] = {"type": "adaptive"}
+                params["output_config"]["effort"] = THINKING_EFFORT
             requests.append({
                 "custom_id": _encode_custom_id(bill.identifier),
                 "params": params,

--- a/seattle_app/management/commands/summarize_reps.py
+++ b/seattle_app/management/commands/summarize_reps.py
@@ -47,17 +47,18 @@ from seattle_app.services.claude_service import (
     REP_SUMMARY_OUTPUT_SCHEMA,
     REP_SUMMARY_SYSTEM_PROMPT,
     _supports_adaptive_thinking,
+    format_batch_error,
 )
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_STATE_PATH = "data/summarize_reps_state.json"
 
-# Per-request budgets. Output is short (250-word cap, ~400 tokens)
-# but we want generous thinking room for the synthesis step where
-# the model balances structured stats against bio context.
+# Per-request token ceiling. Output is short (250-word cap, ~400
+# tokens) but the synthesis step balances structured stats against
+# bio context — thinking is bounded via ``output_config.effort``.
 MAX_TOKENS_PER_REQUEST = 4096
-THINKING_BUDGET_TOKENS = 2048
+THINKING_EFFORT = "medium"
 
 
 def _encode_custom_id(person_id: str) -> str:
@@ -218,7 +219,7 @@ class Command(BaseCommand):
             person_id = _decode_custom_id(result.custom_id)
             kind = result.result.type
             if kind != "succeeded":
-                errors.append((person_id, kind))
+                errors.append((person_id, format_batch_error(result.result)))
                 continue
 
             message = result.result.message
@@ -326,14 +327,12 @@ class Command(BaseCommand):
                     "format": {
                         "type": "json_schema",
                         "schema": REP_SUMMARY_OUTPUT_SCHEMA,
-                    }
+                    },
                 },
             }
             if _supports_adaptive_thinking(model):
-                params["thinking"] = {
-                    "type": "enabled",
-                    "budget_tokens": THINKING_BUDGET_TOKENS,
-                }
+                params["thinking"] = {"type": "adaptive"}
+                params["output_config"]["effort"] = THINKING_EFFORT
             requests.append({
                 "custom_id": _encode_custom_id(person.id),
                 "params": params,

--- a/seattle_app/management/commands/summarize_smc_sections.py
+++ b/seattle_app/management/commands/summarize_smc_sections.py
@@ -39,6 +39,7 @@ from seattle_app.models import MunicipalCodeSection
 from seattle_app.services.claude_service import (
     SECTION_SYSTEM_PROMPT,
     _supports_adaptive_thinking,
+    format_batch_error,
 )
 
 logger = logging.getLogger(__name__)
@@ -46,16 +47,16 @@ logger = logging.getLogger(__name__)
 DEFAULT_FEW_SHOTS_PATH = "data/few_shot_section_summaries.json"
 DEFAULT_STATE_PATH = "data/summarize_smc_state.json"
 
-# Per-request token ceiling and explicit thinking budget. Together
-# these guarantee output room: the model gets at most THINKING_BUDGET
-# tokens of thinking, leaving (MAX_TOKENS - THINKING_BUDGET) for the
-# actual response. We previously used `thinking: adaptive`, but adaptive
-# mode is unbounded — it ate the entire budget on 14 of 88 retried
-# sections in the second run (stop_reason=max_tokens, blocks=['thinking']).
-# Explicit `enabled` mode with a fixed budget makes output starvation
-# impossible by math.
+# Per-request token ceiling. Thinking is bounded via
+# ``output_config.effort`` rather than the legacy
+# ``thinking.budget_tokens`` (which Opus 4.7 no longer accepts). We
+# previously used bare ``thinking: adaptive``, but adaptive without an
+# effort hint is unbounded — it ate the entire budget on 14 of 88
+# retried sections in an earlier run (stop_reason=max_tokens,
+# blocks=['thinking']). The ``low`` effort hint keeps thinking modest
+# enough that the 150-400-word section summary always has output room.
 MAX_TOKENS_PER_REQUEST = 8192
-THINKING_BUDGET_TOKENS = 4096
+THINKING_EFFORT = "low"
 
 
 def _encode_custom_id(section_number: str) -> str:
@@ -251,7 +252,7 @@ class Command(BaseCommand):
             section_number = _decode_custom_id(result.custom_id)
             kind = result.result.type
             if kind != "succeeded":
-                errors.append((section_number, kind))
+                errors.append((section_number, format_batch_error(result.result)))
                 continue
 
             message = result.result.message
@@ -347,10 +348,8 @@ class Command(BaseCommand):
                 "messages": [{"role": "user", "content": user_content}],
             }
             if _supports_adaptive_thinking(model):
-                params["thinking"] = {
-                    "type": "enabled",
-                    "budget_tokens": THINKING_BUDGET_TOKENS,
-                }
+                params["thinking"] = {"type": "adaptive"}
+                params["output_config"] = {"effort": THINKING_EFFORT}
             requests.append({
                 "custom_id": _encode_custom_id(section.section_number),
                 "params": params,

--- a/seattle_app/management/commands/tag_bill_issue_areas.py
+++ b/seattle_app/management/commands/tag_bill_issue_areas.py
@@ -41,18 +41,19 @@ from seattle_app.services.claude_service import (
     BILL_TAG_SYSTEM_PROMPT,
     BILL_TAG_VOCABULARY,
     _supports_adaptive_thinking,
+    format_batch_error,
 )
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_STATE_PATH = "data/tag_bill_issue_areas_state.json"
 
-# Per-request token budgets. Tagging is a tiny structured-JSON task —
-# the output is at most ~50 tokens (3 short tag strings). Adaptive
-# thinking handles the routing decisions; the explicit budget is only
-# for non-Haiku models (Haiku doesn't accept the parameter at all).
+# Per-request token ceiling. Tagging is a tiny structured-JSON task —
+# the output is at most ~50 tokens (3 short tag strings). ``low`` effort
+# is plenty for the routing decision; non-Haiku models bound thinking
+# via ``output_config.effort`` (Haiku doesn't accept the parameter at all).
 MAX_TOKENS_PER_REQUEST = 2048
-THINKING_BUDGET_TOKENS = 1024
+THINKING_EFFORT = "low"
 
 # Hard cap on how much of BillText.text we feed the tagger. The bill
 # title is the dominant signal in practice (`City Light Department`,
@@ -223,7 +224,7 @@ class Command(BaseCommand):
             identifier = _decode_custom_id(result.custom_id)
             kind = result.result.type
             if kind != "succeeded":
-                errors.append((identifier, kind))
+                errors.append((identifier, format_batch_error(result.result)))
                 continue
 
             message = result.result.message
@@ -328,14 +329,12 @@ class Command(BaseCommand):
                     "format": {
                         "type": "json_schema",
                         "schema": BILL_TAG_OUTPUT_SCHEMA,
-                    }
+                    },
                 },
             }
             if _supports_adaptive_thinking(model):
-                params["thinking"] = {
-                    "type": "enabled",
-                    "budget_tokens": THINKING_BUDGET_TOKENS,
-                }
+                params["thinking"] = {"type": "adaptive"}
+                params["output_config"]["effort"] = THINKING_EFFORT
             requests.append({
                 "custom_id": _encode_custom_id(bill.identifier),
                 "params": params,

--- a/seattle_app/services/claude_service.py
+++ b/seattle_app/services/claude_service.py
@@ -384,6 +384,28 @@ def _supports_adaptive_thinking(model: str) -> bool:
     return "haiku" not in model.lower()
 
 
+def format_batch_error(result) -> str:
+    """Render a Batch API non-succeeded result into a short diagnosable string.
+
+    Anthropic's SDK wraps batch errors as nested ErrorResponse objects:
+
+        result.error  -> ErrorResponse(error=InvalidRequestError(type=..., message=...), ...)
+
+    Returns a string like ``"errored: invalid_request_error: <message>"`` so
+    the per-request error in the state file is meaningful without having to
+    re-fetch the batch from the API. Falls back to just the result type
+    when the SDK shape doesn't match (e.g. ``canceled``, ``expired``).
+    """
+    kind = getattr(result, "type", "unknown")
+    err_resp = getattr(result, "error", None)
+    err_inner = getattr(err_resp, "error", None) if err_resp else None
+    err_type = getattr(err_inner, "type", None)
+    err_msg = getattr(err_inner, "message", None) or ""
+    if err_type or err_msg:
+        return f"{kind}: {err_type}: {err_msg[:300]}"
+    return kind
+
+
 class ClaudeService:
     """Wrapper around the Anthropic SDK for Councilmatic summarization tasks."""
 


### PR DESCRIPTION
## Summary

- All five Batch-API management commands (`summarize_legislation`, `summarize_events`, `summarize_reps`, `tag_bill_issue_areas`, `summarize_smc_sections`) were sending the legacy `thinking: {type: "enabled", budget_tokens: N}` shape, which `claude-opus-4-7` (and current models generally) no longer accept:

  > `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`

  Last night's scheduler run — the first one after #197 wired the LLM pipelines into cron — silently 400'd every request in every batch. Surfaced because CB 121215 had no plain-language summary on prod; investigation showed all 19 candidates in `msgbatch_01GM8aMaG4oXdMKjqREf4fQK` errored.

- Ported all five commands to `thinking: {"type": "adaptive"}` + `output_config.effort` (`"low"` for tagging / SMC sections, `"medium"` for legislation / event / rep synthesis). Preserves the bounded-thinking property the SMC summarizer comment explained was important — bare adaptive without an effort hint once ate `max_tokens` on pure thinking on 14 of 88 retried sections.

- Added `format_batch_error()` to `claude_service.py` and called it from each command's non-succeeded branch. The state files now record `"errored: invalid_request_error: <message>"` instead of just `"errored"`, so future batch failures are diagnosable without re-fetching from Anthropic.

- Dropped the now-unused `THINKING_BUDGET_TOKENS` constants and stale comments referencing the explicit-budget pattern.

## Recovery

The 19 failed bills/resolutions from last night don't have `LegislationSummary` rows, so they re-enter the candidate pool automatically once this is deployed — no `--force` needed. Same for any rep / event / SMC / tagging work the broken batches dropped. Either wait for tonight's 2 AM cron, or kick the pipeline manually:

```
docker compose -f docker-compose.prod.yml exec scheduler python manage.py summarize_legislation
# wait 5-30 min for the batch to end
docker compose -f docker-compose.prod.yml exec scheduler python manage.py summarize_legislation
```

(First call submits; second call polls + persists.)

## Test plan

- [ ] Deploy to prod, manually invoke `summarize_legislation` against the 19 bills the previous batch dropped
- [ ] Confirm the new batch's state file shows `success_count: 19` and `error_count: 0`
- [ ] Open `/legislation/cb-121215` on prod and confirm the plain-language summary card renders
- [ ] Spot-check the other four pipelines (run each command once after deploy or wait for tomorrow's 2 AM cron)
- [ ] Negative-path check: temporarily change a request param to trigger an error and confirm the new state-file message is informative (`invalid_request_error: <message>`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKb4BAhDWv1U4jxWqvgbbd)_