### PR TITLE
ops: gate dev scheduler behind a compose profile (stop auto-burning LLM tokens in dev)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,9 +41,16 @@ services:
     ports:
       - "5173:5173"
 
+  # Opt-in in dev: this runs the real LLM pipeline on cron and burns tokens, so
+  # it does NOT start with a plain `docker compose up`. Enable on demand with
+  # `docker compose --profile scheduler up scheduler`. For routine testing, run
+  # the pipeline manually instead, e.g.
+  #   docker compose run --rm app python manage.py run_pipeline --kind full-cycle --dry-run
+  # (Prod's docker-compose.prod.yml has no profile gate — it always runs.)
   scheduler:
     build: .
     container_name: seattle_scheduler
+    profiles: ["scheduler"]
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
The dev `scheduler` container runs cron 24/7 — the full pipeline every 6h against **real Anthropic batches** — so dev has been quietly burning tokens (it was up 2 days). Gate it behind a `scheduler` Compose profile so a plain `docker compose up` no longer starts it.

## Change
- `docker-compose.yml`: `scheduler` service gets `profiles: ["scheduler"]` + a comment.
- `docker compose config --services` now returns `postgres app frontend` (scheduler excluded by default).

## Usage
- **Default dev:** `docker compose up` → no scheduler, no token burn.
- **Run a cycle manually** (the normal testing path): `docker compose run --rm app python manage.py run_pipeline --kind full-cycle --dry-run`
- **Re-enable cron on demand:** `docker compose --profile scheduler up scheduler`

## Scope
Dev only — **prod (`docker-compose.prod.yml`) is untouched** and keeps running the scheduler. Also stopped/removed the currently-running dev `seattle_scheduler` container so the burn stops now (the profile keeps it from coming back on the next `up`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
