### PR TITLE
llm: bump default Opus tier to 4.8

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,5 +60,5 @@ ANTHROPIC_API_KEY=your-anthropic-api-key
 # legislation analysis, Sonnet for the interactive chatbot.
 CLAUDE_CODE_SECTION_MODEL=claude-sonnet-4-6
 CLAUDE_LEGISLATION_MODEL=claude-sonnet-4-6
-CLAUDE_BOOTSTRAP_MODEL=claude-opus-4-7
+CLAUDE_BOOTSTRAP_MODEL=claude-opus-4-8
 CLAUDE_CHAT_MODEL=claude-sonnet-4-6

--- a/seattle_app/settings.py
+++ b/seattle_app/settings.py
@@ -231,12 +231,12 @@ CLAUDE_CODE_SECTION_MODEL = os.getenv("CLAUDE_CODE_SECTION_MODEL", "claude-sonne
 # Sonnet: balanced cost/quality for legislation summarization. The
 # task is mostly reformatting the staff Summary and Fiscal Note into
 # the structured JSON schema (output_config enforces format), so
-# Sonnet is sufficient. Set CLAUDE_LEGISLATION_MODEL=claude-opus-4-7
+# Sonnet is sufficient. Set CLAUDE_LEGISLATION_MODEL=claude-opus-4-8
 # in the environment for higher-quality runs (~5x cost).
 CLAUDE_LEGISLATION_MODEL = os.getenv("CLAUDE_LEGISLATION_MODEL", "claude-sonnet-4-6")
 # Opus: gold-standard summaries of a curated section set; the outputs become
 # few-shot examples for the bulk Sonnet run. Calibration only — not bulk.
-CLAUDE_BOOTSTRAP_MODEL = os.getenv("CLAUDE_BOOTSTRAP_MODEL", "claude-opus-4-7")
+CLAUDE_BOOTSTRAP_MODEL = os.getenv("CLAUDE_BOOTSTRAP_MODEL", "claude-opus-4-8")
 # Sonnet: balanced cost/quality for interactive chat.
 CLAUDE_CHAT_MODEL = os.getenv("CLAUDE_CHAT_MODEL", "claude-sonnet-4-6")
 # Sonnet: short structured-JSON tagging task (1-3 enum tags per bill).


### PR DESCRIPTION
## What

Rolls the project's Opus-tier default from `claude-opus-4-7` to `claude-opus-4-8`:

- `seattle_app/settings.py` — `CLAUDE_BOOTSTRAP_MODEL` default + the legislation-override comment
- `.env.example` — bootstrap line

## No call-shape changes needed for 4.8

How we invoke Opus is model-agnostic except one gate, and it already handles 4.8:

- `_supports_adaptive_thinking()` is a **denylist** (`"haiku" not in model`), so Opus 4.8 auto-enables `thinking: adaptive` + `output_config.effort` with no change.
- The legacy `thinking.budget_tokens` that Opus 4.7 dropped is already gone repo-wide.
- `temperature` is never set → defaults to 1 (required with adaptive thinking).
- No per-model cost map exists on `main`.

## Scope notes

- **Bootstrap is the only Opus-tier default.** `CODE_SECTION`, `LEGISLATION`, `CHAT` stay on Sonnet/Haiku by deliberate cost decisions — untouched.
- **Not touched:** `data/few_shot_section_summaries.json` (the `opus-4-7` there is provenance — those examples really were generated by 4.7) and the historical WORK_LOG lines (rewriting them would falsify the log).
- **Follow-up on `feature/chatbot`:** add a `claude-opus-4-8` row to the chat-service `_PRICING_USD_PER_MTOK` table before any chat-facing model points at 4.8, else the cost estimator falls back to Sonnet-tier pricing and under-counts ~5x. That table doesn't exist on `main`, so it's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)