### PR TITLE
committees: always show Upcoming meetings (with empty state)

### DIFF
--- a/frontend/src/components/CommitteeDetail.css
+++ b/frontend/src/components/CommitteeDetail.css
@@ -172,6 +172,18 @@ a.cmte-roster-link:focus-visible {
   gap: 0.75rem;
 }
 
+/* Empty state for the always-shown "Upcoming meetings" section — a
+   dashed box reads as "nothing scheduled yet" rather than an error. */
+.cmte-detail-meetings-empty {
+  margin: 0;
+  padding: 0.875rem 1rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+  background: #ffffff;
+  border: 1px dashed #e5e7eb;
+  border-radius: 0.5rem;
+}
+
 .cmte-detail-more-link {
   display: inline-block;
   margin-top: 1rem;

--- a/frontend/src/components/CommitteeDetail.jsx
+++ b/frontend/src/components/CommitteeDetail.jsx
@@ -143,16 +143,21 @@ export default function CommitteeDetail() {
 
             {hasMeetings && (
               <div className="cmte-detail-col">
-                {hasUpcoming && (
-                  <section className="cmte-detail-section" aria-labelledby="cmte-upcoming-h2">
-                    <h2 id="cmte-upcoming-h2" className="cmte-detail-section-h2">Upcoming meetings</h2>
+                {/* Always shown — committees meet on staggered schedules and
+                    often have no future meeting posted yet, so an empty state
+                    is more reassuring than a missing section. */}
+                <section className="cmte-detail-section" aria-labelledby="cmte-upcoming-h2">
+                  <h2 id="cmte-upcoming-h2" className="cmte-detail-section-h2">Upcoming meetings</h2>
+                  {hasUpcoming ? (
                     <div className="cmte-meeting-list">
                       {data.upcoming_meetings.map(ev => (
                         <EventCard key={ev.slug} event={ev} />
                       ))}
                     </div>
-                  </section>
-                )}
+                  ) : (
+                    <p className="cmte-detail-meetings-empty">No upcoming meetings scheduled.</p>
+                  )}
+                </section>
 
                 {hasRecent && (
                   <section className="cmte-detail-section" aria-labelledby="cmte-recent-h2">


### PR DESCRIPTION
On the committee detail page, "Upcoming meetings" was only rendered when a committee had a future meeting in the data — which is just **1 of 9 committees** right now. On the other 8 the section disappeared entirely, so it read as missing.

Now the section always renders. When there's nothing scheduled it shows **"No upcoming meetings scheduled."** in a dashed empty-state box, so every committee page consistently shows Upcoming + Recent meetings.

(Why so few upcoming: committees meet on staggered schedules and Legistar often hasn't posted the next meeting yet — not a data bug. As the scraper picks up future meetings, they'll populate here automatically.)

`npm run build` passes. Review at `localhost:5173` — open any committee (e.g. `/committees/public-safety`) to see the empty state, and `/committees/human-services-labor-economic-development` to see a populated one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)