### PR TITLE
events: skip caption-less meetings instead of erroring on SRT 404

### DIFF
--- a/seattle_app/management/commands/extract_event_transcripts.py
+++ b/seattle_app/management/commands/extract_event_transcripts.py
@@ -255,7 +255,24 @@ class Command(BaseCommand):
 
         chapter_markers = self._extract_chapter_markers(sc_html)
 
-        srt_raw = self._fetch_text(srt_url)
+        try:
+            srt_raw = self._fetch_text(srt_url)
+        except requests.exceptions.HTTPError as e:
+            # Seattle Channel's meeting page sometimes advertises a
+            # closed-caption file that was never published: the templated
+            # .srt path is in the page HTML (so the regex above matches),
+            # but the file 404s on their server — confirmed under both the
+            # `seattlechannel` and `SeattleChannel` path casings. That's the
+            # same outcome as "no captions", so skip it benignly instead of
+            # counting a hard error. Otherwise the event stays
+            # transcript__isnull=True and re-errors every nightly run,
+            # masking genuinely new failures behind a permanent "Errors: 1".
+            if getattr(e.response, "status_code", None) == 404:
+                raise _ExtractorSkip(
+                    f"SC page lists an SRT that 404s ({srt_url}) — "
+                    "no captions published for this meeting"
+                ) from e
+            raise
         transcript_text = self._srt_to_plain_text(srt_raw)
 
         return {


### PR DESCRIPTION
Fixes the recurring nightly `Errors: 1` from `extract_event_transcripts`.

## Problem

Seattle Channel's meeting page sometimes advertises a closed-caption `.srt` that was never published. `_scrape_one` lifts that path verbatim from the page, the fetch **404s**, and it propagated as a hard error — then recurred **every night** because the event stays `transcript__isnull=True` and gets re-targeted. Non-blocking (the command still exits 0 and submits batches), but the permanent `Errors: 1` **masks the next real failure**.

## Fix

A 404 on the page-advertised SRT now raises `_ExtractorSkip` instead of erroring — the same benign bucket as the existing "no SRT on the page" skip. Case-agnostic, and it still retries quietly for meetings whose captions are merely lagging (the event stays untranscribed until the file appears).

## Verification (live, 2026-06-02)

Walked the scraper's path for the failing event (`ocd-event/8ef8bb9c…`, 2026-02-19 Transportation, Waterfront, and Seattle Center Committee):

- SC page (`videoid=x184525`) lists **exactly one** `.srt`.
- It 404s under **both** `seattlechannel` and `SeattleChannel` path casings — not a filename quirk, not a case miss.
- No alternate/working SRT on the page; meeting is 3.5 months old, so captions will never appear.

`python -m py_compile` passes. No transcript test suite exists to extend.

## Deferred (noted in #202)

- If many caption-less meetings accumulate nightly silent re-fetches, persist a "gave up after N days" marker so they drop out of targeting (schema change).
- `_SC_SRT_RE` hardcodes `SeattleChannel` casing + `[a-z]+` prefix — brittle.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)