### PR TITLE
frontend: enable Vite file polling for HMR in Docker on Windows

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -53,6 +53,14 @@ export default defineConfig(({ command }) => ({
   base: command === 'build' ? '/static/' : '/',
   plugins: [djangoTrailingSlashRedirect, react()],
   server: {
+    // Poll the filesystem for changes instead of relying on inotify.
+    // The dev server runs in a Docker container with the source bind-
+    // mounted from a Windows host, and inotify events don't cross that
+    // boundary — so without polling, Vite never sees edits or `git pull`s
+    // and HMR silently stops firing (you'd see stale modules until a
+    // container restart). Polling has a small CPU cost but is the
+    // standard fix for Docker-on-Windows dev.
+    watch: { usePolling: true },
     proxy: {
       '/api':    { target: 'http://app:8000', changeOrigin: true },
       '/admin':  { target: 'http://app:8000', changeOrigin: true },


### PR DESCRIPTION
## Why
The Vite dev server (`frontend` container) bind-mounts the source from a Windows host. **inotify file-change events don't cross the Windows→Docker bind mount**, so Vite never sees edits or `git pull`s — HMR silently stops firing and the server keeps serving the modules it transformed when it started. The symptom: you change code (or pull a merged change), hard-refresh `localhost:5173`, and nothing updates — until a manual `docker compose restart frontend`.

This bit us right after the committee two-column layout merged: the code was on `main` and in the container, but `:5173` served a 3-day-old transform.

## Fix
```js
server: {
  watch: { usePolling: true },
  proxy: { /* unchanged */ },
}
```
Vite polls the filesystem instead of relying on inotify (small CPU cost — the standard Docker-on-Windows dev fix). HMR now fires on saves and pulls.

## Verification
Restarted the `frontend` container with the new config: Vite boots clean (`ready in 363 ms`, no errors), `:5173` serves 200.

After merging, `docker compose restart frontend` once to pick it up; from then on HMR works without restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)