### PR TITLE
ops: fix pupa_scrape regression in run_pipeline (drop DJANGO_SETTINGS_MODULE)

### DIFF
--- a/seattle_app/management/commands/run_pipeline.py
+++ b/seattle_app/management/commands/run_pipeline.py
@@ -126,9 +126,17 @@ class Command(BaseCommand):
             metrics: dict = {}
             try:
                 if step_type == "pupa":
+                    # pupa reads django.conf.settings.LOGGING and only defaults
+                    # DJANGO_SETTINGS_MODULE to pupa.settings when it's unset.
+                    # Under manage.py it's seattle_app.settings, which defines no
+                    # LOGGING (so it's Django's default {}), and pupa then does
+                    # settings.LOGGING["handlers"]… -> KeyError. Drop it so pupa
+                    # uses its own settings, exactly as the bash cron call did.
+                    pupa_env = os.environ.copy()
+                    pupa_env.pop("DJANGO_SETTINGS_MODULE", None)
                     proc = subprocess.run(
                         ["pupa", "update", "seattle"],
-                        capture_output=True, text=True,
+                        capture_output=True, text=True, env=pupa_env,
                     )
                     buf.write((proc.stdout or "") + (proc.stderr or ""))
                     metrics["returncode"] = proc.returncode


### PR DESCRIPTION
**Hotfix** for a regression #214/#215 introduced: every prod full-cycle aborts at step 1 (`pupa_scrape`).

## Root cause

`run_pipeline` calls `pupa update seattle` via `subprocess`. pupa's CLI reads **`django.conf.settings.LOGGING`** and only falls back to its own `pupa.settings` (which has a `handlers` key) when `DJANGO_SETTINGS_MODULE` is **unset**:

```python
# pupa/cli/__main__.py
if os.environ.get("DJANGO_SETTINGS_MODULE") is None:
    os.environ["DJANGO_SETTINGS_MODULE"] = "pupa.settings"
...
settings.LOGGING["handlers"]["default"]["level"] = handler_level   # KeyError
```

Under `manage.py`, `DJANGO_SETTINGS_MODULE` is `seattle_app.settings` (set via `setdefault`), and **the project defines no `LOGGING`** → it's Django's default `{}` → `{}["handlers"]` raises `KeyError: 'handlers'`.

- **Bash cron** (worked): `DSM` unset → pupa uses `pupa.settings` → has `handlers`.
- **`run_pipeline` subprocess** (broke): inherits `DSM=seattle_app.settings` → `{}` → 💥

## Fix

Drop `DJANGO_SETTINGS_MODULE` from the pupa subprocess env so it behaves exactly like the bash call.

```python
pupa_env = os.environ.copy()
pupa_env.pop("DJANGO_SETTINGS_MODULE", None)
subprocess.run(["pupa", "update", "seattle"], ..., env=pupa_env)
```

## Verification (dev)

Replicated `run_pipeline`'s condition (parent `DSM=seattle_app.settings`):
- **with** DSM → `pupa` exits 1, `KeyError` present (reproduces prod).
- **without** DSM (the fix) → no `KeyError`; pupa runs past LOGGING setup and scrapes (`INFO pupa: save jurisdiction Seattle City Council…`).

## Notes

- No data lost — the scrape is incremental; the next cycle after deploy catches up. Only `pupa_scrape` (+ its dependent extract steps) was affected; the offset-drain / LLM steps don't run pupa.
- Silver lining: **#214's per-step tracking is exactly what surfaced this** — a `failed` `PipelineStep` with the returncode and full traceback in `output`, instead of a silent `set -e` abort.
- Worth deploying promptly so the next full-cycle scrapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
