### PR TITLE
ops: log hygiene — 30-day logrotate + per-line timestamps + LOGGING config (#205)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM python:3.12 AS app
 LABEL maintainer "DataMade <info@datamade.us>"
 
 RUN apt-get update && \
-	apt-get install -y --no-install-recommends --purge postgresql-client gdal-bin cron && \
+	apt-get install -y --no-install-recommends --purge postgresql-client gdal-bin cron logrotate moreutils && \
 	apt-get autoclean && \
 	rm -rf /var/lib/apt/lists/* && \
 	rm -rf /tmp/*
@@ -51,5 +51,10 @@ RUN chmod 0644 /etc/cron.d/scheduler-crontab && \
     crontab /etc/cron.d/scheduler-crontab && \
     mkdir -p /var/log/cron && \
     touch /var/log/cron/sync.log
+
+# logrotate config for the cron log (#205) — 30-day retention. Triggered by a
+# daily crontab line; copytruncate keeps the entrypoint's `tail -f` working.
+COPY scheduler-logrotate /etc/logrotate.d/sync-log
+RUN chmod 0644 /etc/logrotate.d/sync-log
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/scheduler-crontab
+++ b/scheduler-crontab
@@ -14,25 +14,31 @@ CRON_TZ=America/Los_Angeles
 # environment, so without this DATABASE_URL etc. from .env aren't
 # visible and Django falls back to localhost:5432. The file is written
 # by scripts/scheduler-entrypoint.sh at container start.
-0 0,6,12,18 * * * . /etc/cron-env && cd /app && flock -n /tmp/seattle_pipeline.lock /app/scripts/update_seattle.sh >> /var/log/cron/sync.log 2>&1
+0 0,6,12,18 * * * . /etc/cron-env && cd /app && flock -n /tmp/seattle_pipeline.lock /app/scripts/update_seattle.sh 2>&1 | ts >> /var/log/cron/sync.log
 
 # Offset drain pass ~1h after each 6h cycle: polls + persists the batch
 # that cycle submitted (batches finish in ~5-30 min) so summaries land
 # within ~1h of submission rather than at the next cycle (#204). No
 # scrape runs here, so the commands' submit phase finds nothing new and
 # it's effectively a pure drain. Shares the pipeline lock.
-0 1,7,13,19 * * * . /etc/cron-env && cd /app && flock -n /tmp/seattle_pipeline.lock /app/scripts/poll_llm_batches.sh >> /var/log/cron/sync.log 2>&1
+0 1,7,13,19 * * * . /etc/cron-env && cd /app && flock -n /tmp/seattle_pipeline.lock /app/scripts/poll_llm_batches.sh 2>&1 | ts >> /var/log/cron/sync.log
 
 # Weekly rep refresh (Sunday 2:30 AM): scrape bios from seattle.gov
 # and submit the summarize_reps batch. The offset drain passes above
 # poll + persist it on the next tick. Shares the pipeline lock so it
 # can't collide with a 6h cycle.
-30 2 * * 0 . /etc/cron-env && cd /app && flock -n /tmp/seattle_pipeline.lock /app/scripts/update_reps.sh >> /var/log/cron/sync.log 2>&1
+30 2 * * 0 . /etc/cron-env && cd /app && flock -n /tmp/seattle_pipeline.lock /app/scripts/update_reps.sh 2>&1 | ts >> /var/log/cron/sync.log
 
 # Pipeline health alert (#210) — independent hourly tick at :30, deliberately
 # NOT under the pipeline flock, so it still fires if a run is wedged holding the
 # lock. Emails PIPELINE_ALERT_EMAILS when no successful full-cycle has finished
 # within PIPELINE_HEARTBEAT_HOURS.
-30 * * * * . /etc/cron-env && cd /app && python manage.py check_pipeline_health >> /var/log/cron/sync.log 2>&1
+30 * * * * . /etc/cron-env && cd /app && python manage.py check_pipeline_health 2>&1 | ts >> /var/log/cron/sync.log
+
+# Rotate the cron log daily — 30-day retention via /etc/logrotate.d/sync-log
+# (#205). Independent of the pipeline; state lives on the cron-logs volume so the
+# daily detection survives container recreates. `ts` (moreutils) prefixes a
+# timestamp to every line written to sync.log above — the flat log had none.
+0 4 * * * logrotate -s /var/log/cron/logrotate.status /etc/logrotate.d/sync-log 2>&1 | ts >> /var/log/cron/sync.log
 
 # Empty line required at end of crontab file

--- a/scheduler-logrotate
+++ b/scheduler-logrotate
@@ -1,0 +1,19 @@
+# logrotate config for the scheduler's cron log (issue #205). Installed to
+# /etc/logrotate.d/sync-log by the Dockerfile; run daily by a scheduler-crontab
+# line (the container's `cron` user-crontab doesn't run /etc/cron.daily, so the
+# trigger is explicit). State is kept on the cron-logs volume so the "daily"
+# detection survives container recreates.
+#
+# copytruncate is load-bearing: the scheduler entrypoint runs
+# `tail -f /var/log/cron/sync.log` as PID 1 to feed `docker logs`. A rename-style
+# rotate would leave that tail on the dead inode and the stream would go silent;
+# copytruncate truncates in place so the inode (and the tail) survive.
+/var/log/cron/sync.log {
+    daily
+    rotate 30
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/seattle_app/logging_filters.py
+++ b/seattle_app/logging_filters.py
@@ -1,0 +1,24 @@
+"""Logging filter that stamps the current pipeline ``run_key`` onto log records.
+
+Kept in its own module with **no model imports**: Django applies ``LOGGING`` via
+``dictConfig`` during ``django.setup()``, *before* the app registry is populated,
+so a filter whose module imported models would raise ``AppRegistryNotReady`` at
+startup. The batch pipeline sets ``run_key_var``; the filter copies it onto each
+record so a formatter can render ``[%(run_key)s]``. (#205 / #208)
+"""
+import contextvars
+import logging
+
+# Correlation id for the current pipeline run. Defaults to "-" outside a run.
+run_key_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "pipeline_run_key", default="-"
+)
+
+
+class PipelineRunKeyFilter(logging.Filter):
+    """Inject the current ``run_key`` onto every record so a formatter can
+    prefix ``[%(run_key)s]``."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
+        record.run_key = run_key_var.get()
+        return True

--- a/seattle_app/services/batch_pipeline.py
+++ b/seattle_app/services/batch_pipeline.py
@@ -21,7 +21,6 @@ state survives container recreates / deploys (unlike the old JSON files).
 """
 from __future__ import annotations
 
-import contextvars
 import json
 import logging
 import os
@@ -32,27 +31,16 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 
+from seattle_app.logging_filters import run_key_var
 from seattle_app.models import BatchRun, PipelineRun
 from seattle_app.services.claude_service import format_batch_error
 
 logger = logging.getLogger(__name__)
 
-# Correlation id for the current pipeline run. Stamped onto every flat-log line
-# by the logging filter below once it's wired into LOGGING (#205); also inlined
-# into the operator-facing stdout lines here so a row in the DB always joins to
-# the deep-debug log by run_key / batch_id.
-run_key_var: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "pipeline_run_key", default="-"
-)
-
-
-class PipelineRunKeyFilter(logging.Filter):
-    """Injects the current ``run_key`` into every log record so a formatter can
-    prefix ``[%(run_key)s]``. Wired into ``LOGGING`` in #205."""
-
-    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
-        record.run_key = run_key_var.get()
-        return True
+# ``run_key_var`` (the contextvar the logging filter reads) lives in
+# ``seattle_app.logging_filters`` so LOGGING's dictConfig can import the filter
+# without importing models. We set it per run below; it's also inlined into the
+# operator-facing stdout lines so a DB row joins to the flat log by run_key.
 
 
 def get_or_create_pipeline_run() -> tuple[PipelineRun, bool]:

--- a/seattle_app/settings.py
+++ b/seattle_app/settings.py
@@ -285,6 +285,44 @@ PIPELINE_ALERT_EMAILS = [
     e.strip() for e in os.getenv("PIPELINE_ALERT_EMAILS", "").split(",") if e.strip()
 ]
 
+# Logging (#205). The project previously defined no LOGGING, so settings.LOGGING
+# was Django's default {} — which is what made pupa's CLI KeyError (#216). A real
+# config quiets chatty scrape/HTTP libraries and stamps the pipeline run_key onto
+# logger output via the contextvars filter. The filter lives in a models-free
+# module (seattle_app.logging_filters) because dictConfig runs before the app
+# registry loads. Per-line timestamps on the flat cron log come from `ts`
+# (moreutils) in scheduler-crontab, so the formatter omits asctime to avoid
+# double-stamping.
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {
+        "pipeline_run_key": {
+            "()": "seattle_app.logging_filters.PipelineRunKeyFilter",
+        },
+    },
+    "formatters": {
+        "tagged": {"format": "[%(run_key)s] %(levelname)s %(name)s: %(message)s"},
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "filters": ["pipeline_run_key"],
+            "formatter": "tagged",
+        },
+    },
+    "root": {"handlers": ["console"], "level": "INFO"},
+    "loggers": {
+        # Noisy scrape / HTTP libraries — keep them at WARNING.
+        "scrapelib": {"level": "WARNING"},
+        "urllib3": {"level": "WARNING"},
+        "requests": {"level": "WARNING"},
+        "boto": {"level": "WARNING"},
+        "botocore": {"level": "WARNING"},
+        "s3transfer": {"level": "WARNING"},
+    },
+}
+
 # Content Security Policy settings
 # In development, allow localhost resources
 if DEBUG:


### PR DESCRIPTION
Closes #205 — the **final** issue in the observability epic (#211).

## Three pieces

**Rotation (the original concern).** A logrotate config (`/etc/logrotate.d/sync-log`): daily, **30-day retention**, compress, **copytruncate**. copytruncate is load-bearing — the entrypoint's `tail -f` (PID 1, feeds `docker logs`) must survive rotation; a rename-style rotate would silence the stream. Triggered by a daily `scheduler-crontab` line, with state on the cron-logs volume so daily detection survives container recreates. Adds `logrotate` + `moreutils` to the image.

**Timestamps.** Every `scheduler-crontab` line now pipes through `ts` (moreutils), so the flat log — which had **none** — gets a timestamp per line. Default `ts` format, so no cron `%`-escaping pitfalls.

**LOGGING config.** The project defined no `LOGGING` (it was Django's default `{}` — exactly what made pupa's CLI `KeyError` in #216). Added a real config that quiets noisy scrape/HTTP libraries and stamps the pipeline `run_key` onto logger output via a `contextvars` filter. The filter + contextvar moved to a **models-free** module (`seattle_app/logging_filters.py`) because `dictConfig` runs *before* the app registry loads — a filter importing models would `AppRegistryNotReady` at startup. (`run_key` is already inlined on the pipeline's stdout lines from #208/#214; this completes it for logger output.)

## Validation (dev)

- `manage.py check` loads the `LOGGING`/filter via `dictConfig` cleanly (the AppRegistryNotReady risk is avoided); `batch_pipeline` still imports.
- Rebuilt image: `ts` + `logrotate` present; `logrotate -d` confirms the 30-day config parses; the crontab installs with the `ts` pipes + logrotate line (**5 entries**).

## Deploy

Ships with a normal `up -d --build` (rebuild installs the new apt packages + the logrotate config; the entrypoint reinstalls the crontab). No manual steps.

---

🏁 With this, **epic #211 is complete**: #208 models · #209 dashboard · #214 per-step tracking · #210 alerts · #205 log hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
