### PR TITLE
ops: run LLM pipeline every 6h with drain-then-submit batches

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -184,10 +184,14 @@ Zero-downtime is NOT a goal of this setup — gunicorn restarts mean
 
 ### Post-deploy data population
 
-**Ongoing automation:** as of 2026-05-16, the scheduler container's
-crontab runs the full LLM pipeline nightly — every new bill / event
-gets text-extracted, tagged, and summarized within ~25 hours of its
-first scrape. Rep summaries refresh weekly (Sunday). See
+**Ongoing automation:** the scheduler container runs the full pipeline
+**every 6 hours** (00/06/12/18 Pacific), with an offset drain pass ~1h
+after each cycle (01/07/13/19). New bills/events surface within ~6h of
+posting and get tagged + summarized within ~1h of the batch completing;
+the Batch commands are drain-then-submit, so each cycle polls + persists
+the previous batch and submits a fresh one. Rep summaries refresh weekly
+(Sunday 2:30 AM). All pipeline jobs share a `flock -n /tmp/seattle_pipeline.lock`
+so runs can't overlap or race a batch state file. See
 [scripts/update_seattle.sh](scripts/update_seattle.sh),
 [scripts/poll_llm_batches.sh](scripts/poll_llm_batches.sh),
 [scripts/update_reps.sh](scripts/update_reps.sh), and

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -14,6 +14,7 @@ Filter open work via labels: [`area/*`](https://github.com/SeattleCouncilmatic/s
 - **`base.html` retained.** Kept (with webpack-loader stripped) because `404.html` and `500.html` extend it via `handler404`/`handler500`. Don't delete unless you also rewrite the error templates.
 - **Production deploy** — single Hetzner CPX21 (Caddy + gunicorn + PostGIS + scheduler), all from `docker-compose.prod.yml`. See [DEPLOY.md](DEPLOY.md) for the runbook. Domain: `www.seattlecouncilmatic.org` (apex 308→www).
 - **Post-launch workflow shift (2026-05-04):** new work goes through GH issues, not `## Up next` here. Local testing happens at `localhost:5173` (Vite HMR) — no `npm run build` needed for routine changes. WORK_LOG keeps decisions, conventions, and *meaty* postmortems where the "why" is non-obvious from the diff. Routine PRs live in their PR descriptions and merge commits.
+- **Batch pipeline is drain-then-submit on a 6h cadence (2026-06-04).** The four Anthropic Batch commands (`tag_bill_issue_areas`, `summarize_legislation`, `summarize_events`, `summarize_reps`) poll+persist any in-flight batch and *then* submit a new one in a single invocation — not the old poll-OR-submit toggle. The scheduler runs the full pipeline every 6h (00/06/12/18) with an offset drain pass 1h later (01/07/13/19); all jobs share a `flock`. **Any new Batch command must follow the drain-then-submit shape.** Replaced the single 2 AM submit / 3 AM poll, which left results up to ~24h stale when Anthropic ran slow or captions posted after the 2 AM run (#204, #206).
 
 ## Active work
 

--- a/scheduler-crontab
+++ b/scheduler-crontab
@@ -4,24 +4,29 @@
 # obviously local-time without grepping the compose file.
 CRON_TZ=America/Los_Angeles
 
-# Run full update (scrape + sync + extract bill text + extract event
-# transcripts + submit LLM batches) daily at 2 AM Pacific. Source
-# /etc/cron-env first — cron sanitizes the environment, so without
-# this DATABASE_URL etc. from .env aren't visible and Django falls back
-# to localhost:5432. The file is written by scripts/scheduler-entrypoint.sh
-# at container start.
-0 2 * * * . /etc/cron-env && cd /app && /app/scripts/update_seattle.sh >> /var/log/cron/sync.log 2>&1
+# Run the full pipeline (scrape + sync + extract bill text + extract
+# event transcripts + drain prior LLM batches + submit new ones) every
+# 6 hours. New meetings/bills surface within ~6h of posting instead of
+# waiting for a single 2 AM run (#206). `flock -n` skips an overlapping
+# run rather than doubling the scrape; every pipeline job below shares
+# the one lock so update/poll/rep runs never touch a batch state file
+# concurrently. Source /etc/cron-env first — cron sanitizes the
+# environment, so without this DATABASE_URL etc. from .env aren't
+# visible and Django falls back to localhost:5432. The file is written
+# by scripts/scheduler-entrypoint.sh at container start.
+0 0,6,12,18 * * * . /etc/cron-env && cd /app && flock -n /tmp/seattle_pipeline.lock /app/scripts/update_seattle.sh >> /var/log/cron/sync.log 2>&1
 
-# Poll Anthropic Batch jobs submitted at 2 AM and persist results.
-# Batches typically complete in 5-30 minutes for our daily volumes;
-# an hour's headroom is generous. Includes summarize_reps so the
-# Sunday weekly rep batch (submitted 2:30 AM) gets polled at 3 AM
-# without needing its own daily entry.
-0 3 * * * . /etc/cron-env && cd /app && /app/scripts/poll_llm_batches.sh >> /var/log/cron/sync.log 2>&1
+# Offset drain pass ~1h after each 6h cycle: polls + persists the batch
+# that cycle submitted (batches finish in ~5-30 min) so summaries land
+# within ~1h of submission rather than at the next cycle (#204). No
+# scrape runs here, so the commands' submit phase finds nothing new and
+# it's effectively a pure drain. Shares the pipeline lock.
+0 1,7,13,19 * * * . /etc/cron-env && cd /app && flock -n /tmp/seattle_pipeline.lock /app/scripts/poll_llm_batches.sh >> /var/log/cron/sync.log 2>&1
 
 # Weekly rep refresh (Sunday 2:30 AM): scrape bios from seattle.gov
-# and submit the summarize_reps batch. The 3 AM daily poll covers
-# polling + persistence.
-30 2 * * 0 . /etc/cron-env && cd /app && /app/scripts/update_reps.sh >> /var/log/cron/sync.log 2>&1
+# and submit the summarize_reps batch. The offset drain passes above
+# poll + persist it on the next tick. Shares the pipeline lock so it
+# can't collide with a 6h cycle.
+30 2 * * 0 . /etc/cron-env && cd /app && flock -n /tmp/seattle_pipeline.lock /app/scripts/update_reps.sh >> /var/log/cron/sync.log 2>&1
 
 # Empty line required at end of crontab file

--- a/scripts/poll_llm_batches.sh
+++ b/scripts/poll_llm_batches.sh
@@ -1,30 +1,19 @@
 #!/bin/bash
 set -e  # Exit on error
 
-# Poll any in-flight Anthropic Batch jobs submitted by the 2 AM
-# `update_seattle.sh` run an hour earlier, and persist results.
+# Offset drain pass, run ~1h after each 6h `update_seattle.sh` cycle:
+# polls + persists any batch that cycle submitted so results land
+# without waiting for the next cycle.
 #
 # Each Batch command (`tag_bill_issue_areas`, `summarize_legislation`,
-# `summarize_events`, `summarize_reps`) is two-phase: the first
-# invocation submits a batch and writes the batch ID to its state
-# file; the second invocation polls that batch and (when ended)
-# writes results to the DB. Re-running a command does the right
-# thing based on its own state file:
+# `summarize_events`, `summarize_reps`) is drain-then-submit: it polls +
+# persists an in-flight batch, then submits a new one for any
+# unprocessed rows. Here no scrape has run since the cycle, so the
+# candidate queries are empty and this is effectively a pure drain — it
+# persists the in-flight batch and no-ops the submit ("No rows need …").
 #
-#   - State file has an in-flight batch_id  → poll + persist (if ended)
-#   - State file is empty / batch processed → try to submit (no-op if
-#                                              nothing to do)
-#
-# So calling each command here at 3 AM does the poll for batches
-# submitted at 2 AM. If a command has no in-flight batch, it
-# attempts a submit; for daily commands that's the same submit that
-# already happened at 2 AM (so the bills/events queries return
-# empty and it no-ops with "No rows need …").
-#
-# `summarize_reps` is included even though it's submitted weekly
-# (via `update_reps.sh`, not the daily script). Calling it daily
-# just polls the weekly batch on the morning after submission and
-# no-ops the rest of the week.
+# `summarize_reps` is included so the weekly batch submitted by
+# `update_reps.sh` (Sunday 2:30 AM) gets drained on the next pass.
 
 echo "================================"
 echo "Poll LLM Batches"

--- a/scripts/update_seattle.sh
+++ b/scripts/update_seattle.sh
@@ -13,12 +13,14 @@ echo ""
 echo "2. Syncing to Councilmatic models..."
 python manage.py sync_councilmatic
 
-# Steps 3-7 below were added when wiring the LLM pipelines into the
-# nightly cron. Each command is idempotent — runs against new rows
-# only (skips items that already have a tag/summary/transcript).
-# The Batch commands (`tag_bill_issue_areas`, `summarize_legislation`,
-# `summarize_events`) only SUBMIT here; polling + persistence happens
-# in `poll_llm_batches.sh` an hour later.
+# Steps 3-5 below were added when wiring the LLM pipelines into the
+# scheduler. Each command is idempotent — runs against new rows only
+# (skips items that already have a tag/summary/transcript). The Batch
+# commands (`tag_bill_issue_areas`, `summarize_legislation`,
+# `summarize_events`) are drain-then-submit: each run first polls +
+# persists any batch still in flight from the previous run, then
+# submits a new one for rows scraped since. The offset
+# `poll_llm_batches.sh` pass lands results faster between cycles.
 
 echo ""
 echo "3. Extracting plain text for new bills..."
@@ -29,7 +31,7 @@ echo "4. Extracting Seattle Channel transcripts for new past meetings..."
 python manage.py extract_event_transcripts
 
 echo ""
-echo "5. Submitting LLM batches (will be polled at 3 AM)..."
+echo "5. Draining prior LLM batches + submitting new ones..."
 python manage.py tag_bill_issue_areas
 python manage.py summarize_legislation
 python manage.py summarize_events

--- a/seattle_app/management/commands/summarize_events.py
+++ b/seattle_app/management/commands/summarize_events.py
@@ -135,7 +135,10 @@ class Command(BaseCommand):
 
         if state.get("batch_id") and not state.get("processed"):
             self._poll_and_maybe_process(client, state, state_path)
-            return
+            if not state.get("processed"):
+                return  # batch still in flight; drained on the next run
+            # Ended + persisted: fall through to submit a fresh batch for
+            # new work, so one run drains then submits (#204/#206).
 
         events = self._target_events(
             force=opts["force"], event_id=opts["event_id"]

--- a/seattle_app/management/commands/summarize_legislation.py
+++ b/seattle_app/management/commands/summarize_legislation.py
@@ -143,7 +143,10 @@ class Command(BaseCommand):
         # Phase 1: poll any in-flight batch.
         if state.get("batch_id") and not state.get("processed"):
             self._poll_and_maybe_process(client, state, state_path)
-            return
+            if not state.get("processed"):
+                return  # batch still in flight; drained on the next run
+            # Ended + persisted: fall through to submit a fresh batch for
+            # new work, so one run drains then submits (#204/#206).
 
         # Phase 2: gather candidates and submit.
         bills = self._target_bills(

--- a/seattle_app/management/commands/summarize_reps.py
+++ b/seattle_app/management/commands/summarize_reps.py
@@ -133,7 +133,10 @@ class Command(BaseCommand):
 
         if state.get("batch_id") and not state.get("processed"):
             self._poll_and_maybe_process(client, state, state_path)
-            return
+            if not state.get("processed"):
+                return  # batch still in flight; drained on the next run
+            # Ended + persisted: fall through to submit a fresh batch for
+            # new work, so one run drains then submits (#204/#206).
 
         people = self._target_people(force=opts["force"], person_name=opts["person"])
         if not people:

--- a/seattle_app/management/commands/tag_bill_issue_areas.py
+++ b/seattle_app/management/commands/tag_bill_issue_areas.py
@@ -128,7 +128,10 @@ class Command(BaseCommand):
 
         if state.get("batch_id") and not state.get("processed"):
             self._poll_and_maybe_process(client, state, state_path)
-            return
+            if not state.get("processed"):
+                return  # batch still in flight; drained on the next run
+            # Ended + persisted: fall through to submit a fresh batch for
+            # new work, so one run drains then submits (#204/#206).
 
         bill_ids = (
             [s.strip() for s in opts["bills"].split(",") if s.strip()]


### PR DESCRIPTION
Closes #204, closes #206.

## Why

The scheduler ran the full pipeline once at **2 AM** and polled once at **3 AM**. Two gaps fell out of that:

- **#206 (freshness):** anything posted after 2 AM — a meeting's captions, a late agenda — waited up to ~24h to surface. Live case this week: the June 2 City Council meeting had no summary all day because its SRT went live *after* the 2 AM run.
- **#204 (poll fragility):** a batch that didn't finish inside the single 1-hour poll window wasn't re-polled until the next night, so results landed ~24h late.

## What

**1. Batch commands are now drain-then-submit** (`tag_bill_issue_areas`, `summarize_legislation`, `summarize_events`, `summarize_reps`). Each invocation polls + persists any in-flight batch and *then* submits a fresh one for newly-unprocessed rows — instead of the old poll-OR-submit toggle that only did one per run. One identical 4-line change per command:

```python
if state.get("batch_id") and not state.get("processed"):
    self._poll_and_maybe_process(client, state, state_path)
    if not state.get("processed"):
        return        # still in flight; drained next run
    # ended + persisted → fall through to submit a fresh batch
```

**2. Scheduler runs the full cycle every 6h** (00/06/12/18) with an offset drain pass 1h later (01/07/13/19). All three jobs share a `flock -n /tmp/seattle_pipeline.lock` so runs can't overlap the scrape or race a batch state file.

## Cost

**No change.** Every command still targets only unprocessed rows (`llm_summary__isnull=True`, etc.); a run with nothing new no-ops. LLM spend tracks new-material volume, not run frequency. The Batch 50% discount is per-request, so smaller/more-frequent batches don't lose it.

## Effect

- New metadata (events/bills) surfaces within **~6h** of posting (was up to 24h).
- Summaries land within **~1h** of a batch completing (was up to 24h).
- A slow Anthropic night self-heals at the next 6h cycle instead of waiting a full day.

## Verification

- `python -m py_compile` on all four commands ✓
- `bash -n` on both scripts ✓
- `flock` confirmed present (base image is full `python:3.12`, not slim).
- Ships with a normal `up -d --build`: the entrypoint reinstalls the crontab from `/app/scheduler-crontab` on container start.

## Known pre-existing limitation (out of scope)

Batch state files (`data/*_state.json`) live in the container's writable layer, so a deploy *during* an in-flight batch orphans it (the new container re-submits — idempotent, but pays twice for those items once). Not changed here; the shorter in-flight windows from the 6h cadence actually make the collision window smaller. Persisting `data/` on a volume would be the fix if it ever bites.

## Minor follow-up noted

An item that *errors* in a batch now retries each cycle (faster recovery for transient fails; a persistent poison-pill item would retry ~4×/day). Bounded; a max-attempts marker is a future hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
