### PR TITLE
committees: split bills into Currently-in-committee + Previously-considered

### DIFF
--- a/frontend/src/components/CommitteeDetail.jsx
+++ b/frontend/src/components/CommitteeDetail.jsx
@@ -54,8 +54,15 @@ export default function CommitteeDetail() {
   const hasUpcoming = data.upcoming_meetings.length > 0
   const hasRecent = data.recent_meetings.length > 0
   const hasMeetings = hasUpcoming || hasRecent
-  const hasBills = data.bills.length > 0
-  const moreBills = data.bills_total > data.bills.length
+  // Bills split into current (committee is the bill's current body) and past
+  // (it voted on a bill that has since advanced). The "Currently in committee"
+  // group only renders when it has bills, so the common no-active-work case
+  // reads as one clean "Bills considered by this committee" list.
+  const hasCurrentBills = data.current_bills.length > 0
+  const hasPastBills = data.past_bills.length > 0
+  const hasBills = hasCurrentBills || hasPastBills
+  const moreCurrent = data.current_bills_total > data.current_bills.length
+  const morePast = data.past_bills_total > data.past_bills.length
   // Two columns (bills | meetings, mirroring the home screen) only when
   // both sides have content; otherwise the lone side renders full width.
   const twoCol = hasMeetings && hasBills
@@ -122,22 +129,43 @@ export default function CommitteeDetail() {
 
             {hasBills && (
               <div className="cmte-detail-col">
-                <section className="cmte-detail-section" aria-labelledby="cmte-bills-h2">
-                  <h2 id="cmte-bills-h2" className="cmte-detail-section-h2">
-                    Bills considered by this committee
-                    <span className="cmte-detail-section-count"> ({data.bills_total})</span>
-                  </h2>
-                  <div className="cmte-bill-list">
-                    {data.bills.map(bill => (
-                      <LegislationCard key={bill.slug || bill.identifier} bill={bill} />
-                    ))}
-                  </div>
-                  {moreBills && (
-                    <p className="cmte-detail-more-note">
-                      Showing the {data.bills.length} most recent of {data.bills_total}.
-                    </p>
-                  )}
-                </section>
+                {hasCurrentBills && (
+                  <section className="cmte-detail-section" aria-labelledby="cmte-current-bills-h2">
+                    <h2 id="cmte-current-bills-h2" className="cmte-detail-section-h2">
+                      Currently in committee
+                      <span className="cmte-detail-section-count"> ({data.current_bills_total})</span>
+                    </h2>
+                    <div className="cmte-bill-list">
+                      {data.current_bills.map(bill => (
+                        <LegislationCard key={bill.slug || bill.identifier} bill={bill} />
+                      ))}
+                    </div>
+                    {moreCurrent && (
+                      <p className="cmte-detail-more-note">
+                        Showing the {data.current_bills.length} most recent of {data.current_bills_total}.
+                      </p>
+                    )}
+                  </section>
+                )}
+
+                {hasPastBills && (
+                  <section className="cmte-detail-section" aria-labelledby="cmte-past-bills-h2">
+                    <h2 id="cmte-past-bills-h2" className="cmte-detail-section-h2">
+                      {hasCurrentBills ? 'Previously considered' : 'Bills considered by this committee'}
+                      <span className="cmte-detail-section-count"> ({data.past_bills_total})</span>
+                    </h2>
+                    <div className="cmte-bill-list">
+                      {data.past_bills.map(bill => (
+                        <LegislationCard key={bill.slug || bill.identifier} bill={bill} />
+                      ))}
+                    </div>
+                    {morePast && (
+                      <p className="cmte-detail-more-note">
+                        Showing the {data.past_bills.length} most recent of {data.past_bills_total}.
+                      </p>
+                    )}
+                  </section>
+                )}
               </div>
             )}
 

--- a/seattle_app/api_views.py
+++ b/seattle_app/api_views.py
@@ -1083,14 +1083,31 @@ def committees_index(request):
     return JsonResponse({'results': committees})
 
 
+def _serialize_committee_bill(bill) -> dict:
+    """Card shape for the committee detail bill lists — matches what the
+    frontend LegislationCard consumes. ``sponsorships`` must be prefetched."""
+    sponsorship = bill.sponsorships.first()
+    status_label, status_variant = _normalise_status(bill.extras.get('MatterStatusName', ''))
+    return {
+        'identifier':     bill.identifier,
+        'title':          bill.title,
+        'sponsor':        sponsorship.entity_name if sponsorship else None,
+        'status':         status_label,
+        'status_variant': status_variant,
+        'slug':           bill.slug,
+    }
+
+
 @require_GET
 def committee_detail(request, slug):
     """
     GET /api/committees/<slug>/
 
-    A single committee: roster, upcoming + recent meetings, and the bills
-    currently before it (capped, with a total so the page can link to the
-    full filtered legislation view). 404 for an unknown slug.
+    A single committee: roster, upcoming + recent meetings, and the bills it
+    has handled — split into ``current_bills`` (the committee is the bill's
+    current body) and ``past_bills`` (it voted on the bill, which has since
+    advanced). Each bucket is capped with a ``*_total`` count. 404 for an
+    unknown slug.
     """
     org = _committee_by_slug(slug)
     if org is None:
@@ -1123,52 +1140,52 @@ def committee_detail(request, slug):
         upcoming_meetings = [_serialize_event(e) for e in upcoming_qs]
         recent_meetings = [_serialize_event(e) for e in recent_qs]
 
-    # Bills the committee has handled — currently before it (MatterBodyName)
-    # OR considered in the past (a committee vote event names it). The vote
-    # event is what recovers the association after a bill advances; without
-    # it the list would be near-empty since MatterBodyName parks advanced
-    # matters with "City Clerk". Most recent activity first, capped.
+    # Bills the committee has handled, split into two buckets:
+    #   * current — the committee is the bill's *current* body (MatterBodyName)
+    #   * past    — the committee *considered* it (a committee vote event names
+    #               it) but the bill has since advanced elsewhere
+    # The vote event is what recovers the association after a bill advances,
+    # since MatterBodyName parks advanced matters with "City Clerk". A bill
+    # that's both current and previously-voted lands in 'current'. Each bucket
+    # is most-recent-activity first and capped. annotate(Max(...)) groups by
+    # Bill pk, collapsing the row multiplication the votes/actions joins would
+    # otherwise cause, so each bill appears once and count() is distinct.
     body_names = _committee_body_names(norm)
     vote_body_names = _committee_vote_body_names(norm)
-    bills, bills_total = [], 0
-    if body_names or vote_body_names:
-        bill_filter = Q()
-        if body_names:
-            bill_filter |= Q(extras__MatterBodyName__in=body_names)
-        if vote_body_names:
-            bill_filter |= Q(votes__extras__event_body_name__in=vote_body_names)
-        # annotate(Max(...)) groups by Bill pk, collapsing the row
-        # multiplication the votes/actions joins would otherwise cause, so
-        # each bill appears once and count() is the distinct bill count.
-        bills_qs = (Bill.objects
-                    .filter(bill_filter)
-                    .prefetch_related('sponsorships')
-                    .annotate(latest_action_date=Max('actions__date'))
-                    .order_by('-latest_action_date'))
-        bills_total = bills_qs.count()
-        for bill in bills_qs[:_COMMITTEE_BILL_LIMIT]:
-            sponsorship = bill.sponsorships.first()
-            status_label, status_variant = _normalise_status(
-                bill.extras.get('MatterStatusName', ''))
-            bills.append({
-                'identifier':     bill.identifier,
-                'title':          bill.title,
-                'sponsor':        sponsorship.entity_name if sponsorship else None,
-                'status':         status_label,
-                'status_variant': status_variant,
-                'slug':           bill.slug,
-            })
+
+    current_qs = Bill.objects.none()
+    if body_names:
+        current_qs = (Bill.objects
+                      .filter(extras__MatterBodyName__in=body_names)
+                      .prefetch_related('sponsorships')
+                      .annotate(latest_action_date=Max('actions__date'))
+                      .order_by('-latest_action_date'))
+    current_ids = set(current_qs.values_list('id', flat=True))
+
+    past_qs = Bill.objects.none()
+    if vote_body_names:
+        past_qs = (Bill.objects
+                   .filter(votes__extras__event_body_name__in=vote_body_names)
+                   .exclude(id__in=current_ids)
+                   .prefetch_related('sponsorships')
+                   .annotate(latest_action_date=Max('actions__date'))
+                   .order_by('-latest_action_date'))
+
+    current_bills = [_serialize_committee_bill(b) for b in current_qs[:_COMMITTEE_BILL_LIMIT]]
+    past_bills = [_serialize_committee_bill(b) for b in past_qs[:_COMMITTEE_BILL_LIMIT]]
 
     return JsonResponse({
-        'name':              org.name,
-        'slug':              slugify(org.name),
-        'source_url':        source_url,
-        'member_count':      len(roster),
-        'roster':            roster,
-        'upcoming_meetings': upcoming_meetings,
-        'recent_meetings':   recent_meetings,
-        'bills':             bills,
-        'bills_total':       bills_total,
+        'name':                org.name,
+        'slug':                slugify(org.name),
+        'source_url':          source_url,
+        'member_count':        len(roster),
+        'roster':              roster,
+        'upcoming_meetings':   upcoming_meetings,
+        'recent_meetings':     recent_meetings,
+        'current_bills':       current_bills,
+        'current_bills_total': len(current_ids),
+        'past_bills':          past_bills,
+        'past_bills_total':    past_qs.count() if vote_body_names else 0,
     })
 
 


### PR DESCRIPTION
The hybrid we landed on: group active vs. completed bills, but hide the "Currently in committee" group when it's empty so the common case stays a clean single list.

## Backend
`committee_detail` now returns two buckets instead of one `bills` list:
- **`current_bills`** (+ `current_bills_total`) — the committee is the bill's *current* body (`MatterBodyName` matches).
- **`past_bills`** (+ `past_bills_total`) — the committee *voted on* the bill (committee vote event), which has since advanced. A bill that's both lands in `current`.

## Frontend
- When there are active bills: **"Currently in committee (N)"** leads, with **"Previously considered (M)"** below.
- When there aren't (8 of 9 committees today): the current group is omitted entirely and the past list keeps the original heading **"Bills considered by this committee (M)"** — no empty box.

## Verification
- `manage.py check` clean; `npm run build` passes.
- Parks & City Light → `current=1` (CB 121129, *In Committee*) / `past=7`. Every other committee → `current=0`, so they render the single clean list.

## Note
Independent of #226 (Upcoming-meetings empty state) — different sections of `CommitteeDetail.jsx`, so they merge cleanly in either order.

Review at `localhost:5173`: `/committees/parks-city-light` shows the two-group layout; any other committee shows the single list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)